### PR TITLE
feat: wix-headless-fast — all seven remaining verticals, live-verified

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless-fast
-description: "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from recipes. Each Wix business vertical ships a typed, framework-agnostic React core (data layer returning plain DTOs, hooks, headless components) plus an Astro overlay (SSR pages with owner-editable SEO pre-wired) and a build-time REST seed script — the agent scaffolds via the Wix CLI, deploys the shipped code, seeds the backend, designs the presentation layer itself on the shipped hooks (product card/grid, PDP, home, theme), and releases to Wix hosting. Works on Wix-managed Astro (ambient auth, the default) and on any React-based project (Vite, non-Astro) over the public OAuth client id. Verticals: stores/storefront (products, categories, variants, cart, hosted checkout) and bookings (services, appointment/class time slots, staff, booking form, checkout-or-place). Triggers: build me a store fast, take appointments/bookings fast, storefront with shipped components, wix headless fast, connect Wix Stores or Wix Bookings with ready-made SDK code."
+description: "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from recipes. Each Wix business vertical ships a typed, framework-agnostic React core (data layer returning plain DTOs, hooks, headless components) plus an Astro overlay (SSR pages with owner-editable SEO pre-wired) and a build-time REST seed script — the agent scaffolds via the Wix CLI, deploys the shipped code, seeds the backend, designs the presentation layer itself on the shipped hooks (product card/grid, PDP, home, theme), and releases to Wix hosting. Works on Wix-managed Astro (ambient auth, the default) and on any React-based project (Vite, non-Astro) over the public OAuth client id. Verticals: stores/storefront (products, categories, variants, cart, hosted checkout), bookings (services, appointment/class time slots, staff, booking form, checkout-or-place), blog (posts, categories/tags, rich content), cms (structured content collections), events (listing, RSVP, ticket sales), members (login, gated pages, account), portfolio (project collections, media galleries), pricing-plans (plan grid, hosted purchase), restaurants (menus, online ordering, table reservations). Triggers: build me a store/blog/booking/event/restaurant/portfolio site fast, take appointments fast, sell tickets or membership plans headless, wix headless fast, connect a Wix business app with ready-made SDK code."
 ---
 
 # Wix Headless Fast
@@ -109,9 +109,20 @@ comes from the shipped code, and real errors surface at build/release.
 |---|---|---|
 | Online store: products, categories, variants, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` |
 | Appointments/classes: services, time slots, staff, booking, checkout | **bookings** | `references/bookings/INSTRUCTIONS.md` |
+| Blog: post feed, categories/tags, rich-content post pages | **blog** | `references/blog/INSTRUCTIONS.md` |
+| Structured content collections (directory, recipes, listings) with pages designed per schema | **cms** | `references/cms/INSTRUCTIONS.md` |
+| Events: listing, event pages, free RSVP, ticket sales via hosted checkout | **events** | `references/events/INSTRUCTIONS.md` |
+| Member accounts: login/sign-up, gated pages, account page | **members** | `references/members/INSTRUCTIONS.md` |
+| Portfolio/showcase: collections of projects, project pages with media galleries | **portfolio** | `references/portfolio/INSTRUCTIONS.md` |
+| Membership/subscription plans: pricing page, plan detail, hosted purchase | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` |
+| Restaurant: menu with photos, online ordering, table reservations | **restaurants** | `references/restaurants/INSTRUCTIONS.md` |
 
-A request that doesn't match a shipped vertical isn't this skill's fast path — route it to
-`wix-headless` rather than improvising an unshipped vertical here.
+Verticals compose: a brief that spans several (a restaurant with a blog, a store with member
+accounts) deploys them together — fast-path takes one vertical; deploy the rest with
+`node <SKILL_ROOT>/install/deploy.mjs <vertical…>` from the project root before the install
+starts, and run each vertical's seed. A request that doesn't match any shipped vertical isn't
+this skill's fast path — route it to `wix-headless` rather than improvising an unshipped
+vertical here.
 
 ## Adding a vertical (structure contract)
 

--- a/skills/wix-headless-fast/install/deploy.mjs
+++ b/skills/wix-headless-fast/install/deploy.mjs
@@ -70,6 +70,55 @@ const VERTICAL_DEPS = {
       "@wix/essentials": "^1.0.6",
     },
   },
+  blog: {
+    core: {
+      "@wix/blog": "^1.0.645",
+      "@wix/ricos": "^11.12.0",
+    },
+    astro: {
+      "@wix/seo": "^1.0.79",
+      "@wix/essentials": "^1.0.10", // WIX_APPS.blogs needs ≥1.0.10
+    },
+  },
+  cms: {
+    core: {
+      "@wix/data": "^1.0.512",
+    },
+  },
+  events: {
+    core: {
+      "@wix/events": "^1.0.860",
+      "@wix/redirects": "^1.0.125",
+    },
+    astro: {
+      "@wix/seo": "^1.0.79",
+      "@wix/essentials": "^1.0.10",
+    },
+  },
+  members: {
+    core: {
+      "@wix/members": "^1.0.511",
+    },
+  },
+  portfolio: {
+    core: {
+      "@wix/portfolio": "^1.0.229",
+    },
+  },
+  "pricing-plans": {
+    core: {
+      "@wix/pricing-plans": "^1.0.378",
+      "@wix/redirects": "^1.0.125",
+    },
+  },
+  restaurants: {
+    core: {
+      "@wix/restaurants": "^1.0.525",
+      "@wix/table-reservations": "^1.0.397",
+      "@wix/ecom": "^1.0.2454",
+      "@wix/redirects": "^1.0.125",
+    },
+  },
 };
 
 const COPY = { recursive: true, force: false, errorOnExist: false };

--- a/skills/wix-headless-fast/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/blog/INSTRUCTIONS.md
@@ -1,0 +1,137 @@
+# Blog — playbook
+
+The blog machinery ships as files — post reads (feed paging, slug lookup with the body
+fieldsets), category/tag taxonomy, and the Ricos body renderer, typed end-to-end. **The
+presentation is yours**: you design and implement the post card, the grid, the blog index
+surface, and the post page surface on the shipped hooks/DTOs, plus the home page and the
+brand. You never write blog data logic; you never skip designing. The vertical is
+**read-only** — visitors read posts; authoring stays in the dashboard.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/blog/types.ts` | the DTOs (`PostSummary`, `PostDetail`, `BlogCategory`, `BlogTag`, `PostPage`) — contracts below |
+| `wix/blog/posts.ts` | `fetchPosts` (paged, filterable), `fetchPostBySlug` (full body) |
+| `wix/blog/taxonomy.ts` | `fetchBlogCategories`, `fetchBlogTags`, `fetchCategoryBySlug`, `fetchTagBySlug` |
+| `hooks/blog/useBlogFeed.ts` | feed + taxonomy filter + load-more — contract below |
+| `hooks/blog/usePost.ts` | post by slug + resolved chips — contract below |
+| `components/blog/RichContent.tsx` | the post-body renderer — **wire AS-IS** (machinery, not a reference) |
+| `components/blog/BlogFeedView.tsx` (+ `PostCard`) · `PostView.tsx` | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot + global.css import). If another vertical is also deployed, its layout won — add a Blog nav link there |
+| `pages/blog.astro` | SSR feed — **keep the frontmatter**, swap the island import to YOUR component |
+| `pages/blog/[...slug].astro` | SSR post page with owner-editable SEO — **keep the frontmatter, the `[...slug]` rest param, and the SEO pieces** (`wixMetadata`, `loadSEOTagsServiceConfig`, `<SEO.Tags>`) exactly; restyle the template. The body island stays `client:only="react"` (the ricos viewer breaks under SSR) |
+
+## What you build — the design job
+
+1. **The post card + grid** — your tile (cover, title, excerpt, date · min-read presentation)
+   and rhythm, with skeletons while loading and an honest empty state.
+2. **The blog index surface** — the feed on `useBlogFeed`: category filter (only when >1
+   non-empty category), the grid, and a load-more control gated on `hasMore`.
+3. **The post page surface** — header (categories eyebrow, title, date, cover), the body via
+   the shipped `RichContent`, and the tag chips — restyle the `[...slug].astro` template
+   around it.
+4. **The home page** — hero, latest posts (fetch in frontmatter → your components), brand
+   story.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens. Dark theme: the ricos CSS hardcodes
+near-black text — add a global override scoping `.ricos-content` to the foreground token
+(in Astro use `<style is:global>`; React islands don't inherit scoped Astro styles).
+
+### The contracts your components consume
+
+```ts
+// PostSummary (tiles) — display-ready:
+// { id, slug, title, excerpt, dateLabel /* "Aug 26, 2026" | "" */, dateISO,
+//   minutesToRead /* 0 = unknown */, featured, pinned, coverUrl /* "" = no cover */,
+//   categoryIds, tagIds }
+// PostDetail adds: richContent (Ricos JSON | null — render ONLY via RichContent),
+//   paragraphs (plain-text fallback body).
+// BlogCategory: { id, slug, label, description, postCount, coverUrl }   // display .label
+// BlogTag:      { id, slug, label, postCount }
+
+// useBlogFeed({ initialPage?, initialCategories?, initialTags?, pageSize? }) →
+// { posts: PostSummary[]|null /* null = loading → skeletons */,
+//   categories, tags,
+//   activeCategoryId, setActiveCategoryId(id|null),   // server-side filter
+//   activeTagId, setActiveTagId(id|null),             // mutually exclusive with category
+//   hasMore, loadMore(), loadingMore, error }
+
+// usePost({ slug, initialPost?, initialCategories?, initialTags? }) →
+// { post: PostDetail|null, notFound /* true = render a 404 state, never invent a post */,
+//   categories, tags /* THIS post's, resolved — display .label */, error }
+
+// <RichContent content={post.richContent} fallbackParagraphs={post.paragraphs} />
+//   — the ONLY body render path. In Astro: client:only="react".
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — merge into the
+   other vertical's layout instead if both are deployed).
+2. Write your components under `src/components/blog/` (new names — don't overwrite the
+   references), swap the island import in `pages/blog.astro`, and restyle the
+   `pages/blog/[...slug].astro` template (keep its frontmatter + SEO pieces + the
+   `client:only="react"` RichContent island). **Author your surfaces in as few messages as
+   possible** — batch multiple Writes per message.
+3. Write `pages/index.astro` (home) — it exists from the scaffold; Read it before overwriting.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/blog` → your feed on `useBlogFeed`;
+`/blog/:slug` → your post surface on `usePost` (the `PostView` reference shows the shape).
+
+## Hard rules
+
+- **The body renders only through `RichContent`** — a post body is a Ricos document, not
+  HTML and not text: never `set:html`/innerHTML it, never stringify its nodes, never write
+  your own node walker. `paragraphs` is the honest fallback it already handles.
+- **Route by `slug` through the shipped functions** — never hand-build a post/category/tag
+  URL from ids; display taxonomy by `.label` (the API has no `.name`).
+- **`notFound` means not found** — render your 404 state; never invent a post. Only
+  published posts come back, so a "missing" post is usually an unseeded/unpublished one.
+- **Never hand-build a wixstatic image URL** — `coverUrl` is already resolved; anything else
+  goes through `wix/media.ts`.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Live data or an honest empty state — never mock posts, authors, dates, or read times; no
+  stock placeholder covers. No author bylines or comment/like UI — the DTOs don't carry
+  them; don't fabricate engagement.
+- Keep the post page's SEO pieces and `[...slug]` rest param exactly as shipped.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link plus the Blog pages — the deploy step's JSON printed
+`dashboardUrl`; append `/blog/posts` for writing/editing posts and `/blog/categories` for
+the category menu. Only published posts appear on the site.
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-blog.mjs` from the project root.
+Seed posts that exercise the UI (~3 posts, 2 categories when the brief has sections, varied
+content blocks, a cover image per post).
+
+## Verify (before declaring done)
+
+- [ ] `/blog` renders live posts SSR (view-source shows titles) through YOUR components;
+      empty blog shows your honest empty state.
+- [ ] A post page renders the full body via `RichContent` (headings/quotes/lists show, not
+      raw text), with your header design; a bad slug returns 404/not-found.
+- [ ] Category filter narrows the feed (server-side — check the network tab, not a hidden
+      client filter); load-more appends the next page.
+- [ ] Post page view-source carries the SEO tags (Astro).
+- [ ] Card/grid/index/post surfaces/home are YOUR designs on the tokens; data-layer/hook
+      files unedited; `RichContent` wired as-is.
+- [ ] Dashboard links handed to the owner.

--- a/skills/wix-headless-fast/references/blog/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/blog/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,40 @@
+---
+// The site chrome for every blog page — THIS file (header/footer/nav) plus the @theme
+// token block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" />
+// in <head> and the global.css import. (If another vertical is also deployed, its SiteLayout
+// won; merge a Blog nav link there instead.)
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <a href="/blog" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Blog</a>
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/blog/app-astro/pages/blog.astro
+++ b/skills/wix-headless-fast/references/blog/app-astro/pages/blog.astro
@@ -1,0 +1,24 @@
+---
+// Blog index — data fetched SERVER-SIDE (SEO) and handed to the island as DTO props.
+// Keep this frontmatter; swap the island import to YOUR feed component.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import BlogFeedView from "../components/blog/BlogFeedView";
+import { fetchPosts } from "../wix/blog/posts";
+import { fetchBlogCategories, fetchBlogTags } from "../wix/blog/taxonomy";
+import type { BlogCategory, BlogTag, PostPage } from "../wix/blog/types";
+
+let page: PostPage = { posts: [], nextCursor: null };
+let categories: BlogCategory[] = [];
+let tags: BlogTag[] = [];
+try {
+  [page, categories, tags] = await Promise.all([fetchPosts(), fetchBlogCategories(), fetchBlogTags()]);
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // empty state instead.
+}
+---
+
+<SiteLayout title="Blog">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Blog</h1>
+  <BlogFeedView client:load initialPage={page} initialCategories={categories} initialTags={tags} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/blog/app-astro/pages/blog/[...slug].astro
+++ b/skills/wix-headless-fast/references/blog/app-astro/pages/blog/[...slug].astro
@@ -1,0 +1,99 @@
+---
+// Post page.
+//
+// This is a Wix ITEM PAGE: the wixMetadata export + <SEO.Tags> below let the site owner edit
+// this page's title/description/OG in the dashboard and register the route in the sitemap.
+// Keep all three SEO pieces, the [...slug] rest param, and this frontmatter; restyle the
+// template below freely. The body island is client:only — the ricos viewer breaks under SSR.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import RichContent from "../../components/blog/RichContent";
+import { fetchPostBySlug } from "../../wix/blog/posts";
+import { fetchBlogCategories, fetchBlogTags } from "../../wix/blog/taxonomy";
+import type { BlogCategory, BlogTag } from "../../wix/blog/types";
+import { WIX_APPS } from "@wix/essentials";
+import { SEO } from "@wix/seo/components";
+import { loadSEOTagsServiceConfig } from "@wix/seo/services";
+import { seoTags } from "@wix/seo";
+
+export const wixMetadata = {
+  appDefId: WIX_APPS.blogs.id,
+  pageIdentifier: WIX_APPS.blogs.postPageMetadata.pageIdentifier,
+  identifiers: {
+    slug: WIX_APPS.blogs.postPageMetadata.identifiers.slug,
+  },
+};
+
+const slug = Astro.params.slug;
+if (!slug) {
+  return new Response(null, { status: 404 });
+}
+
+// Behind Wix's proxy the request URL is internal — the real public page URL arrives on
+// x-wix-forwarded-url; the SEO service needs the public one.
+const forwardedUrl = Astro.request.headers.get("x-wix-forwarded-url");
+const pageUrl =
+  forwardedUrl && URL.canParse(forwardedUrl) && /^https?:$/.test(new URL(forwardedUrl).protocol)
+    ? forwardedUrl
+    : Astro.url.href;
+
+let post = null;
+let allCategories: BlogCategory[] = [];
+let allTags: BlogTag[] = [];
+let seoTagsServiceConfig = null;
+try {
+  [post, allCategories, allTags, seoTagsServiceConfig] = await Promise.all([
+    fetchPostBySlug(slug),
+    fetchBlogCategories(),
+    fetchBlogTags(),
+    loadSEOTagsServiceConfig({
+      pageUrl,
+      itemType: seoTags.ItemType.BLOG_POST,
+      itemData: { slug },
+    }).catch(() => null),
+  ]);
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!post) {
+  return new Response(null, { status: 404 });
+}
+
+const postCategories = allCategories.filter((c) => post!.categoryIds.includes(c.id));
+const postTags = allTags.filter((t) => post!.tagIds.includes(t.id));
+---
+
+<SiteLayout title={post.title} description={post.excerpt}>
+  <SEO.Tags seoTagsServiceConfig={seoTagsServiceConfig} slot="seo-tags" />
+
+  <article class="mx-auto max-w-3xl">
+    {postCategories.length > 0 && <p class="eyebrow">{postCategories.map((c) => c.label).join(" · ")}</p>}
+    <h1 class="mt-2 text-3xl font-semibold tracking-tight">{post.title}</h1>
+    <p class="mt-3 text-sm text-muted-foreground">
+      {post.dateLabel && <time datetime={post.dateISO}>{post.dateLabel}</time>}
+      {post.dateLabel && post.minutesToRead > 0 ? " · " : ""}
+      {post.minutesToRead > 0 ? `${post.minutesToRead} min read` : ""}
+    </p>
+    {
+      post.coverUrl && (
+        <div class="mt-6 aspect-[16/9] overflow-hidden rounded-xl bg-secondary">
+          <img src={post.coverUrl} alt={post.title} class="h-full w-full object-cover" />
+        </div>
+      )
+    }
+    <div class="mt-8">
+      <RichContent client:only="react" content={post.richContent} fallbackParagraphs={post.paragraphs} />
+    </div>
+    {
+      postTags.length > 0 && (
+        <div class="mt-10 flex flex-wrap gap-2">
+          {postTags.map((t) => (
+            <span class="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+              {t.label}
+            </span>
+          ))}
+        </div>
+      )
+    }
+  </article>
+</SiteLayout>

--- a/skills/wix-headless-fast/references/blog/app/components/blog/BlogFeedView.tsx
+++ b/skills/wix-headless-fast/references/blog/app/components/blog/BlogFeedView.tsx
@@ -1,0 +1,137 @@
+// REFERENCE feed surface: taxonomy filter chips + post grid + load-more on the @theme tokens.
+// Correct and complete; per the skill's model you design and build your own on useBlogFeed.
+import type { ComponentType, ReactNode } from "react";
+import { useBlogFeed } from "../../hooks/blog/useBlogFeed";
+import type { BlogCategory, BlogTag, PostPage, PostSummary } from "../../wix/blog/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface PostCardProps {
+  post: PostSummary;
+  postHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function PostCard({ post, postHref = (slug) => `/blog/${slug}`, LinkComponent = PlainLink }: PostCardProps) {
+  return (
+    <LinkComponent href={postHref(post.slug)} className="group block no-underline">
+      {post.coverUrl && (
+        <div className="aspect-[16/9] overflow-hidden rounded-lg bg-secondary">
+          <img
+            src={post.coverUrl}
+            alt={post.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        </div>
+      )}
+      <h3 className="mt-3 text-base font-semibold leading-snug text-foreground">{post.title}</h3>
+      {post.excerpt && <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{post.excerpt}</p>}
+      <p className="mt-2 text-xs text-muted-foreground">
+        {post.dateLabel && <time dateTime={post.dateISO}>{post.dateLabel}</time>}
+        {post.dateLabel && post.minutesToRead > 0 ? " · " : ""}
+        {post.minutesToRead > 0 ? `${post.minutesToRead} min read` : ""}
+      </p>
+    </LinkComponent>
+  );
+}
+
+export interface BlogFeedViewProps {
+  initialPage?: PostPage;
+  initialCategories?: BlogCategory[];
+  initialTags?: BlogTag[];
+  emptyMessage?: string;
+  postHref?: PostCardProps["postHref"];
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<PostCardProps>;
+}
+
+const pill = (active: boolean) =>
+  `rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+    active
+      ? "border-primary bg-primary text-primary-foreground"
+      : "border-border text-foreground hover:bg-secondary"
+  }`;
+
+export default function BlogFeedView({
+  initialPage,
+  initialCategories,
+  initialTags,
+  emptyMessage = "No posts yet — check back soon.",
+  postHref,
+  LinkComponent,
+  CardComponent = PostCard,
+}: BlogFeedViewProps) {
+  const {
+    posts,
+    categories,
+    activeCategoryId,
+    setActiveCategoryId,
+    hasMore,
+    loadMore,
+    loadingMore,
+    error,
+  } = useBlogFeed({ initialPage, initialCategories, initialTags });
+
+  const visibleCategories = categories.filter((c) => c.postCount > 0);
+
+  return (
+    <div>
+      {visibleCategories.length > 1 && (
+        <div className="mb-8 flex flex-wrap gap-2" role="group" aria-label="Categories">
+          <button type="button" className={pill(activeCategoryId === null)} onClick={() => setActiveCategoryId(null)}>
+            All
+          </button>
+          {visibleCategories.map((c) => (
+            <button key={c.id} type="button" className={pill(activeCategoryId === c.id)} onClick={() => setActiveCategoryId(c.id)}>
+              {c.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {posts === null ? (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i}>
+              <div className="aspect-[16/9] animate-pulse rounded-lg bg-secondary" />
+              <div className="mt-3 h-3.5 w-2/3 animate-pulse rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      ) : posts.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {posts.map((p) => (
+              <CardComponent key={p.id} post={p} postHref={postHref} LinkComponent={LinkComponent} />
+            ))}
+          </div>
+          {hasMore && (
+            <div className="mt-10 text-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="rounded-lg border border-border px-6 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/blog/app/components/blog/PostView.tsx
+++ b/skills/wix-headless-fast/references/blog/app/components/blog/PostView.tsx
@@ -1,0 +1,113 @@
+// REFERENCE post surface (SPA use — Astro renders the header statically and mounts only
+// RichContent as an island). Correct and complete; per the skill's model you design and
+// build your own on usePost. Chips display .label; the body renders ONLY via RichContent.
+import type { ComponentType } from "react";
+import { usePost } from "../../hooks/blog/usePost";
+import type { BlogCategory, BlogTag, PostDetail } from "../../wix/blog/types";
+import RichContent from "./RichContent";
+import type { LinkLikeProps } from "./BlogFeedView";
+
+export interface PostViewProps {
+  slug: string;
+  initialPost?: PostDetail;
+  initialCategories?: BlogCategory[];
+  initialTags?: BlogTag[];
+  /** Where a chip routes; omit to render chips as plain labels. */
+  categoryHref?: (slug: string) => string;
+  tagHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+const chipClass =
+  "rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground no-underline";
+
+export default function PostView({
+  slug,
+  initialPost,
+  initialCategories,
+  initialTags,
+  categoryHref,
+  tagHref,
+  LinkComponent = PlainLink,
+}: PostViewProps) {
+  const { post, notFound, categories, tags, error } = usePost({
+    slug,
+    initialPost,
+    initialCategories,
+    initialTags,
+  });
+
+  if (notFound) {
+    return (
+      <div className="py-24 text-center">
+        <p className="text-lg font-medium">Post not found</p>
+        <p className="mt-2 text-sm text-muted-foreground">It may have been unpublished or moved.</p>
+      </div>
+    );
+  }
+  if (error) return <p className="py-8 text-sm text-red-600">{error}</p>;
+  if (post === null) {
+    return (
+      <div aria-busy="true">
+        <div className="h-8 w-2/3 animate-pulse rounded bg-secondary" />
+        <div className="mt-6 aspect-[16/9] animate-pulse rounded-lg bg-secondary" />
+      </div>
+    );
+  }
+
+  return (
+    <article className="mx-auto max-w-3xl">
+      {categories.length > 0 && (
+        <p className="eyebrow">
+          {categories.map((c, i) => (
+            <span key={c.id}>
+              {i > 0 && " · "}
+              {categoryHref ? (
+                <LinkComponent href={categoryHref(c.slug)} className="no-underline">
+                  {c.label}
+                </LinkComponent>
+              ) : (
+                c.label
+              )}
+            </span>
+          ))}
+        </p>
+      )}
+      <h1 className="mt-2 text-3xl font-semibold tracking-tight">{post.title}</h1>
+      <p className="mt-3 text-sm text-muted-foreground">
+        {post.dateLabel && <time dateTime={post.dateISO}>{post.dateLabel}</time>}
+        {post.dateLabel && post.minutesToRead > 0 ? " · " : ""}
+        {post.minutesToRead > 0 ? `${post.minutesToRead} min read` : ""}
+      </p>
+      {post.coverUrl && (
+        <div className="mt-6 aspect-[16/9] overflow-hidden rounded-xl bg-secondary">
+          <img src={post.coverUrl} alt={post.title} className="h-full w-full object-cover" />
+        </div>
+      )}
+      <div className="mt-8">
+        <RichContent content={post.richContent} fallbackParagraphs={post.paragraphs} />
+      </div>
+      {tags.length > 0 && (
+        <div className="mt-10 flex flex-wrap gap-2">
+          {tags.map((t) =>
+            tagHref ? (
+              <LinkComponent key={t.id} href={tagHref(t.slug)} className={chipClass}>
+                {t.label}
+              </LinkComponent>
+            ) : (
+              <span key={t.id} className={chipClass}>
+                {t.label}
+              </span>
+            ),
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/skills/wix-headless-fast/references/blog/app/components/blog/RichContent.tsx
+++ b/skills/wix-headless-fast/references/blog/app/components/blog/RichContent.tsx
@@ -1,0 +1,42 @@
+// The post-body renderer — wire AS-IS (machinery, not a reference). A post body is a Ricos
+// document, not HTML and not text: never innerHTML it, never String() its nodes. This is the
+// documented render path (@wix/ricos viewer + quick-start plugins).
+//
+// In Astro this component MUST be a `client:only="react"` island — the ricos viewer breaks
+// under SSR. Dark theme: the ricos CSS hardcodes near-black text; scope an override on
+// `.ricos-content` forcing the foreground token (in Astro use <style is:global> — React
+// islands don't inherit scoped Astro styles).
+import { quickStartViewerPlugins, RicosViewer } from "@wix/ricos";
+import "@wix/ricos/css/all-plugins-viewer.css";
+
+// Module-level, once — never rebuild the plugin list per render.
+const plugins = quickStartViewerPlugins();
+
+export interface RichContentProps {
+  /** PostDetail.richContent — the Ricos document (plain JSON). */
+  content: Record<string, unknown> | null;
+  /** PostDetail.paragraphs — the honest fallback body when richContent is null. */
+  fallbackParagraphs?: string[];
+}
+
+export default function RichContent({ content, fallbackParagraphs = [] }: RichContentProps) {
+  if (content) {
+    return (
+      <div className="ricos-content">
+        <RicosViewer content={content as any} plugins={plugins} />
+      </div>
+    );
+  }
+  if (fallbackParagraphs.length > 0) {
+    return (
+      <div className="space-y-4">
+        {fallbackParagraphs.map((p, i) => (
+          <p key={i} className="leading-relaxed">
+            {p}
+          </p>
+        ))}
+      </div>
+    );
+  }
+  return null;
+}

--- a/skills/wix-headless-fast/references/blog/app/hooks/blog/useBlogFeed.ts
+++ b/skills/wix-headless-fast/references/blog/app/hooks/blog/useBlogFeed.ts
@@ -1,0 +1,123 @@
+// Blog feed + taxonomy filter + cursor paging. SSR-friendly: pass server-fetched data as
+// `initial*` (Astro frontmatter / server component) and no client fetch happens; a SPA passes
+// nothing. Category/tag filtering fetches live (server-side-filtered); the two filters are
+// mutually exclusive — setting one clears the other.
+import { useEffect, useState } from "react";
+import { fetchPosts } from "../../wix/blog/posts";
+import { fetchBlogCategories, fetchBlogTags } from "../../wix/blog/taxonomy";
+import type { BlogCategory, BlogTag, PostPage, PostSummary } from "../../wix/blog/types";
+
+export interface UseBlogFeedOptions {
+  initialPage?: PostPage;
+  initialCategories?: BlogCategory[];
+  initialTags?: BlogTag[];
+  pageSize?: number;
+}
+
+export interface UseBlogFeed {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  posts: PostSummary[] | null;
+  categories: BlogCategory[];
+  tags: BlogTag[];
+  activeCategoryId: string | null;
+  setActiveCategoryId: (id: string | null) => void;
+  activeTagId: string | null;
+  setActiveTagId: (id: string | null) => void;
+  /** True when another page exists — render a "load more" control on it. */
+  hasMore: boolean;
+  loadMore: () => void;
+  loadingMore: boolean;
+  error: string | null;
+}
+
+export function useBlogFeed({
+  initialPage,
+  initialCategories,
+  initialTags,
+  pageSize = 20,
+}: UseBlogFeedOptions = {}): UseBlogFeed {
+  const [posts, setPosts] = useState<PostSummary[] | null>(initialPage?.posts ?? null);
+  const [nextCursor, setNextCursor] = useState<string | null>(initialPage?.nextCursor ?? null);
+  const [categories, setCategories] = useState<BlogCategory[]>(initialCategories ?? []);
+  const [tags, setTags] = useState<BlogTag[]>(initialTags ?? []);
+  const [activeCategoryId, setCategoryId] = useState<string | null>(null);
+  const [activeTagId, setTagId] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialCategories) {
+      fetchBlogCategories().then((c) => alive && setCategories(c));
+    }
+    if (!initialTags) {
+      fetchBlogTags().then((t) => alive && setTags(t));
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // The unfiltered first page may have come from the server; only fetch when it didn't,
+    // or when a filter is active (filters are server-side).
+    if (activeCategoryId === null && activeTagId === null && initialPage) {
+      setPosts(initialPage.posts);
+      setNextCursor(initialPage.nextCursor);
+      return;
+    }
+    let alive = true;
+    setPosts(null);
+    setError(null);
+    fetchPosts({ limit: pageSize, categoryId: activeCategoryId, tagId: activeTagId })
+      .then((page) => {
+        if (!alive) return;
+        setPosts(page.posts);
+        setNextCursor(page.nextCursor);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setPosts([]);
+        setNextCursor(null);
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeCategoryId, activeTagId, pageSize]);
+
+  function loadMore(): void {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setError(null);
+    fetchPosts({ limit: pageSize, cursor: nextCursor })
+      .then((page) => {
+        setPosts((prev) => [...(prev ?? []), ...page.posts]);
+        setNextCursor(page.nextCursor);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoadingMore(false));
+  }
+
+  return {
+    posts,
+    categories,
+    tags,
+    activeCategoryId,
+    setActiveCategoryId: (id) => {
+      setCategoryId(id);
+      setTagId(null);
+    },
+    activeTagId,
+    setActiveTagId: (id) => {
+      setTagId(id);
+      setCategoryId(null);
+    },
+    hasMore: nextCursor !== null,
+    loadMore,
+    loadingMore,
+    error,
+  };
+}

--- a/skills/wix-headless-fast/references/blog/app/hooks/blog/usePost.ts
+++ b/skills/wix-headless-fast/references/blog/app/hooks/blog/usePost.ts
@@ -1,0 +1,70 @@
+// One post by slug + its resolved category/tag chips. SSR-friendly: pass the server-fetched
+// post (and taxonomy) as `initial*` and no client fetch happens; a SPA passes only the slug.
+// Chips resolve from the FULL taxonomy lists (blog taxonomies are small, fetched once) —
+// never per-id lookups in a render loop.
+import { useEffect, useMemo, useState } from "react";
+import { fetchPostBySlug } from "../../wix/blog/posts";
+import { fetchBlogCategories, fetchBlogTags } from "../../wix/blog/taxonomy";
+import type { BlogCategory, BlogTag, PostDetail } from "../../wix/blog/types";
+
+export interface UsePostOptions {
+  slug: string;
+  initialPost?: PostDetail;
+  initialCategories?: BlogCategory[];
+  initialTags?: BlogTag[];
+}
+
+export interface UsePost {
+  /** null while loading (render a skeleton) AND when not found — disambiguate via notFound. */
+  post: PostDetail | null;
+  /** True once the slug definitively resolved to nothing — render a not-found state. */
+  notFound: boolean;
+  /** This post's categories/tags, resolved to full objects (display .label, route by .slug). */
+  categories: BlogCategory[];
+  tags: BlogTag[];
+  error: string | null;
+}
+
+export function usePost({ slug, initialPost, initialCategories, initialTags }: UsePostOptions): UsePost {
+  const [post, setPost] = useState<PostDetail | null>(initialPost ?? null);
+  const [notFound, setNotFound] = useState(false);
+  const [allCategories, setAllCategories] = useState<BlogCategory[]>(initialCategories ?? []);
+  const [allTags, setAllTags] = useState<BlogTag[]>(initialTags ?? []);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialPost || initialPost.slug !== slug) {
+      setPost(null);
+      setNotFound(false);
+      fetchPostBySlug(slug)
+        .then((p) => {
+          if (!alive) return;
+          if (p) setPost(p);
+          else setNotFound(true);
+        })
+        .catch((e) => alive && setError(e instanceof Error ? e.message : String(e)));
+    }
+    if (!initialCategories) {
+      fetchBlogCategories().then((c) => alive && setAllCategories(c));
+    }
+    if (!initialTags) {
+      fetchBlogTags().then((t) => alive && setAllTags(t));
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  const categories = useMemo(
+    () => (post ? allCategories.filter((c) => post.categoryIds.includes(c.id)) : []),
+    [post, allCategories],
+  );
+  const tags = useMemo(
+    () => (post ? allTags.filter((t) => post.tagIds.includes(t.id)) : []),
+    [post, allTags],
+  );
+
+  return { post, notFound, categories, tags, error };
+}

--- a/skills/wix-headless-fast/references/blog/app/wix/blog/posts.ts
+++ b/skills/wix-headless-fast/references/blog/app/wix/blog/posts.ts
@@ -1,0 +1,97 @@
+// Post reads (Wix Blog V3) — the only file that touches raw post entities. Everything it
+// returns is a plain DTO from ./types. Copy as-is; extend by adding functions, not by editing
+// these. Blog posts are NOT CMS collections — always @wix/blog, never @wix/data.
+import { posts as postsModule } from "@wix/blog";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { PostDetail, PostPage, PostSummary } from "./types";
+
+const posts = wixModule(postsModule);
+
+/** The Wix Blog app id (Astro item-page routing; comments use it as appId). */
+export const BLOG_APP_ID = "14bcded7-0066-7c35-14d7-466cb3f09103";
+
+type Raw = Record<string, any>;
+
+function dateParts(value: unknown): { dateLabel: string; dateISO: string } {
+  if (!value) return { dateLabel: "", dateISO: "" };
+  const d = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(d.getTime())) return { dateLabel: "", dateISO: "" };
+  return {
+    dateLabel: d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }),
+    dateISO: d.toISOString(),
+  };
+}
+
+function toSummary(raw: Raw): PostSummary {
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    title: raw.title ?? "",
+    excerpt: raw.excerpt ?? "",
+    ...dateParts(raw.firstPublishedDate),
+    minutesToRead: raw.minutesToRead ?? 0,
+    featured: raw.featured === true,
+    pinned: raw.pinned === true,
+    // The cover is a media STRING (wix:image:// or https) at media.wixMedia.image.
+    coverUrl: imgSrc(raw.media?.wixMedia?.image, 1200, 675),
+    categoryIds: raw.categoryIds ?? [],
+    tagIds: raw.tagIds ?? [],
+  };
+}
+
+function toDetail(raw: Raw): PostDetail {
+  return {
+    ...toSummary(raw),
+    richContent: raw.richContent ?? null,
+    // contentText is plain text — split on newlines for the fallback body.
+    paragraphs: String(raw.contentText ?? "")
+      .split("\n")
+      .map((s: string) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+export interface FetchPostsOptions {
+  limit?: number;
+  /** `nextCursor` from a previous page. */
+  cursor?: string | null;
+  /** Server-side filters (first page only — the cursor carries them on later pages). */
+  categoryId?: string | null;
+  tagId?: string | null;
+}
+
+/**
+ * One page of published posts, newest first (pinned posts lead). Only published posts come
+ * back to a visitor token — a "missing" post usually wasn't published, not a query bug.
+ */
+export async function fetchPosts({ limit = 20, cursor, categoryId, tagId }: FetchPostsOptions = {}): Promise<PostPage> {
+  let q = posts.queryPosts().limit(limit);
+  if (cursor) {
+    // A cursor encodes the original filter+sort — re-sending them alongside it is rejected.
+    q = q.skipTo(cursor);
+  } else {
+    q = q.descending("firstPublishedDate");
+    if (categoryId) q = q.hasSome("categoryIds", [categoryId]);
+    if (tagId) q = q.hasSome("tagIds", [tagId]);
+  }
+  const res = await q.find();
+  return {
+    posts: (res.items ?? []).map((p: Raw) => toSummary(p)),
+    nextCursor: res.hasNext() ? (res.cursors?.next ?? null) : null,
+  };
+}
+
+/**
+ * Fetch one post by its URL slug with the full body (RICH_CONTENT + CONTENT_TEXT fieldsets —
+ * without them the body fields come back undefined). Null when not found.
+ */
+export async function fetchPostBySlug(slug: string): Promise<PostDetail | null> {
+  const res = await posts
+    .queryPosts({ fieldsets: ["RICH_CONTENT", "CONTENT_TEXT"] })
+    .eq("slug", slug)
+    .limit(1)
+    .find();
+  const raw = res.items?.[0];
+  return raw ? toDetail(raw as Raw) : null;
+}

--- a/skills/wix-headless-fast/references/blog/app/wix/blog/taxonomy.ts
+++ b/skills/wix-headless-fast/references/blog/app/wix/blog/taxonomy.ts
@@ -1,0 +1,74 @@
+// Category + tag reads (Wix Blog V3) — the only file that touches raw taxonomy entities.
+// Everything it returns is a plain DTO from ./types. Copy as-is; extend by adding functions.
+import { categories as categoriesModule, tags as tagsModule } from "@wix/blog";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { BlogCategory, BlogTag } from "./types";
+
+const categories = wixModule(categoriesModule);
+const tags = wixModule(tagsModule);
+
+type Raw = Record<string, any>;
+
+function toCategory(raw: Raw): BlogCategory {
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    label: raw.label ?? "",
+    description: raw.description ?? "",
+    postCount: raw.postCount ?? 0,
+    coverUrl: imgSrc(raw.coverImage, 1200, 675),
+  };
+}
+
+function toTag(raw: Raw): BlogTag {
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    label: raw.label ?? "",
+    postCount: raw.publishedPostCount ?? 0,
+  };
+}
+
+/** Categories in menu order (displayPosition) — non-fatal (empty array on failure). */
+export async function fetchBlogCategories(): Promise<BlogCategory[]> {
+  try {
+    const res = await categories.queryCategories().ascending("displayPosition").limit(100).find();
+    return (res.items ?? []).map((c: Raw) => toCategory(c)).filter((c) => c.id);
+  } catch {
+    return [];
+  }
+}
+
+/** Tags, most-published-posts first — non-fatal (empty array on failure). */
+export async function fetchBlogTags(): Promise<BlogTag[]> {
+  try {
+    const res = await tags.queryTags().descending("publishedPostCount").limit(100).find();
+    return (res.items ?? []).map((t: Raw) => toTag(t)).filter((t) => t.id);
+  } catch {
+    return [];
+  }
+}
+
+// The two by-slug getters return DIFFERENT envelopes upstream ({ category } vs { tag } here;
+// getTag(id) even returns the tag bare) — the mapping below absorbs that asymmetry once.
+
+/** One category by its URL slug. Null when not found. */
+export async function fetchCategoryBySlug(slug: string): Promise<BlogCategory | null> {
+  try {
+    const res = await categories.getCategoryBySlug(slug);
+    return res.category ? toCategory(res.category as Raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** One tag by its URL slug. Null when not found. */
+export async function fetchTagBySlug(slug: string): Promise<BlogTag | null> {
+  try {
+    const res = await tags.getTagBySlug(slug);
+    return res.tag ? toTag(res.tag as Raw) : null;
+  } catch {
+    return null;
+  }
+}

--- a/skills/wix-headless-fast/references/blog/app/wix/blog/types.ts
+++ b/skills/wix-headless-fast/references/blog/app/wix/blog/types.ts
@@ -1,0 +1,62 @@
+// Blog DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. Cover images are
+// resolved https URLs; dates are pre-formatted display strings plus an ISO value for <time>.
+
+/** A post as a feed/grid tile needs it. */
+export interface PostSummary {
+  id: string;
+  slug: string;
+  title: string;
+  /** Short summary (≤500 chars) — the card body. May be "". */
+  excerpt: string;
+  /** Display-ready publish date, e.g. "Aug 26, 2026" ("" when missing). */
+  dateLabel: string;
+  /** ISO publish date for <time datetime> ("" when missing). */
+  dateISO: string;
+  /** Estimated reading time in minutes (0 when unknown). */
+  minutesToRead: number;
+  featured: boolean;
+  /** Pinned posts lead the default feed order. */
+  pinned: boolean;
+  /** Resolved https cover URL ("" when the post has no cover). */
+  coverUrl: string;
+  categoryIds: string[];
+  tagIds: string[];
+}
+
+/** A post as the post page needs it. */
+export interface PostDetail extends PostSummary {
+  /**
+   * Ricos rich-content document (plain JSON) — the real post body. Render it ONLY through
+   * the shipped RichContent component (@wix/ricos viewer); it is not HTML and not text.
+   */
+  richContent: Record<string, unknown> | null;
+  /** Plain-text body split into paragraphs — the honest fallback when richContent is null. */
+  paragraphs: string[];
+}
+
+export interface BlogCategory {
+  id: string;
+  slug: string;
+  /** Display name (the API calls it `label`, never `name`). */
+  label: string;
+  description: string;
+  /** Number of posts in the category (hide empty categories with it). */
+  postCount: number;
+  /** Resolved https cover URL ("" when none). */
+  coverUrl: string;
+}
+
+export interface BlogTag {
+  id: string;
+  slug: string;
+  label: string;
+  /** Number of PUBLISHED posts with this tag. */
+  postCount: number;
+}
+
+/** One feed page; pass `nextCursor` back to fetch the next (null → no more). */
+export interface PostPage {
+  posts: PostSummary[];
+  nextCursor: string | null;
+}

--- a/skills/wix-headless-fast/references/blog/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/blog/lock/astro/package-lock.json
@@ -1,0 +1,16156 @@
+{
+ "name": "wix-headless-fast-blog",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-blog",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/blog": "^1.0.645",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/essentials": "^1.0.10",
+    "@wix/ricos": "^11.12.0",
+    "@wix/sdk": "^1.21.5",
+    "@wix/seo": "^1.0.79",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@codemirror/autocomplete": {
+   "version": "6.20.3",
+   "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+   "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.17.0",
+    "@lezer/common": "^1.0.0"
+   }
+  },
+  "node_modules/@codemirror/commands": {
+   "version": "6.10.4",
+   "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+   "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.27.0",
+    "@lezer/common": "^1.1.0"
+   }
+  },
+  "node_modules/@codemirror/lang-json": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+   "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@lezer/json": "^1.0.0"
+   }
+  },
+  "node_modules/@codemirror/language": {
+   "version": "6.12.4",
+   "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+   "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.23.0",
+    "@lezer/common": "^1.5.0",
+    "@lezer/highlight": "^1.0.0",
+    "@lezer/lr": "^1.0.0",
+    "style-mod": "^4.0.0"
+   }
+  },
+  "node_modules/@codemirror/lint": {
+   "version": "6.9.7",
+   "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+   "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.42.0",
+    "crelt": "^1.0.5"
+   }
+  },
+  "node_modules/@codemirror/search": {
+   "version": "6.7.1",
+   "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+   "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.37.0",
+    "crelt": "^1.0.5"
+   }
+  },
+  "node_modules/@codemirror/state": {
+   "version": "6.7.1",
+   "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+   "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@marijn/find-cluster-break": "^1.0.0"
+   }
+  },
+  "node_modules/@codemirror/theme-one-dark": {
+   "version": "6.1.3",
+   "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+   "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0",
+    "@lezer/highlight": "^1.0.0"
+   }
+  },
+  "node_modules/@codemirror/view": {
+   "version": "6.43.8",
+   "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+   "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/state": "^6.7.0",
+    "crelt": "^1.0.6",
+    "style-mod": "^4.1.0",
+    "w3c-keyname": "^2.2.4"
+   }
+  },
+  "node_modules/@compiled/react": {
+   "version": "0.19.1",
+   "resolved": "https://registry.npmjs.org/@compiled/react/-/react-0.19.1.tgz",
+   "integrity": "sha512-vurcg91LVBeLVz/TQ4XaQMInkaIpuCvL9PzfNReiVW7z4SkoqO0KnXR14OAi0ABUuhBNPhlgviFeWwAut9SlsA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "csstype": "^3.1.3"
+   },
+   "peerDependencies": {
+    "react": ">=18.0.0"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@dmsnell/diff-match-patch": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+   "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@emoji-mart/data": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+   "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+   "license": "MIT"
+  },
+  "node_modules/@emoji-mart/react": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+   "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+   "license": "MIT",
+   "peerDependencies": {
+    "emoji-mart": "^5.2",
+    "react": "^16.8 || ^17 || ^18"
+   }
+  },
+  "node_modules/@emotion/is-prop-valid": {
+   "version": "0.8.8",
+   "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+   "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emotion/memoize": "0.7.4"
+   }
+  },
+  "node_modules/@emotion/memoize": {
+   "version": "0.7.4",
+   "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+   "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react": {
+   "version": "0.26.28",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+   "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.2",
+    "@floating-ui/utils": "^0.2.8",
+    "tabbable": "^6.0.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT"
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@hypnosphi/create-react-context": {
+   "version": "0.3.1",
+   "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+   "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+   "license": "MIT",
+   "dependencies": {
+    "gud": "^1.0.0",
+    "warning": "^4.0.3"
+   },
+   "peerDependencies": {
+    "prop-types": "^15.0.0",
+    "react": ">=0.14.0"
+   }
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@internationalized/date": {
+   "version": "3.12.3",
+   "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+   "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/number": {
+   "version": "3.6.7",
+   "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+   "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/string": {
+   "version": "3.2.10",
+   "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+   "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@lezer/common": {
+   "version": "1.5.2",
+   "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+   "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+   "license": "MIT"
+  },
+  "node_modules/@lezer/highlight": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+   "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@lezer/common": "^1.3.0"
+   }
+  },
+  "node_modules/@lezer/json": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+   "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@lezer/common": "^1.2.0",
+    "@lezer/highlight": "^1.0.0",
+    "@lezer/lr": "^1.0.0"
+   }
+  },
+  "node_modules/@lezer/lr": {
+   "version": "1.4.10",
+   "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+   "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+   "license": "MIT",
+   "dependencies": {
+    "@lezer/common": "^1.0.0"
+   }
+  },
+  "node_modules/@loadable/component": {
+   "version": "5.16.7",
+   "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.16.7.tgz",
+   "integrity": "sha512-XvkFixLUOTEaj8lI7uwc4nf8Wmq3IulYG7SZHCWcPm/Li5gjJDFfIkgWOLPnD7jqPJVtAG9bEz4SCek+SpHYYg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.18",
+    "hoist-non-react-statics": "^3.3.1",
+    "react-is": "^16.12.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/gregberge"
+   },
+   "peerDependencies": {
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@marijn/find-cluster-break": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+   "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+   "license": "MIT"
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/dumper/node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT"
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dialog": {
+   "version": "1.1.23",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+   "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@react-aria/focus": {
+   "version": "3.22.1",
+   "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+   "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0",
+    "react-aria": "^3.48.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-dnd/asap": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+   "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+   "license": "MIT"
+  },
+  "node_modules/@react-dnd/invariant": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+   "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+   "license": "MIT"
+  },
+  "node_modules/@react-dnd/shallowequal": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+   "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
+   "license": "MIT"
+  },
+  "node_modules/@react-types/shared": {
+   "version": "3.36.1",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+   "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+   "license": "Apache-2.0",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@sinonjs/commons": {
+   "version": "1.8.6",
+   "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+   "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "type-detect": "4.0.8"
+   }
+  },
+  "node_modules/@sinonjs/commons/node_modules/type-detect": {
+   "version": "4.0.8",
+   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+   "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/@sinonjs/formatio": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+   "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "samsam": "1.3.0"
+   }
+  },
+  "node_modules/@sinonjs/samsam": {
+   "version": "3.3.3",
+   "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+   "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@sinonjs/commons": "^1.3.0",
+    "array-from": "^2.1.1",
+    "lodash": "^4.17.15"
+   }
+  },
+  "node_modules/@sinonjs/text-encoding": {
+   "version": "0.7.3",
+   "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+   "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+   "deprecated": "Deprecated: no longer maintained and no longer used by Sinon packages. See\n  https://github.com/sinonjs/nise/issues/243 for replacement details.",
+   "license": "(Unlicense OR Apache-2.0)"
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@stylable/uni-driver": {
+   "version": "2.5.3",
+   "resolved": "https://registry.npmjs.org/@stylable/uni-driver/-/uni-driver-2.5.3.tgz",
+   "integrity": "sha512-thE0QYRDmJ3tF3p4LE3Av5dSPGMwmBkK0H257MxtfPEE0JMN3Hez9i4xDNq5L591kuStCq1oEx+r/H5i6BQ5HA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/@swc/helpers": {
+   "version": "0.5.23",
+   "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+   "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@testing-library/dom": {
+   "version": "10.4.1",
+   "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+   "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.10.4",
+    "@babel/runtime": "^7.12.5",
+    "@types/aria-query": "^5.0.1",
+    "aria-query": "5.3.0",
+    "dom-accessibility-api": "^0.5.9",
+    "lz-string": "^1.5.0",
+    "picocolors": "1.1.1",
+    "pretty-format": "^27.0.2"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@testing-library/react": {
+   "version": "16.3.2",
+   "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+   "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@babel/runtime": "^7.12.5"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "peerDependencies": {
+    "@testing-library/dom": "^10.0.0",
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "@types/react-dom": "^18.0.0 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/aria-query": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+   "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+   "license": "MIT"
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/base16": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@types/base16/-/base16-1.0.5.tgz",
+   "integrity": "sha512-OzOWrTluG9cwqidEzC/Q6FAmIPcnZfm8BFRlIx0+UIUqnuAmi5OS88O0RpT3Yz6qdmqObvUhasrbNsCofE4W9A==",
+   "license": "MIT"
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/hoist-non-react-statics": {
+   "version": "3.3.7",
+   "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+   "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+   "license": "MIT",
+   "dependencies": {
+    "hoist-non-react-statics": "^3.3.0"
+   },
+   "peerDependencies": {
+    "@types/react": "*"
+   }
+  },
+  "node_modules/@types/lodash": {
+   "version": "4.17.25",
+   "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+   "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+   "license": "MIT"
+  },
+  "node_modules/@types/lodash-es": {
+   "version": "4.17.12",
+   "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+   "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/lodash": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@uiw/codemirror-extensions-basic-setup": {
+   "version": "4.25.11",
+   "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.11.tgz",
+   "integrity": "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/autocomplete": "^6.0.0",
+    "@codemirror/commands": "^6.0.0",
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/lint": "^6.0.0",
+    "@codemirror/search": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://jaywcjlove.github.io/#/sponsor"
+   },
+   "peerDependencies": {
+    "@codemirror/autocomplete": ">=6.0.0",
+    "@codemirror/commands": ">=6.0.0",
+    "@codemirror/language": ">=6.0.0",
+    "@codemirror/lint": ">=6.0.0",
+    "@codemirror/search": ">=6.0.0",
+    "@codemirror/state": ">=6.0.0",
+    "@codemirror/view": ">=6.0.0"
+   }
+  },
+  "node_modules/@uiw/codemirror-themes": {
+   "version": "4.25.11",
+   "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.11.tgz",
+   "integrity": "sha512-SBNCOgRsCtewGNocRbmjbCkltGXlFcPJsvhxQ351VynQjnWUiPbUrFcEU/haQ3HanROdAAjWXZJPk5bMBxl2jw==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://jaywcjlove.github.io/#/sponsor"
+   },
+   "peerDependencies": {
+    "@codemirror/language": ">=6.0.0",
+    "@codemirror/state": ">=6.0.0",
+    "@codemirror/view": ">=6.0.0"
+   }
+  },
+  "node_modules/@uiw/react-codemirror": {
+   "version": "4.25.11",
+   "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.11.tgz",
+   "integrity": "sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.18.6",
+    "@codemirror/commands": "^6.1.0",
+    "@codemirror/state": "^6.1.1",
+    "@codemirror/theme-one-dark": "^6.0.0",
+    "@uiw/codemirror-extensions-basic-setup": "4.25.11",
+    "codemirror": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://jaywcjlove.github.io/#/sponsor"
+   },
+   "peerDependencies": {
+    "@babel/runtime": ">=7.11.0",
+    "@codemirror/state": ">=6.0.0",
+    "@codemirror/theme-one-dark": ">=6.0.0",
+    "@codemirror/view": ">=6.0.0",
+    "codemirror": ">=6.0.0",
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
+   }
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/aria-ai-avatar": {
+   "version": "0.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/aria-ai-avatar/-/@wix/aria-ai-avatar-0.11.0.tgz",
+   "integrity": "sha512-xAhC06GaYzr94OEtAQZB8kCfbY0+7VOuGIA1z6hUBVFkqDsMUIocJdiU4IVAUGd7nYHIm5XqwKdlrHWPtJMGQw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "classnames": "^2.5.1"
+   },
+   "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_blog-cache": {
+   "version": "1.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_blog-cache/-/@wix/auto_sdk_blog_blog-cache-1.0.41.tgz",
+   "integrity": "sha512-7ar6SmJZJvzL9LabVZ9Ky8E9QUgtwNIhGBXiNDRr8r1CMn52FrBaErieSMM7B4QhSUEk2z/da6SSw/6NGoDPZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_categories": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_categories/-/@wix/auto_sdk_blog_categories-1.0.48.tgz",
+   "integrity": "sha512-hj/C2DvEJdfCwUgQ0ktnebkHl4vbQErpxp2J1j5Fz0iv1Vg5Ciqr3377eyU9VZC4UdSeg001etRWZgWllE9zXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_draft-posts": {
+   "version": "1.0.98",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_draft-posts/-/@wix/auto_sdk_blog_draft-posts-1.0.98.tgz",
+   "integrity": "sha512-NAH0KBbF+GUdPF+T6TVLDUBhKukgE0v92ryV39LB4RDYm3nXvhyhikQ+saO0gjPtPJiSgADDWKMZA71odhyNBA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_likes": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_likes/-/@wix/auto_sdk_blog_likes-1.0.24.tgz",
+   "integrity": "sha512-iIjq4KDjTNp2pM96CErFedKciJhsI8prPKCwD6MK8p5os7a24q6Lsrh8pct0KGccRVJiPUk6AVgo8FrIvNINIw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_posts": {
+   "version": "1.0.177",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_posts/-/@wix/auto_sdk_blog_posts-1.0.177.tgz",
+   "integrity": "sha512-tM2fRUl+oSsTcxLyBIifs5gyoxVrJVitbglzxCXCCbs26pWiCrzgTC8f3EWzN7VtmF4RpA6lbO394CzDQYCArg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_blog_tags": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_tags/-/@wix/auto_sdk_blog_tags-1.0.57.tgz",
+   "integrity": "sha512-t5iBZg9sXPs3Qe9IOYGnvBovoX8zROZSby+FlaXE+UuiKwPcicVNbiRpk6+KMgxYd97fAOQUpjjHyFgU59rRbg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_comments_categories": {
+   "version": "1.0.61",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_categories/-/@wix/auto_sdk_comments_categories-1.0.61.tgz",
+   "integrity": "sha512-16BeZ4SXWsL6xbT5l3WZZ1l0aNZi967N1QzQGx1Fo++FqV8C4IlRFZBtjnEo1ebZyBI22C3loNZwBvUqusm4pA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_comments_comments": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_comments/-/@wix/auto_sdk_comments_comments-1.0.69.tgz",
+   "integrity": "sha512-m6CsJXlsyH2KRkPkRdrQEtm5CdoDVGlLG+MuErRAMV0/wrWlrRrVbTFuSwSw7S5nlvxswtblMFI/vxiznEhiKg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_comments_ratings": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_ratings/-/@wix/auto_sdk_comments_ratings-1.0.5.tgz",
+   "integrity": "sha512-5E/1yHQGOyviO+igJ84dW4UzUU6kUrWgTLRsnpNqh4RorxP97IzhN1wo1zDg4ESyZig/x04dRKY+kODUWnVnCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_comments_widgets": {
+   "version": "1.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_widgets/-/@wix/auto_sdk_comments_widgets-1.0.39.tgz",
+   "integrity": "sha512-yeuCKxB9y2/xj36Fl9ElN1RVi27h5uqdrZfEgXtyFLbdxDrQk0cXFEh9U8EgLF+IyBjR/KONWVIAYjs/dMuq7Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_authentication": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/@wix/auto_sdk_members_authentication-1.0.45.tgz",
+   "integrity": "sha512-rYbM07KLz3FQgjxb1tUO/7Ns+ZnI15XCdXQI13NZRmWLLU6NhxfVuy7EyHNxb+IgeEXzAyiqB1taGY4IriMx9g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_authorization": {
+   "version": "1.0.36",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/@wix/auto_sdk_members_authorization-1.0.36.tgz",
+   "integrity": "sha512-hpaTseJXSv9CpQWwFItXjmIPgq0NjNBBm98XX6We7m+lDMXkoDHvIgo645xS/jIMpWbwRS26/iY61W9A9Is02g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badge-assignments": {
+   "version": "1.0.30",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/@wix/auto_sdk_members_badge-assignments-1.0.30.tgz",
+   "integrity": "sha512-0RggesluwvfP8lEpLTaJlKtz9LKEuuPzIKpxce+iGbSZin6CyvmaV9HIGEO+G64QSOdWCzXUY8JU+9/4ni1xPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badges": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/@wix/auto_sdk_members_badges-1.0.52.tgz",
+   "integrity": "sha512-vJPXfwIKobCLFvW6EalpbP9mZe/fTL7WiZsdlZJUX7igr64udS65JAnnDb73Ge7l9SoiWtXUDLPcvbMMF+mw8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badges-v-2": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/@wix/auto_sdk_members_badges-v-2-1.0.37.tgz",
+   "integrity": "sha512-KHy7ZizF1KW+icDRabv3swQtR0i+WQ43XcqQ3sFYVowpXsb73rg9XgpZ8/3gc+d5sEedIh9OuCOtYfzZi2htsg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-field-applications": {
+   "version": "1.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/@wix/auto_sdk_members_custom-field-applications-1.0.41.tgz",
+   "integrity": "sha512-GnCIAZ7ATgCr9gEqxuClE4y9VHEN1ayxq2nJrdHatIkxsoElvWp2E/Uw9e7O0TUdkNXLLlBvd3mjeKpdrUhUvQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-field-suggestions": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/@wix/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
+   "integrity": "sha512-2LCuljSdthAoIoiw4A+ZjSIOqCam4TnsJI1meZLmvOUBenQghzeflwvFvmIG13h+lkKWiLc0WmkhrmEo8Iosog==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-fields": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/@wix/auto_sdk_members_custom-fields-1.0.59.tgz",
+   "integrity": "sha512-e0Gj3mWXzv1VDGY95CMh1zVp6YQGbLuURD4TTDuxETvqEYMFzTtDXfTuGi90MbEWAwTk1aqYF8BR0gKL0ILV8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_default-privacy": {
+   "version": "1.0.34",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/@wix/auto_sdk_members_default-privacy-1.0.34.tgz",
+   "integrity": "sha512-pgAe1M898aSSnYKn0mIf8SdGNeA2lK8OI9vncLv9kV1wknP5ue6/eNr3GEBl5JawspoifxbyuD7C+c1R8WiLBw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-followers": {
+   "version": "1.0.44",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/@wix/auto_sdk_members_member-followers-1.0.44.tgz",
+   "integrity": "sha512-LVxdoeXewsZul72frlyLY5PYU6Ycz6ddbvYkhZr09TCgP6sPvwCuI+br/r3sxGwJ3XlM3w9cFtwOc6cZf40+eA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-privacy-settings": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/@wix/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
+   "integrity": "sha512-JpcWY+fppyjBXfwcIX7ztlo34ZpA+b7Cbhh62oaH8fzQq7PpfVk9zc94FT2EEiwutaipgJOU4SyrLl3/JULwGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-report": {
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/@wix/auto_sdk_members_member-report-1.0.49.tgz",
+   "integrity": "sha512-kx+netTOEhPS32d98pgko+fbwyR4HT87TlxdKqg1aBaJBrDEz2M533wc8wTJX1TArj9B41ew39k/fXdbfCEozA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-role-definition": {
+   "version": "1.0.47",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/@wix/auto_sdk_members_member-role-definition-1.0.47.tgz",
+   "integrity": "sha512-PpGcfee/QCqtCU4U7KdGjqe8CB8ereXnMxLleisyapNWhwfWo1r1XBfq4EaVc0GF9uLdozWWx6Oums/bB42E6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-to-member-block": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/@wix/auto_sdk_members_member-to-member-block-1.0.35.tgz",
+   "integrity": "sha512-U5Z5l7KGpYztXtz0E3V7JNogdJGNCPmcR5yjeEZdT0u8yZTQKsnF7hNvMxxyv2RMGJwCNmdYLHbFYj/ic/Futw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_members": {
+   "version": "1.0.131",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/@wix/auto_sdk_members_members-1.0.131.tgz",
+   "integrity": "sha512-kgPFRm1faDjRsCv7kOcALlZiHpBJ9Ix5PZy8NJxzJEu2kKBdkdH6kVBTk+R13lRO6XkK5NRPytY9cinu2suP2g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_members-about": {
+   "version": "1.0.78",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/@wix/auto_sdk_members_members-about-1.0.78.tgz",
+   "integrity": "sha512-HPXMekpWcexRubnf5gA0flYiYktEcsj4kMi0oyC47zTTIO7tmpqjJULH365y8rzDx6vPLUb25Lzyb+rCZPTxwA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_user-member": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/@wix/auto_sdk_members_user-member-1.0.56.tgz",
+   "integrity": "sha512-FMiVGhE+F6psLwXTKC4Rz2W/dDl1Sa2Fj/P80+jDkTZ5IDR5c4Qq5M3Prlj7MmHIjSx7OsEX6zdRVoGFBjfA0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_llms-txt": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_redirects": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
+   "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_robots-txt": {
+   "version": "1.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-patterns": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
+   "version": "1.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-tags": {
+   "version": "1.0.28",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/awaiter-utils": {
+   "version": "1.0.141",
+   "resolved": "https://registry.npmjs.org/@wix/awaiter-utils/-/@wix/awaiter-utils-1.0.141.tgz",
+   "integrity": "sha512-ScV5PZNZR/KwX/pmANHWdn2Il0mDqVZL8/0qQRF38zKmiXiUqSipp4uiuRft2ocA2Jz+aP9qvAW1+CJgvW9VNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/@wix/blog": {
+   "version": "1.0.645",
+   "resolved": "https://registry.npmjs.org/@wix/blog/-/@wix/blog-1.0.645.tgz",
+   "integrity": "sha512-UnEL4pyLtsrWtmnTniuqX1vWmQNrInVmzfOrSQ6KUGP8W087H2eXU+LM4K5a+m69IY/Oe/D7GjgwhdDcs6/TsA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_blog_blog-cache": "1.0.41",
+    "@wix/auto_sdk_blog_categories": "1.0.48",
+    "@wix/auto_sdk_blog_draft-posts": "1.0.98",
+    "@wix/auto_sdk_blog_likes": "1.0.24",
+    "@wix/auto_sdk_blog_posts": "1.0.177",
+    "@wix/auto_sdk_blog_tags": "1.0.57",
+    "@wix/blog_app-extensions": "1.0.53",
+    "@wix/headless-blog": "^0.0.29"
+   }
+  },
+  "node_modules/@wix/blog_app-extensions": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/blog_app-extensions/-/@wix/blog_app-extensions-1.0.53.tgz",
+   "integrity": "sha512-Zd3o91ln1Sf0K4cgL1R0J5/OuCQSWROM83etZJHtA34xhBCou49MFUIW74GkYWt99dsIQl/YkxjqQhQ21naNOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/comments": {
+   "version": "1.0.197",
+   "resolved": "https://registry.npmjs.org/@wix/comments/-/@wix/comments-1.0.197.tgz",
+   "integrity": "sha512-2OibIsJ4TVlanGz3DYmxAMsu6b9Kg7O6czpnOOrAj0/7tvLONzOy5qR+I2wZ8r9aG7lINjSuy83LFOdwvZuzLQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_comments_categories": "1.0.61",
+    "@wix/auto_sdk_comments_comments": "1.0.69",
+    "@wix/auto_sdk_comments_ratings": "1.0.5",
+    "@wix/auto_sdk_comments_widgets": "1.0.39"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/design-system": {
+   "version": "1.317.1",
+   "resolved": "https://registry.npmjs.org/@wix/design-system/-/@wix/design-system-1.317.1.tgz",
+   "integrity": "sha512-BHrr8gXr9ZtcrPYB0xSUTwEviZ6G3duMGA3nAI4wxynkijKUU2P5Y+mlzYC0X1rnISUxxEKP8NQsBzai8B4lWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "@floating-ui/react": "0.26.28",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@react-aria/focus": "^3.21.5",
+    "@wix/awaiter-utils": "^1.0.141",
+    "@wix/design-system-illustrations": "^2.34.2",
+    "@wix/design-system-tokens": "^1.225.2",
+    "@wix/design-systems-locale-utils": "1.197.0",
+    "@wix/unidriver-core": "^1.5.5",
+    "@wix/wix-ui-icons-common": "^3.189.14",
+    "@wix/wix-ui-test-utils": "^1.3.5",
+    "chart.js": "^2.9.4",
+    "classnames": "^2.5.1",
+    "color": "^2.0.1",
+    "d3-array": "^2.12.1",
+    "d3-axis": "^2.1.0",
+    "d3-ease": "^2.0.0",
+    "d3-format": "^2.0.0",
+    "d3-scale": "^3.3.0",
+    "d3-selection": "^2.0.0",
+    "d3-shape": "^2.1.0",
+    "d3-transition": "^2.0.0",
+    "date-fns": "^2.30.0",
+    "difference": "^1.0.2",
+    "dnd-core": "^11.1.3",
+    "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-react": "^8.6.0",
+    "fbjs": "^2.0.0",
+    "framer-motion": "6.2.4",
+    "gradient-parser": "^1.0.2",
+    "hoist-non-react-methods": "^1.1.0",
+    "hoist-non-react-statics": "^3.3.2",
+    "howler": "^2.2.4",
+    "immutable": "^3.8.2",
+    "invariant": "^2.2.1",
+    "lodash": "^4.18.1",
+    "object-assign": "^4.1.1",
+    "omit": "^1.0.1",
+    "overlayscrollbars": "2.6.1",
+    "popper.js": "^1.16.1",
+    "rc-slider": "9.7.2",
+    "react-chartjs-2": "^2.11.2",
+    "react-day-picker": "^7.4.10",
+    "react-dnd": "^11.1.3",
+    "react-dnd-test-backend": "^11.1.3",
+    "react-dnd-touch-backend": "^11.1.3",
+    "react-modal": "^3.16.3",
+    "react-popper": "^1.3.11",
+    "react-remove-scroll": "2.7.1",
+    "react-scroll-sync": "0.11.0",
+    "react-transition-group": "^4.4.5",
+    "react-window": "^1.8.10",
+    "shallowequal": "^1.1.0",
+    "tslib": "^2.8.1"
+   },
+   "peerDependencies": {
+    "@playwright/test": "1.58.2",
+    "@types/react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "@types/react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "@wix/ambassador": "^4.0.485",
+    "@wix/ambassador-wix-atlas-service-web": "^1.0.150",
+    "playwright": "1.58.2",
+    "puppeteer": "^5.5.0 || ^14.0.0",
+    "puppeteer-core": "^10.1.0 || ^14.0.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@playwright/test": {
+     "optional": true
+    },
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    },
+    "@wix/ambassador": {
+     "optional": true
+    },
+    "@wix/ambassador-wix-atlas-service-web": {
+     "optional": true
+    },
+    "playwright": {
+     "optional": true
+    },
+    "puppeteer": {
+     "optional": true
+    },
+    "puppeteer-core": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/design-system-illustrations": {
+   "version": "2.34.2",
+   "resolved": "https://registry.npmjs.org/@wix/design-system-illustrations/-/@wix/design-system-illustrations-2.34.2.tgz",
+   "integrity": "sha512-zSOPmTimQ4/wm+gXKuwl81mfMwkRlsaWz1qGOKcMVZBY1OcpgFGdObFflNQwRsB/H8DaKRgZwGoZ3zovw9xi0g==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
+   }
+  },
+  "node_modules/@wix/design-system-tokens": {
+   "version": "1.225.2",
+   "resolved": "https://registry.npmjs.org/@wix/design-system-tokens/-/@wix/design-system-tokens-1.225.2.tgz",
+   "integrity": "sha512-Y3zhHWuFUoMJMWZhKMDRtVm0WQmkHI9RP9NZvHFIPJfXdunGFvOXR1p/aQttfBl8FSZU6ASmMAsYvFv6uG8AHg==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/design-system/node_modules/react-chartjs-2": {
+   "version": "2.11.2",
+   "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.2.tgz",
+   "integrity": "sha512-hcPS9vmRJeAALPPf0uo02BiD8BDm0HNmneJYTZVR74UKprXOpql+Jy1rVuj93rKw0Jfx77mkcRfXPxTe5K83uw==",
+   "license": "MIT",
+   "dependencies": {
+    "lodash": "^4.17.19",
+    "prop-types": "^15.7.2"
+   },
+   "peerDependencies": {
+    "chart.js": "^2.3",
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/design-system/node_modules/react-day-picker": {
+   "version": "7.4.10",
+   "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.10.tgz",
+   "integrity": "sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==",
+   "license": "MIT",
+   "dependencies": {
+    "prop-types": "^15.6.2"
+   },
+   "peerDependencies": {
+    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/design-system/node_modules/react-popper": {
+   "version": "1.3.11",
+   "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+   "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.1.2",
+    "@hypnosphi/create-react-context": "^0.3.1",
+    "deep-equal": "^1.1.1",
+    "popper.js": "^1.14.4",
+    "prop-types": "^15.6.1",
+    "typed-styles": "^0.0.7",
+    "warning": "^4.0.2"
+   },
+   "peerDependencies": {
+    "react": "0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/design-system/node_modules/react-remove-scroll": {
+   "version": "2.7.1",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+   "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+   "license": "MIT",
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/design-systems-locale-utils": {
+   "version": "1.197.0",
+   "resolved": "https://registry.npmjs.org/@wix/design-systems-locale-utils/-/@wix/design-systems-locale-utils-1.197.0.tgz",
+   "integrity": "sha512-dvaFxQGWEK87f81thtfjB8Bq7CSvna+DpnPppAXRycaJTB602o3iGu1R8pVYswSbtsyXJP5eDHoO96meV3+DbA==",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-blog": {
+   "version": "0.0.29",
+   "resolved": "https://registry.npmjs.org/@wix/headless-blog/-/@wix/headless-blog-0.0.29.tgz",
+   "integrity": "sha512-j+tDgQpVr1h656Gkgxgc6MekK2k8c8avcDlljLhfADjrzMtsgPWB07r0YzHeSHkCaSF8aIVRLwQs9ZOH1HV0UA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/blog": "^1.0.477",
+    "@wix/comments": "^1.0.133",
+    "@wix/headless-media": "0.0.20",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/members": "^1.0.322",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.27",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-components/node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-seo": {
+   "version": "0.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
+   "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/seo": "^1.0.14",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/media/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/members": {
+   "version": "1.0.511",
+   "resolved": "https://registry.npmjs.org/@wix/members/-/@wix/members-1.0.511.tgz",
+   "integrity": "sha512-n30tjMx6LAiDiCVT2jnenoFIxEwgIwbn7S5pWbesVvo73+mDuyn0+bxVJJw0acGY00nvnmpJsdrU28VMOz5CKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_members_authentication": "1.0.45",
+    "@wix/auto_sdk_members_authorization": "1.0.36",
+    "@wix/auto_sdk_members_badge-assignments": "1.0.30",
+    "@wix/auto_sdk_members_badges": "1.0.52",
+    "@wix/auto_sdk_members_badges-v-2": "1.0.37",
+    "@wix/auto_sdk_members_custom-field-applications": "1.0.41",
+    "@wix/auto_sdk_members_custom-field-suggestions": "1.0.40",
+    "@wix/auto_sdk_members_custom-fields": "1.0.59",
+    "@wix/auto_sdk_members_default-privacy": "1.0.34",
+    "@wix/auto_sdk_members_member-followers": "1.0.44",
+    "@wix/auto_sdk_members_member-privacy-settings": "1.0.59",
+    "@wix/auto_sdk_members_member-report": "1.0.49",
+    "@wix/auto_sdk_members_member-role-definition": "1.0.47",
+    "@wix/auto_sdk_members_member-to-member-block": "1.0.35",
+    "@wix/auto_sdk_members_members": "1.0.131",
+    "@wix/auto_sdk_members_members-about": "1.0.78",
+    "@wix/auto_sdk_members_user-member": "1.0.56"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/motion": {
+   "version": "2.1.11",
+   "resolved": "https://registry.npmjs.org/@wix/motion/-/motion-2.1.11.tgz",
+   "integrity": "sha512-Ma5Mr1AyzTW6xyBnnnSiAXk5+/UJuh1XzfAcfOKHQSaMIgVK03JKh7G0m9bOSdGT5k0kv5bWU8zH7AJ8G0z+KA==",
+   "license": "MIT",
+   "dependencies": {
+    "fastdom": "^1.0.11"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@wix/motion-presets": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/motion-presets/-/motion-presets-1.0.4.tgz",
+   "integrity": "sha512-SaL0tRkfarnxsrTYMusR6CWT1WA7+Ywx50xJ8Vu8HdVC8+d4aHjRhN6W/iNMrpgjocypWcjz6JQl4mAzQGD23A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/motion": "^2.1.8"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/ricos": {
+   "version": "11.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/ricos/-/@wix/ricos-11.12.0.tgz",
+   "integrity": "sha512-u3jWIDLhZ8h5mxchsItfP4dsT6Q5wgE1ojhT2NRC/UJBF/HAiQVahLnK4xHu6SjZLTFfV5/3kATXhoLlP8499w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@codemirror/lang-json": "^6.0.0",
+    "@codemirror/lint": "^6.0.0",
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
+    "@floating-ui/react-dom": "^2.0.0",
+    "@lezer/highlight": "^1.2.0",
+    "@loadable/component": "^5.14.1",
+    "@uiw/codemirror-themes": "^4.21.25",
+    "@uiw/react-codemirror": "^4.19.7",
+    "@wix/ai-assistant-avatar": "^0.41.0",
+    "@wix/design-system": "^1.231.0",
+    "@wix/design-system-illustrations": "^2.28.0",
+    "@wix/image-kit": "^1.123.0",
+    "@wix/members": "^1.0.137",
+    "@wix/motion": "^2.1.7",
+    "@wix/motion-presets": "^1.0.3",
+    "@wix/sdk": "^1.17.1",
+    "@wix/unidriver-core": "^1.3.6",
+    "@wix/unidriver-jsdom-react": "^1.3.6",
+    "@wix/unidriver-playwright": "^1.3.9",
+    "@wix/unidriver-puppeteer": "^1.3.6",
+    "@wix/wix-ui-icons-common": "^3.189.0",
+    "classnames": "^2.5.1",
+    "emoji-mart": "^5.6.0",
+    "emulate-tab": "^1.2.1",
+    "fastdom": "^1.0.12",
+    "focus-trap": "^7.6.2",
+    "fp-ts-esm": "^2.16.10",
+    "fuse.js": "^7.0.0",
+    "html-entities": "^2.3.6",
+    "i18next": "^19.0.0",
+    "id3js": "2.1.1",
+    "json-to-ast": "^2.1.0",
+    "linkify-it": "^5.0.0",
+    "linkifyjs": "4.3.2",
+    "load-script": "^2.0.0",
+    "monocle-ts-esm": "^2.3.13",
+    "omit-deep": "0.3.0",
+    "parse5": "^6.0.0",
+    "prosemirror-commands": "^1.6.0",
+    "prosemirror-dev-tools": "4.3.0",
+    "prosemirror-keymap": "^1.2.2",
+    "prosemirror-model": "^1.22.3",
+    "prosemirror-schema-list": "^1.4.1",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-transform": "^1.10.0",
+    "prosemirror-view": "^1.34.3",
+    "react-dock": "^0.6.0",
+    "react-i18next": "^11.18.6",
+    "react-infinite-scroller": "^1.2.4",
+    "react-json-tree": "^0.17.0",
+    "react-portal-tooltip": "^2.4.7",
+    "rope-sequence": "^1.3.0",
+    "roughjs": "^4.6.6",
+    "svgson": "^5.3.1",
+    "ts-is-present": "^1.1.1",
+    "use-sync-external-store": "^1.6.0",
+    "y-prosemirror": "^1.3.7",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.27"
+   },
+   "peerDependencies": {
+    "@babel/runtime": "^7.17.2",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@wix/ricos/node_modules/@wix/ai-assistant-avatar": {
+   "version": "0.41.0",
+   "resolved": "https://registry.npmjs.org/@wix/ai-assistant-avatar/-/@wix/ai-assistant-avatar-0.41.0.tgz",
+   "integrity": "sha512-ux3xPNEo0p+vFNZx5qf2Bs5StZU0dJGT8+qqqrGhIKDOYv9j8g0SoYJByJPFi5lqTkA9lyRpMQ3PfL8vpITViA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.27.6",
+    "@wix/aria-ai-avatar": "^0.11.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
+   }
+  },
+  "node_modules/@wix/ricos/node_modules/i18next": {
+   "version": "19.9.2",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+   "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.0"
+   }
+  },
+  "node_modules/@wix/ricos/node_modules/react-i18next": {
+   "version": "11.18.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+   "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.14.5",
+    "html-parse-stringify": "^3.0.1"
+   },
+   "peerDependencies": {
+    "i18next": ">= 19.0.0",
+    "react": ">= 16.8.0"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/ricos/node_modules/react-portal-tooltip": {
+   "version": "2.4.7",
+   "resolved": "https://registry.npmjs.org/react-portal-tooltip/-/react-portal-tooltip-2.4.7.tgz",
+   "integrity": "sha512-ZOuCKpvu8rr6aS6nNjckd78qEgWyHZnKidZ9Yqrd0HR5K9NYJ7csb4duc0kEXeG8DiCWsLPU70o1EVP+MxlINg==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/seo": {
+   "version": "1.0.79",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
+   "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
+    "@wix/auto_sdk_seo_llms-txt": "1.0.0",
+    "@wix/auto_sdk_seo_redirects": "1.0.2",
+    "@wix/auto_sdk_seo_robots-txt": "1.0.21",
+    "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
+    "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
+    "@wix/auto_sdk_seo_seo-tags": "1.0.28",
+    "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
+    "@wix/headless-seo": "^0.0.16"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/unidriver-common": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-common/-/@wix/unidriver-common-1.5.6.tgz",
+   "integrity": "sha512-0owm5hJUpAEcackgflRVEha/nKocySZyRrZbVKetmNzWjxf+WGt8rzvr6DDiRZmB9ZRCtXWUXVvJSLTAIkoBWw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/unidriver-core": "^1.5.6"
+   }
+  },
+  "node_modules/@wix/unidriver-core": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-core/-/@wix/unidriver-core-1.5.6.tgz",
+   "integrity": "sha512-5xeIXr5tO0pkCTI71sYkkHC9znK8G8XRoqml2cHMb88nmdGwJndSdmp+CtF2NQkdZm/13ZR82Aj/ZYY3aNz7lw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/unidriver-jsdom-react": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react/-/@wix/unidriver-jsdom-react-1.5.6.tgz",
+   "integrity": "sha512-85C3LOWi73PtoEt9SnqKp/Lt6euT1iZZO5ciyLhAKyemzI4LV0gIhyl3voQpSCSwgtMqOECKp++2xpUx/2C0Ig==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@wix/unidriver-common": "^1.5.6",
+    "@wix/unidriver-core": "^1.5.6"
+   },
+   "peerDependencies": {
+    "@testing-library/react": ">=14 <17",
+    "react": ">=16 <=19",
+    "react-dom": ">=16 <=19"
+   }
+  },
+  "node_modules/@wix/unidriver-jsdom-react-legacy": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react-legacy/-/@wix/unidriver-jsdom-react-legacy-1.5.6.tgz",
+   "integrity": "sha512-0FcUfzqepZGI1ny9EJAw1eSjT+xZgMwtyLzuwPT9LZEccLLnveYwmVmbJjku4f/dh6mFOpR0F7TUO40tzP9U3w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/unidriver-common": "^1.5.6",
+    "@wix/unidriver-core": "^1.5.6"
+   },
+   "peerDependencies": {
+    "react": ">=16.14.0 <=18",
+    "react-dom": ">=16.14.0 <=18"
+   }
+  },
+  "node_modules/@wix/unidriver-playwright": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-playwright/-/@wix/unidriver-playwright-1.5.6.tgz",
+   "integrity": "sha512-7VFjIgU47f7BHzssGNNg/WwkE2j0tEs7AkfN6h85+nHCgdD+cKRy1pZkok3qLfD54Ii6QxOOzJTFHonxon7uSQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/unidriver-common": "^1.5.6",
+    "@wix/unidriver-core": "^1.5.6"
+   }
+  },
+  "node_modules/@wix/unidriver-puppeteer": {
+   "version": "1.5.6",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-puppeteer/-/@wix/unidriver-puppeteer-1.5.6.tgz",
+   "integrity": "sha512-RjTOEsmDCV/rqXIqgVvLh341VPPHpFH/FBq16W5nPH0/drZkOPbdznSS5STpJUQ0C4mYBrXgIC/23U3keB+2Fg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/unidriver-common": "^1.5.6",
+    "@wix/unidriver-core": "^1.5.6",
+    "array.prototype.at": "^1.1.3"
+   }
+  },
+  "node_modules/@wix/wix-ui-icons-common": {
+   "version": "3.189.14",
+   "resolved": "https://registry.npmjs.org/@wix/wix-ui-icons-common/-/@wix/wix-ui-icons-common-3.189.14.tgz",
+   "integrity": "sha512-ZCwih1buJWXgJBdL7jBwTNLSyBLLMIO04U/S7zf+JEl9S2aYAgKNO4kUDSAkDBbfKPotPhcBV/X1EVe3JxbGUw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "react-error-boundary": "^5.0.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/wix-ui-test-utils": {
+   "version": "1.3.5",
+   "resolved": "https://registry.npmjs.org/@wix/wix-ui-test-utils/-/@wix/wix-ui-test-utils-1.3.5.tgz",
+   "integrity": "sha512-tczLyUQw0ChQQ25HHr5zK55o+kvaVgxz/aJzP8Yg7Pca4ja9Qes+pBv1JFQUb8vO9eBohsqrcP0XrNQr4JzTog==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.29.7",
+    "@stylable/uni-driver": "^2.5.3",
+    "@wix/unidriver-core": "^1.4.8",
+    "@wix/unidriver-jsdom-react": "^1.4.8",
+    "@wix/unidriver-jsdom-react-legacy": "^1.4.8",
+    "@wix/unidriver-playwright": "^1.4.8",
+    "@wix/unidriver-puppeteer": "^1.4.8",
+    "tslib": "^2.8.1"
+   },
+   "peerDependencies": {
+    "@testing-library/react": ">=12",
+    "playwright": "^1.54.2",
+    "puppeteer": "^14.0.0",
+    "puppeteer-core": "^14.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@testing-library/react": {
+     "optional": true
+    },
+    "playwright": {
+     "optional": true
+    },
+    "puppeteer": {
+     "optional": true
+    },
+    "puppeteer-core": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "5.2.0",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+   "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.0",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+   "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "dequal": "^2.0.3"
+   }
+  },
+  "node_modules/array-buffer-byte-length": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+   "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "is-array-buffer": "^3.0.5"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/array-from": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+   "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+   "license": "MIT"
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/array.prototype.at": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/array.prototype.at/-/array.prototype.at-1.1.3.tgz",
+   "integrity": "sha512-TX4J1Uig4skvpOakrvP8q/uyhUj+ZDNmQoZpHf3MsKTrXcMHDPrgJlpv2nRJMfANrsmhg1JoOGrg3yOp209SWg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.7",
+    "define-properties": "^1.2.1",
+    "es-abstract": "^1.23.2",
+    "es-object-atoms": "^1.0.0",
+    "es-shim-unscopables": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/arraybuffer.prototype.slice": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+   "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+   "license": "MIT",
+   "dependencies": {
+    "array-buffer-byte-length": "^1.0.1",
+    "call-bind": "^1.0.8",
+    "define-properties": "^1.2.1",
+    "es-abstract": "^1.23.5",
+    "es-errors": "^1.3.0",
+    "get-intrinsic": "^1.2.6",
+    "is-array-buffer": "^3.0.4"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/asap": {
+   "version": "2.0.6",
+   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+   "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+   "license": "MIT"
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/async-function": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+   "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/available-typed-arrays": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+   "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "possible-typed-array-names": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/base16": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+   "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "devOptional": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "devOptional": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/buffer-from": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+   "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+   "license": "MIT"
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/call-bind": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+   "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind-apply-helpers": "^1.0.2",
+    "es-define-property": "^1.0.1",
+    "get-intrinsic": "^1.3.0",
+    "set-function-length": "^1.2.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/call-bind-apply-helpers": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+   "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "function-bind": "^1.1.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/call-bound": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+   "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind-apply-helpers": "^1.0.2",
+    "get-intrinsic": "^1.3.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "devOptional": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chart.js": {
+   "version": "2.9.4",
+   "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+   "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+   "license": "MIT",
+   "dependencies": {
+    "chartjs-color": "^2.1.0",
+    "moment": "^2.10.2"
+   }
+  },
+  "node_modules/chartjs-color": {
+   "version": "2.4.1",
+   "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+   "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+   "license": "MIT",
+   "dependencies": {
+    "chartjs-color-string": "^0.6.0",
+    "color-convert": "^1.9.3"
+   }
+  },
+  "node_modules/chartjs-color-string": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+   "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+   "license": "MIT",
+   "dependencies": {
+    "color-name": "^1.0.0"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/classnames": {
+   "version": "2.5.1",
+   "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+   "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+   "license": "MIT"
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/code-error-fragment": {
+   "version": "0.0.230",
+   "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
+   "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/codemirror": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+   "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@codemirror/autocomplete": "^6.0.0",
+    "@codemirror/commands": "^6.0.0",
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/lint": "^6.0.0",
+    "@codemirror/search": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0"
+   }
+  },
+  "node_modules/color": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+   "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+   "license": "MIT",
+   "dependencies": {
+    "color-convert": "^1.9.1",
+    "color-string": "^1.5.2"
+   }
+  },
+  "node_modules/color-convert": {
+   "version": "1.9.3",
+   "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+   "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+   "license": "MIT",
+   "dependencies": {
+    "color-name": "1.1.3"
+   }
+  },
+  "node_modules/color-convert/node_modules/color-name": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+   "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+   "license": "MIT"
+  },
+  "node_modules/color-name": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+   "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+   "license": "MIT"
+  },
+  "node_modules/color-string": {
+   "version": "1.9.1",
+   "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+   "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+   "license": "MIT",
+   "dependencies": {
+    "color-name": "^1.0.0",
+    "simple-swizzle": "^0.2.2"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/concat-stream": {
+   "version": "1.6.2",
+   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+   "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+   "engines": [
+    "node >= 0.8"
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "buffer-from": "^1.0.0",
+    "inherits": "^2.0.3",
+    "readable-stream": "^2.2.2",
+    "typedarray": "^0.0.6"
+   }
+  },
+  "node_modules/concat-stream/node_modules/isarray": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+   "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+   "license": "MIT"
+  },
+  "node_modules/concat-stream/node_modules/readable-stream": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+   "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+   "license": "MIT",
+   "dependencies": {
+    "core-util-is": "~1.0.0",
+    "inherits": "~2.0.3",
+    "isarray": "~1.0.0",
+    "process-nextick-args": "~2.0.0",
+    "safe-buffer": "~5.1.1",
+    "string_decoder": "~1.1.1",
+    "util-deprecate": "~1.0.1"
+   }
+  },
+  "node_modules/concat-stream/node_modules/safe-buffer": {
+   "version": "5.1.2",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+   "license": "MIT"
+  },
+  "node_modules/concat-stream/node_modules/string_decoder": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+   "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.1.0"
+   }
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/core-js": {
+   "version": "3.50.0",
+   "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+   "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/core-js"
+   }
+  },
+  "node_modules/core-util-is": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+   "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+   "license": "MIT"
+  },
+  "node_modules/crelt": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+   "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="
+  },
+  "node_modules/cross-fetch": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+   "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+   "license": "MIT",
+   "dependencies": {
+    "node-fetch": "^2.7.0"
+   }
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "license": "MIT"
+  },
+  "node_modules/d3-array": {
+   "version": "2.12.1",
+   "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+   "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "internmap": "^1.0.0"
+   }
+  },
+  "node_modules/d3-axis": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
+   "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-color": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+   "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-dispatch": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+   "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-ease": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+   "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-format": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+   "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-interpolate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+   "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-color": "1 - 2"
+   }
+  },
+  "node_modules/d3-path": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+   "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-scale": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+   "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-array": "^2.3.0",
+    "d3-format": "1 - 2",
+    "d3-interpolate": "1.2.0 - 2",
+    "d3-time": "^2.1.1",
+    "d3-time-format": "2 - 3"
+   }
+  },
+  "node_modules/d3-selection": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+   "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-shape": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+   "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-path": "1 - 2"
+   }
+  },
+  "node_modules/d3-time": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+   "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-array": "2"
+   }
+  },
+  "node_modules/d3-time-format": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+   "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-time": "1 - 2"
+   }
+  },
+  "node_modules/d3-timer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+   "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/d3-transition": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+   "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "d3-color": "1 - 2",
+    "d3-dispatch": "1 - 2",
+    "d3-ease": "1 - 2",
+    "d3-interpolate": "1 - 2",
+    "d3-timer": "1 - 2"
+   },
+   "peerDependencies": {
+    "d3-selection": "2"
+   }
+  },
+  "node_modules/data-view-buffer": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+   "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "es-errors": "^1.3.0",
+    "is-data-view": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/data-view-byte-length": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+   "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "es-errors": "^1.3.0",
+    "is-data-view": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/inspect-js"
+   }
+  },
+  "node_modules/data-view-byte-offset": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+   "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "es-errors": "^1.3.0",
+    "is-data-view": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/date-fns": {
+   "version": "2.30.0",
+   "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+   "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.21.0"
+   },
+   "engines": {
+    "node": ">=0.11"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/date-fns"
+   }
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/deep-equal": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+   "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+   "license": "MIT",
+   "dependencies": {
+    "is-arguments": "^1.1.1",
+    "is-date-object": "^1.0.5",
+    "is-regex": "^1.1.4",
+    "object-is": "^1.1.5",
+    "object-keys": "^1.1.1",
+    "regexp.prototype.flags": "^1.5.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/deep-rename-keys": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/deep-rename-keys/-/deep-rename-keys-0.2.1.tgz",
+   "integrity": "sha512-RHd9ABw4Fvk+gYDWqwOftG849x0bYOySl/RgX0tLI9i27ZIeSO91mLZJEp7oPHOMFqHvpgu21YptmDt0FYD/0A==",
+   "license": "MIT",
+   "dependencies": {
+    "kind-of": "^3.0.2",
+    "rename-keys": "^1.1.2"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/define-data-property": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+   "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+   "license": "MIT",
+   "dependencies": {
+    "es-define-property": "^1.0.0",
+    "es-errors": "^1.3.0",
+    "gopd": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/define-properties": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+   "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "define-data-property": "^1.0.1",
+    "has-property-descriptors": "^1.0.0",
+    "object-keys": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT"
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/difference": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/difference/-/difference-1.0.2.tgz",
+   "integrity": "sha512-bNfxVectrfp4CcZx/qdVhnyPnMWMetwMDrJB6jyEKUTqA4y6WQpeeGSWD8ZCUVzc4TKaeHHASlJwlhDYy3SSeg==",
+   "license": "MIT"
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dnd-core": {
+   "version": "11.1.3",
+   "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-11.1.3.tgz",
+   "integrity": "sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==",
+   "license": "MIT",
+   "dependencies": {
+    "@react-dnd/asap": "^4.0.0",
+    "@react-dnd/invariant": "^2.0.0",
+    "redux": "^4.0.4"
+   }
+  },
+  "node_modules/dom-accessibility-api": {
+   "version": "0.5.16",
+   "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+   "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+   "license": "MIT"
+  },
+  "node_modules/dom-align": {
+   "version": "1.12.4",
+   "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
+   "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
+   "license": "MIT"
+  },
+  "node_modules/dom-helpers": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+   "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.8.7",
+    "csstype": "^3.0.2"
+   }
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/dunder-proto": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+   "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind-apply-helpers": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "gopd": "^1.2.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "devOptional": true,
+   "license": "ISC"
+  },
+  "node_modules/embla-carousel": {
+   "version": "8.6.0",
+   "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+   "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+   "license": "MIT"
+  },
+  "node_modules/embla-carousel-autoplay": {
+   "version": "8.6.0",
+   "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+   "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "embla-carousel": "8.6.0"
+   }
+  },
+  "node_modules/embla-carousel-react": {
+   "version": "8.6.0",
+   "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+   "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+   "license": "MIT",
+   "dependencies": {
+    "embla-carousel": "8.6.0",
+    "embla-carousel-reactive-utils": "8.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   }
+  },
+  "node_modules/embla-carousel-reactive-utils": {
+   "version": "8.6.0",
+   "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+   "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+   "license": "MIT",
+   "peerDependencies": {
+    "embla-carousel": "8.6.0"
+   }
+  },
+  "node_modules/emoji-mart": {
+   "version": "5.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+   "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+   "license": "MIT"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/emulate-tab": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/emulate-tab/-/emulate-tab-1.2.1.tgz",
+   "integrity": "sha512-msvZDjWv3hTSpq/j0hqudE+Zthulpo1AuSAHcMqCgv2PmJbIXjWXDTx4sLrY3adMiHT4IXDT4cS9LMbwSlzScw==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-abstract": {
+   "version": "1.24.2",
+   "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+   "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+   "license": "MIT",
+   "dependencies": {
+    "array-buffer-byte-length": "^1.0.2",
+    "arraybuffer.prototype.slice": "^1.0.4",
+    "available-typed-arrays": "^1.0.7",
+    "call-bind": "^1.0.8",
+    "call-bound": "^1.0.4",
+    "data-view-buffer": "^1.0.2",
+    "data-view-byte-length": "^1.0.2",
+    "data-view-byte-offset": "^1.0.1",
+    "es-define-property": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "es-object-atoms": "^1.1.1",
+    "es-set-tostringtag": "^2.1.0",
+    "es-to-primitive": "^1.3.0",
+    "function.prototype.name": "^1.1.8",
+    "get-intrinsic": "^1.3.0",
+    "get-proto": "^1.0.1",
+    "get-symbol-description": "^1.1.0",
+    "globalthis": "^1.0.4",
+    "gopd": "^1.2.0",
+    "has-property-descriptors": "^1.0.2",
+    "has-proto": "^1.2.0",
+    "has-symbols": "^1.1.0",
+    "hasown": "^2.0.2",
+    "internal-slot": "^1.1.0",
+    "is-array-buffer": "^3.0.5",
+    "is-callable": "^1.2.7",
+    "is-data-view": "^1.0.2",
+    "is-negative-zero": "^2.0.3",
+    "is-regex": "^1.2.1",
+    "is-set": "^2.0.3",
+    "is-shared-array-buffer": "^1.0.4",
+    "is-string": "^1.1.1",
+    "is-typed-array": "^1.1.15",
+    "is-weakref": "^1.1.1",
+    "math-intrinsics": "^1.1.0",
+    "object-inspect": "^1.13.4",
+    "object-keys": "^1.1.1",
+    "object.assign": "^4.1.7",
+    "own-keys": "^1.0.1",
+    "regexp.prototype.flags": "^1.5.4",
+    "safe-array-concat": "^1.1.3",
+    "safe-push-apply": "^1.0.0",
+    "safe-regex-test": "^1.1.0",
+    "set-proto": "^1.0.0",
+    "stop-iteration-iterator": "^1.1.0",
+    "string.prototype.trim": "^1.2.10",
+    "string.prototype.trimend": "^1.0.9",
+    "string.prototype.trimstart": "^1.0.8",
+    "typed-array-buffer": "^1.0.3",
+    "typed-array-byte-length": "^1.0.3",
+    "typed-array-byte-offset": "^1.0.4",
+    "typed-array-length": "^1.0.7",
+    "unbox-primitive": "^1.1.0",
+    "which-typed-array": "^1.1.19"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/es-abstract-get": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+   "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "es-object-atoms": "^1.1.2",
+    "is-callable": "^1.2.7",
+    "object-inspect": "^1.13.4"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/es-define-property": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+   "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/es-errors": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+   "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/es-object-atoms": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+   "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/es-set-tostringtag": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+   "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "get-intrinsic": "^1.2.6",
+    "has-tostringtag": "^1.0.2",
+    "hasown": "^2.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/es-shim-unscopables": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+   "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+   "license": "MIT",
+   "dependencies": {
+    "hasown": "^2.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/es-to-primitive": {
+   "version": "1.3.4",
+   "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+   "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+   "license": "MIT",
+   "dependencies": {
+    "es-abstract-get": "^1.0.0",
+    "es-define-property": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "is-callable": "^1.2.7",
+    "is-date-object": "^1.1.0",
+    "is-symbol": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/exenv": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+   "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fastdom": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+   "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+   "license": "MIT",
+   "dependencies": {
+    "strictdom": "^1.0.1"
+   }
+  },
+  "node_modules/fbjs": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
+   "integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "core-js": "^3.6.4",
+    "cross-fetch": "^3.0.4",
+    "fbjs-css-vars": "^1.0.0",
+    "loose-envify": "^1.0.0",
+    "object-assign": "^4.1.0",
+    "promise": "^7.1.1",
+    "setimmediate": "^1.0.5",
+    "ua-parser-js": "^0.7.18"
+   }
+  },
+  "node_modules/fbjs-css-vars": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+   "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/focus-trap": {
+   "version": "7.8.0",
+   "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+   "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+   "license": "MIT",
+   "dependencies": {
+    "tabbable": "^6.4.0"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/for-each": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+   "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+   "license": "MIT",
+   "dependencies": {
+    "is-callable": "^1.2.7"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/fp-ts-esm": {
+   "version": "2.16.10",
+   "resolved": "https://registry.npmjs.org/fp-ts-esm/-/fp-ts-esm-2.16.10.tgz",
+   "integrity": "sha512-LrVYnlEoq5dQwDjaj8ca8zMR9ldWprdu5a39vmOc+UVkX2dj6TfjfFhx1Oin9r3q2CBgxKUIf3lXOzFFGd/YJg==",
+   "license": "MIT"
+  },
+  "node_modules/framer-motion": {
+   "version": "6.2.4",
+   "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.2.4.tgz",
+   "integrity": "sha512-1UfnSG4c4CefKft6QMYGx8AWt3TtaFoR/Ax4dkuDDD5BDDeIuUm7gesmJrF8GzxeX/i6fMm8+MEdPngUyPVdLA==",
+   "license": "MIT",
+   "dependencies": {
+    "framesync": "6.0.1",
+    "hey-listen": "^1.0.8",
+    "popmotion": "11.0.3",
+    "style-value-types": "5.0.0",
+    "tslib": "^2.1.0"
+   },
+   "optionalDependencies": {
+    "@emotion/is-prop-valid": "^0.8.2"
+   },
+   "peerDependencies": {
+    "react": ">=16.8 || ^17.0.0",
+    "react-dom": ">=16.8 || ^17.0.0"
+   }
+  },
+  "node_modules/framesync": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+   "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.1.0"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/function-bind": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+   "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/function.prototype.name": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+   "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.9",
+    "call-bound": "^1.0.4",
+    "es-define-property": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "functions-have-names": "^1.2.3",
+    "has-property-descriptors": "^1.0.2",
+    "hasown": "^2.0.4",
+    "is-callable": "^1.2.7",
+    "is-document.all": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/functions-have-names": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+   "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/fuse.js": {
+   "version": "7.5.0",
+   "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+   "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/krisk"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/generator-function": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+   "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-intrinsic": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+   "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind-apply-helpers": "^1.0.2",
+    "es-define-property": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "es-object-atoms": "^1.1.1",
+    "function-bind": "^1.1.2",
+    "get-proto": "^1.0.1",
+    "gopd": "^1.2.0",
+    "has-symbols": "^1.1.0",
+    "hasown": "^2.0.2",
+    "math-intrinsics": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/get-proto": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+   "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+   "license": "MIT",
+   "dependencies": {
+    "dunder-proto": "^1.0.1",
+    "es-object-atoms": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/get-symbol-description": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+   "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "es-errors": "^1.3.0",
+    "get-intrinsic": "^1.2.6"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/get-value": {
+   "version": "2.0.6",
+   "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+   "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/globalthis": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+   "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "define-properties": "^1.2.1",
+    "gopd": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/gopd": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+   "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/gradient-parser": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.2.0.tgz",
+   "integrity": "sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/grapheme-splitter": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+   "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+   "license": "MIT"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/gud": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+   "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+   "license": "MIT"
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/hachure-fill": {
+   "version": "0.5.2",
+   "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+   "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+   "license": "MIT"
+  },
+  "node_modules/has-bigints": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+   "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/has-flag": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+   "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/has-property-descriptors": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+   "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+   "license": "MIT",
+   "dependencies": {
+    "es-define-property": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/has-proto": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+   "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+   "license": "MIT",
+   "dependencies": {
+    "dunder-proto": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/has-symbols": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+   "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/has-tostringtag": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+   "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+   "license": "MIT",
+   "dependencies": {
+    "has-symbols": "^1.0.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/has-value": {
+   "version": "0.3.1",
+   "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+   "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "get-value": "^2.0.3",
+    "has-values": "^0.1.4",
+    "isobject": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/has-value/node_modules/isarray": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+   "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+   "license": "MIT"
+  },
+  "node_modules/has-value/node_modules/isobject": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+   "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+   "license": "MIT",
+   "dependencies": {
+    "isarray": "1.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/has-values": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+   "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/hasown": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+   "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+   "license": "MIT",
+   "dependencies": {
+    "function-bind": "^1.1.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-html/node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/hast-util-from-html/node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw/node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/hast-util-raw/node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hey-listen": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+   "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+   "license": "MIT"
+  },
+  "node_modules/hoist-non-react-methods": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/hoist-non-react-methods/-/hoist-non-react-methods-1.1.0.tgz",
+   "integrity": "sha512-0y58VIZRsvwl8m4e/NrGSiZSPQUmlaxK5UnnR0aJ8++2xN6MLb2j73TknC0aK7mlQaA97bwK/mgadTtvFP7zLA==",
+   "license": "MIT",
+   "dependencies": {
+    "sinon": "^4.2.0"
+   }
+  },
+  "node_modules/hoist-non-react-statics": {
+   "version": "3.3.2",
+   "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+   "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "react-is": "^16.7.0"
+   }
+  },
+  "node_modules/howler": {
+   "version": "2.2.4",
+   "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+   "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
+   "license": "MIT"
+  },
+  "node_modules/html": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
+   "integrity": "sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==",
+   "license": "BSD",
+   "dependencies": {
+    "concat-stream": "^1.4.7"
+   },
+   "bin": {
+    "html": "bin/html.js"
+   }
+  },
+  "node_modules/html-entities": {
+   "version": "2.6.0",
+   "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+   "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/mdevils"
+    },
+    {
+     "type": "patreon",
+     "url": "https://patreon.com/mdevils"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/id3js": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/id3js/-/id3js-2.1.1.tgz",
+   "integrity": "sha512-9Gi+sG0RHSa5qn8hkwi2KCl+2jV8YrtiZidXbOO3uLfRAxc2jilRg0fiQ3CbeoAmR7G7ap3RVs1kqUVhIyZaog==",
+   "license": "MIT"
+  },
+  "node_modules/immutable": {
+   "version": "3.8.3",
+   "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+   "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "license": "ISC"
+  },
+  "node_modules/internal-slot": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+   "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "hasown": "^2.0.2",
+    "side-channel": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/internmap": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+   "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/invariant": {
+   "version": "2.2.4",
+   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+   "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.0.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-arguments": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+   "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-array-buffer": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+   "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.8",
+    "call-bound": "^1.0.3",
+    "get-intrinsic": "^1.2.6"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-arrayish": {
+   "version": "0.3.4",
+   "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+   "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+   "license": "MIT"
+  },
+  "node_modules/is-async-function": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+   "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "async-function": "^1.0.0",
+    "call-bound": "^1.0.3",
+    "get-proto": "^1.0.1",
+    "has-tostringtag": "^1.0.2",
+    "safe-regex-test": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-bigint": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+   "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "has-bigints": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-boolean-object": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+   "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-buffer": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+   "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+   "license": "MIT"
+  },
+  "node_modules/is-callable": {
+   "version": "1.2.7",
+   "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+   "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-data-view": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+   "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "get-intrinsic": "^1.2.6",
+    "is-typed-array": "^1.1.13"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-date-object": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+   "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-document.all": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+   "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.4"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-finalizationregistry": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+   "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-generator-function": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+   "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.4",
+    "generator-function": "^2.0.0",
+    "get-proto": "^1.0.1",
+    "has-tostringtag": "^1.0.2",
+    "safe-regex-test": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-map": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+   "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-negative-zero": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+   "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-number-object": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+   "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-plain-object": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+   "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+   "license": "MIT",
+   "dependencies": {
+    "isobject": "^3.0.1"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/is-regex": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+   "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "gopd": "^1.2.0",
+    "has-tostringtag": "^1.0.2",
+    "hasown": "^2.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-set": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+   "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-shared-array-buffer": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+   "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-string": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+   "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-symbol": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+   "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "has-symbols": "^1.1.0",
+    "safe-regex-test": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-typed-array": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+   "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "which-typed-array": "^1.1.16"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-weakmap": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+   "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-weakref": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+   "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-weakset": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+   "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "get-intrinsic": "^1.2.6"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isarray": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+   "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+   "license": "MIT"
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/isobject": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+   "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/isomorphic.js": {
+   "version": "0.2.5",
+   "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+   "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+   "license": "MIT",
+   "funding": {
+    "type": "GitHub Sponsors \u2764",
+    "url": "https://github.com/sponsors/dmonad"
+   }
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/jotai": {
+   "version": "2.20.2",
+   "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.2.tgz",
+   "integrity": "sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20.0"
+   },
+   "peerDependencies": {
+    "@babel/core": ">=7.0.0",
+    "@babel/template": ">=7.0.0",
+    "@types/react": ">=17.0.0",
+    "react": ">=17.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@babel/core": {
+     "optional": true
+    },
+    "@babel/template": {
+     "optional": true
+    },
+    "@types/react": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "devOptional": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json-to-ast": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
+   "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
+   "license": "MIT",
+   "dependencies": {
+    "code-error-fragment": "0.0.230",
+    "grapheme-splitter": "^1.0.4"
+   },
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "devOptional": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/jsondiffpatch": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+   "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
+   "license": "MIT",
+   "dependencies": {
+    "@dmsnell/diff-match-patch": "^1.1.0"
+   },
+   "bin": {
+    "jsondiffpatch": "bin/jsondiffpatch.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || >=20.0.0"
+   }
+  },
+  "node_modules/just-extend": {
+   "version": "4.2.1",
+   "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+   "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+   "license": "MIT"
+  },
+  "node_modules/kind-of": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+   "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+   "license": "MIT",
+   "dependencies": {
+    "is-buffer": "^1.1.5"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lib0": {
+   "version": "0.2.117",
+   "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+   "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+   "license": "MIT",
+   "dependencies": {
+    "isomorphic.js": "^0.2.4"
+   },
+   "bin": {
+    "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+    "0gentesthtml": "bin/gentesthtml.js",
+    "0serve": "bin/0serve.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "GitHub Sponsors \u2764",
+    "url": "https://github.com/sponsors/dmonad"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/linkify-it": {
+   "version": "5.0.2",
+   "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+   "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/markdown-it"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "uc.micro": "^2.0.0"
+   }
+  },
+  "node_modules/linkifyjs": {
+   "version": "4.3.2",
+   "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+   "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+   "license": "MIT"
+  },
+  "node_modules/load-script": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/load-script/-/load-script-2.0.0.tgz",
+   "integrity": "sha512-km6cyoPW4rM22JMGb+SHUKPMZVDpUaMpMAKrv8UHWllIxc/qjgMGHD91nY+5hM+/NFs310OZ2pqQeJKs7HqWPA==",
+   "license": "MIT"
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/lodash-es": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+   "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.curry": {
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+   "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.debounce": {
+   "version": "4.0.8",
+   "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+   "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.get": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+   "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+   "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+   "license": "MIT"
+  },
+  "node_modules/lolex": {
+   "version": "2.7.5",
+   "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+   "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "devOptional": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/lz-string": {
+   "version": "1.5.0",
+   "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+   "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+   "license": "MIT",
+   "bin": {
+    "lz-string": "bin/bin.js"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/math-intrinsics": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+   "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/memoize-one": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+   "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+   "license": "MIT"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/moment": {
+   "version": "2.30.1",
+   "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+   "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+   "license": "MIT",
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/monocle-ts-esm": {
+   "version": "2.3.13",
+   "resolved": "https://registry.npmjs.org/monocle-ts-esm/-/monocle-ts-esm-2.3.13.tgz",
+   "integrity": "sha512-yvstqznK9I+xLR+u2V2VIFHv9K42gs4uEJg+wxGl7SCt8eKZlILDrUWBCQIm40DBj+aKD5QuypcTxGK3owZqhQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "fp-ts-esm": "^2.16.10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "5.1.16",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+   "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nise": {
+   "version": "1.5.3",
+   "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+   "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@sinonjs/formatio": "^3.2.1",
+    "@sinonjs/text-encoding": "^0.7.1",
+    "just-extend": "^4.0.2",
+    "lolex": "^5.0.1",
+    "path-to-regexp": "^1.7.0"
+   }
+  },
+  "node_modules/nise/node_modules/@sinonjs/formatio": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+   "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@sinonjs/commons": "^1",
+    "@sinonjs/samsam": "^3.1.0"
+   }
+  },
+  "node_modules/nise/node_modules/lolex": {
+   "version": "5.1.2",
+   "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+   "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@sinonjs/commons": "^1.7.0"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+   "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+   "license": "MIT",
+   "dependencies": {
+    "whatwg-url": "^5.0.0"
+   },
+   "engines": {
+    "node": "4.x || >=6.0.0"
+   },
+   "peerDependencies": {
+    "encoding": "^0.1.0"
+   },
+   "peerDependenciesMeta": {
+    "encoding": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/object-assign": {
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+   "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/object-inspect": {
+   "version": "1.13.4",
+   "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+   "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/object-is": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+   "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.7",
+    "define-properties": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/object-keys": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+   "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/object.assign": {
+   "version": "4.1.7",
+   "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+   "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.8",
+    "call-bound": "^1.0.3",
+    "define-properties": "^1.2.1",
+    "es-object-atoms": "^1.0.0",
+    "has-symbols": "^1.1.0",
+    "object-keys": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/omit": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/omit/-/omit-1.0.1.tgz",
+   "integrity": "sha512-WHNzQdTq2gO0iJgbPySheMN79fL3FtriIOGam8Ei4kRpdtTSdq9LX3BxSZlvKKz4vtiSUqASCFD3adel0zP/iA==",
+   "license": "MIT"
+  },
+  "node_modules/omit-deep": {
+   "version": "0.3.0",
+   "resolved": "https://registry.npmjs.org/omit-deep/-/omit-deep-0.3.0.tgz",
+   "integrity": "sha512-Lbl/Ma59sss2b15DpnWnGmECBRL8cRl/PjPbPMVW+Y8zIQzRrwMaI65Oy6HvxyhYeILVKBJb2LWeG81bj5zbMg==",
+   "license": "MIT",
+   "dependencies": {
+    "is-plain-object": "^2.0.1",
+    "unset-value": "^0.1.1"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/orderedmap": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+   "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+   "license": "MIT"
+  },
+  "node_modules/overlayscrollbars": {
+   "version": "2.6.1",
+   "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.6.1.tgz",
+   "integrity": "sha512-V+ZAqWMYMyGBJNRDEcdRC7Ch+WT9RBx9hY8bfJSMyFObQeJoecs1Vqg7ZAzBVcpN6sCUXFAZldCbeySwmmD0RA==",
+   "license": "MIT"
+  },
+  "node_modules/own-keys": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+   "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.4",
+    "get-intrinsic": "^1.3.0",
+    "object-keys": "^1.1.1",
+    "safe-push-apply": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+   "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+   "license": "MIT"
+  },
+  "node_modules/path-data-parser": {
+   "version": "0.1.0",
+   "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+   "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+   "license": "MIT"
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+   "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+   "license": "MIT",
+   "dependencies": {
+    "isarray": "0.0.1"
+   }
+  },
+  "node_modules/path-to-regexp/node_modules/isarray": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+   "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/points-on-curve": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+   "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+   "license": "MIT"
+  },
+  "node_modules/points-on-path": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+   "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+   "license": "MIT",
+   "dependencies": {
+    "path-data-parser": "0.1.0",
+    "points-on-curve": "0.2.0"
+   }
+  },
+  "node_modules/popmotion": {
+   "version": "11.0.3",
+   "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+   "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+   "license": "MIT",
+   "dependencies": {
+    "framesync": "6.0.1",
+    "hey-listen": "^1.0.8",
+    "style-value-types": "5.0.0",
+    "tslib": "^2.1.0"
+   }
+  },
+  "node_modules/popper.js": {
+   "version": "1.16.1",
+   "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+   "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+   "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/popperjs"
+   }
+  },
+  "node_modules/possible-typed-array-names": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+   "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/postcss/node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/pretty-format": {
+   "version": "27.5.1",
+   "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+   "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1",
+    "ansi-styles": "^5.0.0",
+    "react-is": "^17.0.1"
+   },
+   "engines": {
+    "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+   }
+  },
+  "node_modules/pretty-format/node_modules/react-is": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+   "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+   "license": "MIT"
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/process-nextick-args": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+   "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+   "license": "MIT"
+  },
+  "node_modules/promise": {
+   "version": "7.3.1",
+   "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+   "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+   "license": "MIT",
+   "dependencies": {
+    "asap": "~2.0.3"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/prop-types": {
+   "version": "15.8.1",
+   "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+   "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.4.0",
+    "object-assign": "^4.1.1",
+    "react-is": "^16.13.1"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/prosemirror-commands": {
+   "version": "1.7.2",
+   "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+   "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-model": "^1.0.0",
+    "prosemirror-state": "^1.0.0",
+    "prosemirror-transform": "^1.10.2"
+   }
+  },
+  "node_modules/prosemirror-dev-tools": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/prosemirror-dev-tools/-/prosemirror-dev-tools-4.3.0.tgz",
+   "integrity": "sha512-u3jlguWG+voAlTWoUCw/D2l2FImKoNNZUrkCcPvWkRZBpMVxH+sMtZTXH+em520HDD7z2JNVzOIHl/0ZXh3j7w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.6",
+    "@compiled/react": "^0.19.0",
+    "html": "^1.0.0",
+    "jotai": "^2.17.1",
+    "jsondiffpatch": "^0.7.3",
+    "nanoid": "^5.1.6",
+    "prosemirror-model": ">=1.0.0",
+    "prosemirror-state": ">=1.0.0",
+    "react-dock": "^0.8.0",
+    "react-json-tree": "^0.20.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/prosemirror-dev-tools/node_modules/color": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+   "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+   "license": "MIT",
+   "dependencies": {
+    "color-convert": "^2.0.1",
+    "color-string": "^1.9.0"
+   },
+   "engines": {
+    "node": ">=12.5.0"
+   }
+  },
+  "node_modules/prosemirror-dev-tools/node_modules/color-convert": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+   "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+   "license": "MIT",
+   "dependencies": {
+    "color-name": "~1.1.4"
+   },
+   "engines": {
+    "node": ">=7.0.0"
+   }
+  },
+  "node_modules/prosemirror-dev-tools/node_modules/react-base16-styling": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.10.0.tgz",
+   "integrity": "sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/lodash": "^4.17.0",
+    "color": "^4.2.3",
+    "csstype": "^3.1.3",
+    "lodash-es": "^4.17.21"
+   }
+  },
+  "node_modules/prosemirror-dev-tools/node_modules/react-dock": {
+   "version": "0.8.0",
+   "resolved": "https://registry.npmjs.org/react-dock/-/react-dock-0.8.0.tgz",
+   "integrity": "sha512-/sUBWnsNlHIxmxoUHFPq8gcaH5k7MWGuHHeG3UjnXH3UblByxnARlUYewlMBtCUqcmbpPquYE5+GGvaG/hRkkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/lodash-es": "^4.17.12",
+    "lodash-es": "^4.17.21"
+   },
+   "peerDependencies": {
+    "@types/react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/prosemirror-dev-tools/node_modules/react-json-tree": {
+   "version": "0.20.0",
+   "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.20.0.tgz",
+   "integrity": "sha512-h+f9fUNAxzBx1rbrgUF7+zSWKGHDtt2VPYLErIuB0JyKGnWgFMM21ksqQyb3EXwXNnoMW2rdE5kuAaubgGOx2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/lodash": "^4.17.15",
+    "react-base16-styling": "^0.10.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/prosemirror-keymap": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+   "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-state": "^1.0.0",
+    "w3c-keyname": "^2.2.0"
+   }
+  },
+  "node_modules/prosemirror-model": {
+   "version": "1.25.11",
+   "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+   "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+   "license": "MIT",
+   "dependencies": {
+    "orderedmap": "^2.0.0"
+   }
+  },
+  "node_modules/prosemirror-schema-list": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+   "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-model": "^1.0.0",
+    "prosemirror-state": "^1.0.0",
+    "prosemirror-transform": "^1.7.3"
+   }
+  },
+  "node_modules/prosemirror-state": {
+   "version": "1.4.4",
+   "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+   "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-model": "^1.0.0",
+    "prosemirror-transform": "^1.0.0",
+    "prosemirror-view": "^1.27.0"
+   }
+  },
+  "node_modules/prosemirror-transform": {
+   "version": "1.12.0",
+   "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+   "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-model": "^1.21.0"
+   }
+  },
+  "node_modules/prosemirror-view": {
+   "version": "1.42.2",
+   "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+   "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prosemirror-model": "^1.25.8",
+    "prosemirror-state": "^1.0.0",
+    "prosemirror-transform": "^1.1.0"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/rc-align": {
+   "version": "4.0.15",
+   "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
+   "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.10.1",
+    "classnames": "2.x",
+    "dom-align": "^1.7.0",
+    "rc-util": "^5.26.0",
+    "resize-observer-polyfill": "^1.5.1"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-motion": {
+   "version": "2.9.5",
+   "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+   "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.11.1",
+    "classnames": "^2.2.1",
+    "rc-util": "^5.44.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-slider": {
+   "version": "9.7.2",
+   "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.7.2.tgz",
+   "integrity": "sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.10.1",
+    "classnames": "^2.2.5",
+    "rc-tooltip": "^5.0.1",
+    "rc-util": "^5.0.0",
+    "shallowequal": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=8.x"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-tooltip": {
+   "version": "5.3.1",
+   "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.3.1.tgz",
+   "integrity": "sha512-e6H0dMD38EPaSPD2XC8dRfct27VvT2TkPdoBSuNl3RRZ5tspiY/c5xYEmGC0IrABvMBgque4Mr2SMZuliCvoiQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.11.2",
+    "classnames": "^2.3.1",
+    "rc-trigger": "^5.3.1"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-trigger": {
+   "version": "5.3.4",
+   "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
+   "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.18.3",
+    "classnames": "^2.2.6",
+    "rc-align": "^4.0.0",
+    "rc-motion": "^2.0.0",
+    "rc-util": "^5.19.2"
+   },
+   "engines": {
+    "node": ">=8.x"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-util": {
+   "version": "5.44.4",
+   "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+   "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.18.3",
+    "react-is": "^18.2.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
+   }
+  },
+  "node_modules/rc-util/node_modules/react-is": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+   "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-aria": {
+   "version": "3.51.0",
+   "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+   "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "aria-hidden": "^1.2.3",
+    "clsx": "^2.0.0",
+    "react-stately": "3.49.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-base16-styling": {
+   "version": "0.9.1",
+   "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.9.1.tgz",
+   "integrity": "sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.16.7",
+    "@types/base16": "^1.0.2",
+    "@types/lodash": "^4.14.178",
+    "base16": "^1.0.0",
+    "color": "^3.2.1",
+    "csstype": "^3.0.10",
+    "lodash.curry": "^4.1.1"
+   }
+  },
+  "node_modules/react-base16-styling/node_modules/color": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+   "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+   "license": "MIT",
+   "dependencies": {
+    "color-convert": "^1.9.3",
+    "color-string": "^1.6.0"
+   }
+  },
+  "node_modules/react-dnd": {
+   "version": "11.1.3",
+   "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-11.1.3.tgz",
+   "integrity": "sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@react-dnd/shallowequal": "^2.0.0",
+    "@types/hoist-non-react-statics": "^3.3.1",
+    "dnd-core": "^11.1.3",
+    "hoist-non-react-statics": "^3.3.0"
+   },
+   "peerDependencies": {
+    "react": ">= 16.9.0",
+    "react-dom": ">= 16.9.0"
+   }
+  },
+  "node_modules/react-dnd-test-backend": {
+   "version": "11.1.3",
+   "resolved": "https://registry.npmjs.org/react-dnd-test-backend/-/react-dnd-test-backend-11.1.3.tgz",
+   "integrity": "sha512-5qFm+NI2GdWIUfiYun0A8Gv0xjbq0NGOPS+f6z3x/3nTuliApjmqcM1lfTgePoz1FDG47ZofF58N8y96If62+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "dnd-core": "^11.1.3"
+   }
+  },
+  "node_modules/react-dnd-touch-backend": {
+   "version": "11.1.3",
+   "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-11.1.3.tgz",
+   "integrity": "sha512-8lz4fxfYwUuJ6Y2seQYwh8+OfwKcbBX0CIbz7AwXfBYz54Wg2nIDU6CP8Dyybt/Wyx4D3oXmTPEaOMB62uqJvQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@react-dnd/invariant": "^2.0.0",
+    "dnd-core": "^11.1.3"
+   }
+  },
+  "node_modules/react-dock": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/react-dock/-/react-dock-0.6.0.tgz",
+   "integrity": "sha512-jEOhv1s+pqRQ4JxgUw4XUotnprOehZ23mqchf3whxYXnvNgTQOXCxh6bpcqW8P6OybIk2bYO18r3qimZ3ypCbg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.18.3",
+    "@types/lodash": "^4.14.182",
+    "@types/prop-types": "^15.7.5",
+    "lodash.debounce": "^4.0.8",
+    "prop-types": "^15.8.1"
+   },
+   "peerDependencies": {
+    "@types/react": "^16.3.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-error-boundary": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+   "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.5"
+   },
+   "peerDependencies": {
+    "react": ">=16.13.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-infinite-scroller": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
+   "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prop-types": "^15.5.8"
+   },
+   "peerDependencies": {
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+   }
+  },
+  "node_modules/react-is": {
+   "version": "16.13.1",
+   "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+   "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+   "license": "MIT"
+  },
+  "node_modules/react-json-tree": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.17.0.tgz",
+   "integrity": "sha512-hcWjibI/fAvsKnfYk+lka5OrE1Lvb1jH5pSnFhIU5T8cCCxB85r6h/NOzDPggSSgErjmx4rl3+2EkeclIKBOhg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.18.3",
+    "@types/lodash": "^4.14.182",
+    "@types/prop-types": "^15.7.5",
+    "prop-types": "^15.8.1",
+    "react-base16-styling": "^0.9.1"
+   },
+   "peerDependencies": {
+    "@types/react": "^16.3.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+   }
+  },
+  "node_modules/react-lifecycles-compat": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+   "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+   "license": "MIT"
+  },
+  "node_modules/react-modal": {
+   "version": "3.16.3",
+   "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+   "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+   "license": "MIT",
+   "dependencies": {
+    "exenv": "^1.2.0",
+    "prop-types": "^15.7.2",
+    "react-lifecycles-compat": "^3.0.0",
+    "warning": "^4.0.3"
+   },
+   "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-scroll-sync": {
+   "version": "0.11.0",
+   "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.11.0.tgz",
+   "integrity": "sha512-COfA885/2NAQPxusIU6sukKiSFXgAd9+OWD7iBWA4NF5Y1Np8poBKLwgZ3y4iywo5/+ch0PLGz887myIbm+fPw==",
+   "license": "MIT",
+   "dependencies": {
+    "prop-types": "^15.5.7"
+   },
+   "peerDependencies": {
+    "react": "16.x || 17.x || 18.x",
+    "react-dom": "16.x || 17.x || 18.x"
+   }
+  },
+  "node_modules/react-stately": {
+   "version": "3.49.0",
+   "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+   "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-transition-group": {
+   "version": "4.4.5",
+   "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+   "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@babel/runtime": "^7.5.5",
+    "dom-helpers": "^5.0.1",
+    "loose-envify": "^1.4.0",
+    "prop-types": "^15.6.2"
+   },
+   "peerDependencies": {
+    "react": ">=16.6.0",
+    "react-dom": ">=16.6.0"
+   }
+  },
+  "node_modules/react-window": {
+   "version": "1.8.11",
+   "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+   "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "memoize-one": ">=3.1.1 <6"
+   },
+   "engines": {
+    "node": ">8.0.0"
+   },
+   "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/redux": {
+   "version": "4.2.1",
+   "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+   "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.9.2"
+   }
+  },
+  "node_modules/reflect.getprototypeof": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+   "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.8",
+    "define-properties": "^1.2.1",
+    "es-abstract": "^1.23.9",
+    "es-errors": "^1.3.0",
+    "es-object-atoms": "^1.0.0",
+    "get-intrinsic": "^1.2.7",
+    "get-proto": "^1.0.1",
+    "which-builtin-type": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/regexp.prototype.flags": {
+   "version": "1.5.4",
+   "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+   "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.8",
+    "define-properties": "^1.2.1",
+    "es-errors": "^1.3.0",
+    "get-proto": "^1.0.1",
+    "gopd": "^1.2.0",
+    "set-function-name": "^2.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rename-keys": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/rename-keys/-/rename-keys-1.2.0.tgz",
+   "integrity": "sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.8.0"
+   }
+  },
+  "node_modules/resize-observer-polyfill": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+   "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+   "license": "MIT"
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/rope-sequence": {
+   "version": "1.3.4",
+   "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+   "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+   "license": "MIT"
+  },
+  "node_modules/roughjs": {
+   "version": "4.6.6",
+   "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+   "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+   "license": "MIT",
+   "dependencies": {
+    "hachure-fill": "^0.5.2",
+    "path-data-parser": "^0.1.0",
+    "points-on-curve": "^0.2.0",
+    "points-on-path": "^0.2.1"
+   }
+  },
+  "node_modules/safe-array-concat": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+   "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.9",
+    "call-bound": "^1.0.4",
+    "get-intrinsic": "^1.3.0",
+    "has-symbols": "^1.1.0",
+    "isarray": "^2.0.5"
+   },
+   "engines": {
+    "node": ">=0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safe-push-apply": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+   "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "isarray": "^2.0.5"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/safe-regex-test": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+   "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "es-errors": "^1.3.0",
+    "is-regex": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/samsam": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+   "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+   "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
+   "license": "BSD-3-Clause"
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/set-function-length": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+   "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+   "license": "MIT",
+   "dependencies": {
+    "define-data-property": "^1.1.4",
+    "es-errors": "^1.3.0",
+    "function-bind": "^1.1.2",
+    "get-intrinsic": "^1.2.4",
+    "gopd": "^1.0.1",
+    "has-property-descriptors": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/set-function-name": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+   "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+   "license": "MIT",
+   "dependencies": {
+    "define-data-property": "^1.1.4",
+    "es-errors": "^1.3.0",
+    "functions-have-names": "^1.2.3",
+    "has-property-descriptors": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/set-proto": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+   "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+   "license": "MIT",
+   "dependencies": {
+    "dunder-proto": "^1.0.1",
+    "es-errors": "^1.3.0",
+    "es-object-atoms": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/setimmediate": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+   "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+   "license": "MIT"
+  },
+  "node_modules/shallowequal": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+   "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+   "license": "MIT"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/side-channel": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+   "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "object-inspect": "^1.13.4",
+    "side-channel-list": "^1.0.1",
+    "side-channel-map": "^1.0.1",
+    "side-channel-weakmap": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/side-channel-list": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+   "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "object-inspect": "^1.13.4"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/side-channel-map": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+   "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "es-errors": "^1.3.0",
+    "get-intrinsic": "^1.2.5",
+    "object-inspect": "^1.13.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/side-channel-weakmap": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+   "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "es-errors": "^1.3.0",
+    "get-intrinsic": "^1.2.5",
+    "object-inspect": "^1.13.3",
+    "side-channel-map": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/simple-swizzle": {
+   "version": "0.2.4",
+   "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+   "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-arrayish": "^0.3.1"
+   }
+  },
+  "node_modules/sinon": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+   "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+   "deprecated": "16.1.1",
+   "hasInstallScript": true,
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@sinonjs/formatio": "^2.0.0",
+    "diff": "^3.1.0",
+    "lodash.get": "^4.4.2",
+    "lolex": "^2.2.0",
+    "nise": "^1.2.0",
+    "supports-color": "^5.1.0",
+    "type-detect": "^4.0.5"
+   }
+  },
+  "node_modules/sinon/node_modules/diff": {
+   "version": "3.5.1",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.1.tgz",
+   "integrity": "sha512-Z3u54A8qGyqFOSr2pk0ijYs8mOE9Qz8kTvtKeBI+upoG9j04Sq+oI7W8zAJiQybDcESET8/uIdHzs0p3k4fZlw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/stop-iteration-iterator": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+   "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+   "license": "MIT",
+   "dependencies": {
+    "es-errors": "^1.3.0",
+    "internal-slot": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/strictdom": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+   "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+   "license": "MIT"
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/string.prototype.trim": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+   "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.9",
+    "call-bound": "^1.0.4",
+    "define-data-property": "^1.1.4",
+    "define-properties": "^1.2.1",
+    "es-abstract": "^1.24.2",
+    "es-object-atoms": "^1.1.2",
+    "has-property-descriptors": "^1.0.2",
+    "safe-regex-test": "^1.1.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/string.prototype.trimend": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+   "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.9",
+    "call-bound": "^1.0.4",
+    "define-properties": "^1.2.1",
+    "es-object-atoms": "^1.1.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/string.prototype.trimstart": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+   "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.7",
+    "define-properties": "^1.2.1",
+    "es-object-atoms": "^1.0.0"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/style-mod": {
+   "version": "4.1.3",
+   "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+   "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+   "license": "MIT"
+  },
+  "node_modules/style-value-types": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+   "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+   "license": "MIT",
+   "dependencies": {
+    "hey-listen": "^1.0.8",
+    "tslib": "^2.1.0"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "5.5.0",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+   "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+   "license": "MIT",
+   "dependencies": {
+    "has-flag": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/svgson": {
+   "version": "5.3.1",
+   "resolved": "https://registry.npmjs.org/svgson/-/svgson-5.3.1.tgz",
+   "integrity": "sha512-qdPgvUNWb40gWktBJnbJRelWcPzkLed/ShhnRsjbayXz8OtdPOzbil9jtiZdrYvSDumAz/VNQr6JaNfPx/gvPA==",
+   "license": "MIT",
+   "dependencies": {
+    "deep-rename-keys": "^0.2.1",
+    "xml-reader": "2.4.3"
+   }
+  },
+  "node_modules/tabbable": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+   "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+   "license": "MIT"
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/tr46": {
+   "version": "0.0.3",
+   "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+   "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+   "license": "MIT"
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ts-is-present": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/ts-is-present/-/ts-is-present-1.2.2.tgz",
+   "integrity": "sha512-cA5MPLWGWYXvnlJb4TamUUx858HVHBsxxdy8l7jxODOLDyGYnQOllob2A2jyDghGa5iJHs2gzFNHvwGJ0ZfR8g==",
+   "license": "MIT"
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-detect": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+   "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typed-array-buffer": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+   "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "es-errors": "^1.3.0",
+    "is-typed-array": "^1.1.14"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/typed-array-byte-length": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+   "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.8",
+    "for-each": "^0.3.3",
+    "gopd": "^1.2.0",
+    "has-proto": "^1.2.0",
+    "is-typed-array": "^1.1.14"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/typed-array-byte-offset": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+   "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "available-typed-arrays": "^1.0.7",
+    "call-bind": "^1.0.8",
+    "for-each": "^0.3.3",
+    "gopd": "^1.2.0",
+    "has-proto": "^1.2.0",
+    "is-typed-array": "^1.1.15",
+    "reflect.getprototypeof": "^1.0.9"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/typed-array-length": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+   "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bind": "^1.0.9",
+    "for-each": "^0.3.5",
+    "gopd": "^1.2.0",
+    "is-typed-array": "^1.1.15",
+    "possible-typed-array-names": "^1.1.0",
+    "reflect.getprototypeof": "^1.0.10"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/typed-styles": {
+   "version": "0.0.7",
+   "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+   "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
+   "license": "MIT"
+  },
+  "node_modules/typedarray": {
+   "version": "0.0.6",
+   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+   "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+   "license": "MIT"
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ua-parser-js": {
+   "version": "0.7.41",
+   "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+   "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/ua-parser-js"
+    },
+    {
+     "type": "paypal",
+     "url": "https://paypal.me/faisalman"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/faisalman"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "ua-parser-js": "script/cli.js"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/uc.micro": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+   "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+   "license": "MIT"
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/unbox-primitive": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+   "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.3",
+    "has-bigints": "^1.0.2",
+    "has-symbols": "^1.1.0",
+    "which-boxed-primitive": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unset-value": {
+   "version": "0.1.2",
+   "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
+   "integrity": "sha512-yhv5I4TsldLdE3UcVQn0hD2T5sNCPv4+qm/CTUpRKIpwthYRIipsAPdsrNpOI79hPQa0rTTeW22Fq6JWRcTgNg==",
+   "license": "MIT",
+   "dependencies": {
+    "has-value": "^0.3.1",
+    "isobject": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "devOptional": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/w3c-keyname": {
+   "version": "2.2.8",
+   "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+   "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+   "license": "MIT"
+  },
+  "node_modules/warning": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+   "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.0.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/webidl-conversions": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+   "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/whatwg-url": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+   "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+   "license": "MIT",
+   "dependencies": {
+    "tr46": "~0.0.3",
+    "webidl-conversions": "^3.0.0"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-boxed-primitive": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+   "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-bigint": "^1.1.0",
+    "is-boolean-object": "^1.2.1",
+    "is-number-object": "^1.1.1",
+    "is-string": "^1.1.1",
+    "is-symbol": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/which-builtin-type": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+   "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "call-bound": "^1.0.2",
+    "function.prototype.name": "^1.1.6",
+    "has-tostringtag": "^1.0.2",
+    "is-async-function": "^2.0.0",
+    "is-date-object": "^1.1.0",
+    "is-finalizationregistry": "^1.1.0",
+    "is-generator-function": "^1.0.10",
+    "is-regex": "^1.2.1",
+    "is-weakref": "^1.0.2",
+    "isarray": "^2.0.5",
+    "which-boxed-primitive": "^1.1.0",
+    "which-collection": "^1.0.2",
+    "which-typed-array": "^1.1.16"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/which-collection": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+   "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-map": "^2.0.3",
+    "is-set": "^2.0.3",
+    "is-weakmap": "^2.0.2",
+    "is-weakset": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/which-typed-array": {
+   "version": "1.1.22",
+   "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+   "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+   "license": "MIT",
+   "dependencies": {
+    "available-typed-arrays": "^1.0.7",
+    "call-bind": "^1.0.9",
+    "call-bound": "^1.0.4",
+    "for-each": "^0.3.5",
+    "get-proto": "^1.0.1",
+    "gopd": "^1.2.0",
+    "has-tostringtag": "^1.0.2"
+   },
+   "engines": {
+    "node": ">= 0.4"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrangler/node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xml-lexer": {
+   "version": "0.2.2",
+   "resolved": "https://registry.npmjs.org/xml-lexer/-/xml-lexer-0.2.2.tgz",
+   "integrity": "sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^2.0.0"
+   }
+  },
+  "node_modules/xml-lexer/node_modules/eventemitter3": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+   "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+   "license": "MIT"
+  },
+  "node_modules/xml-reader": {
+   "version": "2.4.3",
+   "resolved": "https://registry.npmjs.org/xml-reader/-/xml-reader-2.4.3.tgz",
+   "integrity": "sha512-xWldrIxjeAMAu6+HSf9t50ot1uL5M+BtOidRCWHXIeewvSeIpscWCsp4Zxjk8kHHhdqFBrfK8U0EJeCcnyQ/gA==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^2.0.0",
+    "xml-lexer": "^0.2.2"
+   }
+  },
+  "node_modules/xml-reader/node_modules/eventemitter3": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+   "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+   "license": "MIT"
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/y-prosemirror": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+   "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+   "license": "MIT",
+   "dependencies": {
+    "lib0": "^0.2.109"
+   },
+   "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+   },
+   "funding": {
+    "type": "GitHub Sponsors \u2764",
+    "url": "https://github.com/sponsors/dmonad"
+   },
+   "peerDependencies": {
+    "prosemirror-model": "^1.7.1",
+    "prosemirror-state": "^1.2.3",
+    "prosemirror-view": "^1.9.10",
+    "y-protocols": "^1.0.1",
+    "yjs": "^13.5.38"
+   }
+  },
+  "node_modules/y-protocols": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+   "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+   "license": "MIT",
+   "dependencies": {
+    "lib0": "^0.2.85"
+   },
+   "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+   },
+   "funding": {
+    "type": "GitHub Sponsors \u2764",
+    "url": "https://github.com/sponsors/dmonad"
+   },
+   "peerDependencies": {
+    "yjs": "^13.0.0"
+   }
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "devOptional": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yjs": {
+   "version": "13.6.32",
+   "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
+   "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
+   "license": "MIT",
+   "dependencies": {
+    "lib0": "^0.2.99"
+   },
+   "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+   },
+   "funding": {
+    "type": "GitHub Sponsors \u2764",
+    "url": "https://github.com/sponsors/dmonad"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/blog/seed/SEED.md
+++ b/skills/wix-headless-fast/references/blog/seed/SEED.md
@@ -1,0 +1,67 @@
+# Blog — seeding
+
+Seed by **running `seed-blog.mjs` with a plan file** — don't hand-write the REST calls.
+The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
+required), installs the Blog app if needed, resolves a real author memberId (every post
+create requires one), and creates everything in the right order — categories/tags first,
+then **published** posts, then imported cover images (PATCH + re-publish).
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/blog/seed/seed-blog.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief. **Default to 3 posts** (the seed shows
+the shape; the owner writes the rest in the dashboard) and make them exercise the UI: group
+them into 2 categories when the brief has natural sections, tag a couple, vary the content
+blocks (heading + paragraphs + a quote or list per post), and give every post a
+`coverImageUrl` (verified — a feed without covers looks broken).
+
+```json
+{
+  "categories": ["Brewing", "Stories"],
+  "posts": [
+    { "title": "How We Roast Our Single-Origin Beans", "category": "Stories", "tags": ["coffee"],
+      "coverImageUrl": "https://…",
+      "content": [
+        { "type": "heading", "text": "From farm to cup", "level": 2 },
+        { "type": "paragraph", "text": "Every batch starts with beans sourced from a single estate." },
+        { "type": "quote", "text": "Great coffee is grown, not made." }
+      ] },
+    { "title": "The Pour-Over, Step by Step", "category": "Brewing", "tags": ["guides"],
+      "coverImageUrl": "https://…",
+      "content": [
+        { "type": "paragraph", "text": "A repeatable ritual in five minutes." },
+        { "type": "ordered", "items": ["Rinse the filter", "Bloom 30 seconds", "Pour in circles"] }
+      ] },
+    { "title": "Why Water Matters More Than You Think", "category": "Brewing",
+      "coverImageUrl": "https://…",
+      "content": [
+        { "type": "paragraph", "text": "Coffee is 98% water — its minerals decide the cup." },
+        { "type": "bulleted", "items": ["Filtered, not distilled", "Aim for ~150 ppm hardness"] }
+      ] }
+  ]
+}
+```
+
+- `content` blocks: `{type:"heading",text,level?}` · `{type:"paragraph",text}` ·
+  `{type:"quote",text}` · `{type:"bulleted"|"ordered",items:[…]}`. For node types these don't
+  cover (code, inline images), pass a pre-built Ricos `richContent` on the post instead.
+- `category`/`categories`/`tags` are display **names** — created idempotently and resolved to
+  ids internally. Optional: skip them entirely when the brief doesn't group posts.
+- `coverImageUrl` — a plain https image URL; the script imports it into Wix Media (Blog binds
+  covers by file id, not URL) and re-publishes the post. A failed cover never blocks the run.
+- Posts are created **published** — an unpublished post never reaches visitors. The bulk
+  create returns 200 even on partial failure: check each `posts[].success` in the result.
+
+**Seeding is additive — never delete or overwrite existing content**; ask first if a cleanup
+seems needed.
+
+## Escape hatch — individual functions
+`setupBlog` composes exported steps — `installBlogApp`, `getAuthorMemberId`, `createPosts`,
+`createCategories`, `createTags`, `importImage`, `attachPostCovers`, plus `makeCtx()` —
+import them only for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.

--- a/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
+++ b/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
@@ -1,0 +1,279 @@
+// Blog seed — a BUILD-TIME script, never shipped in the app. Run from the project root
+// (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/blog/seed/seed-blog.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Blog app if needed, resolves
+// a real author memberId (every post create requires one), creates categories/tags (idempotent
+// by label, with a fresh-install verify-retry), bulk-creates PUBLISHED posts with Ricos
+// richContent, and imports+attaches cover images (PATCH + re-publish). Prints a JSON result
+// to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "categories"?: [name], "tags"?: [name],
+//     "posts": [{ "title", "content": [blocks] | "richContent"?, "category"?|"categories"?,
+//                 "tags"?, "coverImageUrl"? }] }
+//   content blocks: { type:"heading", text, level? } | { type:"paragraph", text }
+//     | { type:"quote", text } | { type:"bulleted"|"ordered", items:[text,…] }
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
+// read the live API reference; authoritative source recipe:
+// wix-headless/references/inline-recipes/setup-blog.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const BLOG_APP_ID = "14bcded7-0066-7c35-14d7-466cb3f09103";
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- Ricos richContent builder (setup-blog.md § "CRITICAL RICOS NESTING") --------------------
+// Rules baked in: TEXT is always a leaf inside a container; BLOCKQUOTE / LIST_ITEM wrap a
+// PARAGRAPH; BULLETED_LIST / ORDERED_LIST wrap LIST_ITEM -> PARAGRAPH -> TEXT; every container
+// node gets a unique id, TEXT leaves use id "". For node types not covered here (code, images)
+// pass a pre-built `richContent` on the post instead — it's used verbatim.
+const mkText = (text) => ({ type: "TEXT", id: "", nodes: [], textData: { text: text || "", decorations: [] } });
+const mkParagraph = (id, text) => ({ type: "PARAGRAPH", id, nodes: [mkText(text)], paragraphData: {} });
+
+function mkRichContent(blocks = [], postIdx = 0) {
+  let n = 0;
+  const id = () => `p${postIdx}-n${n++}`;
+  const nodes = [];
+  for (const b of blocks) {
+    switch (b.type) {
+      case "heading":
+        nodes.push({ type: "HEADING", id: id(), nodes: [mkText(b.text)], headingData: { level: b.level ?? 2 } });
+        break;
+      case "quote":
+        nodes.push({ type: "BLOCKQUOTE", id: id(), nodes: [mkParagraph(id(), b.text)], blockquoteData: { indentation: 1 } });
+        break;
+      case "bulleted":
+      case "ordered": {
+        const listType = b.type === "bulleted" ? "BULLETED_LIST" : "ORDERED_LIST";
+        nodes.push({
+          type: listType, id: id(),
+          nodes: (b.items ?? []).map((item) => ({ type: "LIST_ITEM", id: id(), nodes: [mkParagraph(id(), item)] })),
+        });
+        break;
+      }
+      case "paragraph":
+      default:
+        nodes.push(mkParagraph(id(), b.text));
+    }
+  }
+  return { nodes };
+}
+
+// One post's plain data -> a flat Blog V3 draft-post object. media is omitted — covers are a
+// separate pass (attachPostCovers), per the recipe.
+function buildPost(p, i, memberId) {
+  return {
+    title: p.title,
+    memberId,
+    richContent: p.richContent ?? mkRichContent(p.content, i),
+    ...(p.categoryIds ? { categoryIds: p.categoryIds } : {}),
+    ...(p.tagIds ? { tagIds: p.tagIds } : {}),
+  };
+}
+
+// ---- operations ----------------------------------------------------------------------------
+
+export async function installBlogApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: BLOG_APP_ID, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+// Every post create needs a REAL author memberId — a fabricated id fails with
+// "memberIds ... do not exist". A provisioned site has the owner as members[0].
+export async function getAuthorMemberId(ctx) {
+  const r = await req(ctx, "/members/v1/members?fieldsets=PUBLIC&paging.limit=1", { method: "GET" });
+  const id = r.members?.[0]?.id;
+  if (!id) throw new Error(`No site member found for author attribution: ${JSON.stringify(r).slice(0, 400)}`);
+  return id;
+}
+
+/**
+ * Create posts, PUBLISHED (publish:true — unpublished posts never reach visitors).
+ * Endpoint auto-selected per the recipe: single-post endpoint for exactly one (nested
+ * `{ draftPost }` envelope), bulk for >= 2 — `bulk` sits BETWEEN v3 and draft-posts, and each
+ * bulk item is FLAT (wrapping it in `draftPost` 400s). Returns [{ id, index, success }].
+ */
+export async function createPosts(ctx, posts, { memberId, publish = true } = {}) {
+  if (!memberId) throw new Error("createPosts requires opts.memberId (see getAuthorMemberId)");
+  if (posts.length === 1) {
+    const r = await req(ctx, "/blog/v3/draft-posts", { body: { draftPost: buildPost(posts[0], 0, memberId), publish } });
+    return [{ id: r.draftPost?.id, index: 0, success: !!r.draftPost?.id }];
+  }
+  const r = await req(ctx, "/blog/v3/bulk/draft-posts/create", {
+    body: { draftPosts: posts.map((p, i) => buildPost(p, i, memberId)), publish },
+  });
+  // Bulk returns 200 even on partial failure — read per-item results[].itemMetadata.success.
+  return (r.results ?? []).map((x) => ({
+    id: x.itemMetadata?.id, index: x.itemMetadata?.originalIndex, success: !!x.itemMetadata?.success,
+  }));
+}
+
+// Existing label -> id, straight from the query (the source of truth for what persisted).
+async function labelIdMap(ctx, kind) {
+  const path = kind === "categories" ? "/blog/v3/categories/query" : "/v3/tags/query";
+  const r = await req(ctx, path, { body: { query: { paging: { limit: 100 } } } });
+  return new Map((r[kind] ?? []).map((x) => [x.label, x.id]));
+}
+
+// Create category/tag labels resiliently. TWO hazards this absorbs:
+//  1. Fresh-install provisioning window — for a few seconds after the Blog app installs,
+//     per-item category/tag creates return 200 with an id but DON'T persist (the id is a lie).
+//     So the create response is never trusted — re-query, treat the query as truth, re-create
+//     what's still missing until it sticks.
+//  2. Idempotency — an already-present label (a partial-failure re-run) is skipped.
+// Category bodies are NESTED (`{ category: { label } }`); tag bodies are FLAT (`{ label }`) —
+// a `{ tag: { label } }` body sends an empty top-level label and 400s. Returns [{ id, name }].
+async function ensureLabels(ctx, kind, createPath, mkBody, names) {
+  let map = await labelIdMap(ctx, kind);
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const missing = names.filter((n) => !map.has(n));
+    if (!missing.length) break;
+    if (attempt) await sleep(1500); // backoff only between retries — happy path pays nothing
+    for (const name of missing) {
+      try { await req(ctx, createPath, { body: mkBody(name) }); }
+      catch (e) { if (!String(e.message).includes("-> 409")) throw e; } // 409 = raced, already there
+    }
+    map = await labelIdMap(ctx, kind);
+  }
+  return names.map((name) => ({ id: map.get(name), name }));
+}
+
+/** Create categories idempotently by label (no bulk endpoint). Feed ids into post.categoryIds. */
+export async function createCategories(ctx, names) {
+  return ensureLabels(ctx, "categories", "/blog/v3/categories", (name) => ({ category: { label: name } }), names);
+}
+
+/** Create tags idempotently by label. Feed ids into post.tagIds. */
+export async function createTags(ctx, names) {
+  return ensureLabels(ctx, "tags", "/blog/v3/tags", (name) => ({ label: name }), names);
+}
+
+// Blog binds a post cover by Wix Media file ID — an external url must be imported first.
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+// covers: [{ postId, fileId }] where fileId is the Wix Media file.id from importImage. Per
+// post: PATCH /blog/v3/draft-posts/{id} (NOT POST …/{id}/update — that 404s), setting
+// media.displayed:true + media.custom:true + wixMedia.image.id (the id ALONE is a silent
+// no-op), then RE-PUBLISH — the PATCH sets hasUnpublishedChanges, so the live post stays
+// cover-less until republished. Image failures never block the run.
+export async function attachPostCovers(ctx, covers) {
+  let attached = 0;
+  for (const { postId, fileId } of covers) {
+    try {
+      await req(ctx, `/blog/v3/draft-posts/${postId}`, {
+        method: "PATCH",
+        body: { draftPost: { media: { displayed: true, custom: true, wixMedia: { image: { id: fileId } } } } },
+      });
+      await req(ctx, `/blog/v3/draft-posts/${postId}/publish`, { method: "POST" });
+      attached++;
+    } catch (e) {
+      console.error(`cover attach skipped for post ${postId}: ${e.message}`);
+    }
+  }
+  return attached;
+}
+
+/**
+ * ONE-CALL seed: install → author memberId → categories/tags (names resolved to ids) →
+ * published posts → covers, ids threaded in memory. The default path.
+ */
+export async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
+  await installBlogApp(ctx);
+  await sleep(3000); // let a fresh Blog install settle so the first category/tag writes stick
+                     // (correctness is still guaranteed by ensureLabels' verify-retry).
+  const memberId = await getAuthorMemberId(ctx);
+
+  const catNames = [...new Set([...categories, ...posts.flatMap((p) => [].concat(p.category ?? [], p.categories ?? []))])];
+  const tagNames = [...new Set([...tags, ...posts.flatMap((p) => [].concat(p.tags ?? []))])];
+  const cats = catNames.length ? await createCategories(ctx, catNames) : [];
+  const tgs = tagNames.length ? await createTags(ctx, tagNames) : [];
+  const catId = new Map(cats.map((c) => [c.name, c.id]));
+  const tagId = new Map(tgs.map((t) => [t.name, t.id]));
+
+  const created = await createPosts(ctx, posts.map((p) => {
+    const cn = [].concat(p.category ?? [], p.categories ?? []);
+    const tn = [].concat(p.tags ?? []);
+    return {
+      ...p,
+      ...(cn.length ? { categoryIds: cn.map((n) => catId.get(n)).filter(Boolean) } : {}),
+      ...(tn.length ? { tagIds: tn.map((n) => tagId.get(n)).filter(Boolean) } : {}),
+    };
+  }), { memberId });
+
+  const covers = [];
+  for (let i = 0; i < created.length; i++) {
+    const url = posts[i]?.coverImageUrl;
+    if (!created[i]?.id || !created[i]?.success || !url) continue;
+    try {
+      const file = await importImage(ctx, url, `post-${i}.png`);
+      covers.push({ postId: created[i].id, fileId: file.id });
+    } catch {
+      /* never block on image failure — the post stays text-only */
+    }
+  }
+  const coversAttached = covers.length ? await attachPostCovers(ctx, covers) : 0;
+
+  return { posts: created, categories: cats, tags: tgs, coversAttached };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-blog.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupBlog(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/cms/INSTRUCTIONS.md
@@ -1,0 +1,168 @@
+# CMS — playbook
+
+The data machinery ships as files — typed reads/writes over ANY collection, hooks, and the
+normalization layer (dates → ISO strings, `wix:image://` → https URLs), correct end-to-end.
+CMS is schema-generic, so unlike other verticals there are **no fixed pages**: the seed plan
+(`plan.json`) is the site's content model, and **you design the pages from it** — a listing
+surface and an item page per content collection, plus the home page and the brand. You never
+write data-access logic; you never skip designing.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read the reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/cms/types.ts` | the DTOs (`CmsItem`, `CmsFilter`, `CmsSort`, `CmsQuery`, `CmsPage`) — contracts below |
+| `wix/cms/items.ts` | `queryItems`, `getItemById`, `getItemBy`, `countItems`, `insertItem`, `updateItem`, `patchItemFields`, `removeItem` |
+| `hooks/cms/useCollection.ts` | list state + skip paging — contract below |
+| `hooks/cms/useItem.ts` | one item by `_id` or slug field — contract below |
+| `components/cms/CollectionView.tsx` (+ `CollectionCard`) | **REFERENCE implementation** — a field-map-driven grid; build your own instead of shipping it |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot + global.css import). If another vertical is also deployed, its layout won — add your content nav links there |
+
+There are **no shipped pages** — you author them (below).
+
+## What you build — the design job
+
+Read the seed plan first: its collections, field keys, and permissions are the contract your
+pages bind to (collection ids and field keys verbatim).
+
+1. **A listing surface per content collection** — your card (image, title, secondary fields)
+   and rhythm, with skeletons while loading and an honest empty state — on `useCollection`
+   (or SSR via `queryItems` alone when the page needs no interactivity).
+2. **An item page per collection with a `slug` field** — your detail layout on the DTO
+   (SSR fetch via `getItemBy`), with a real 404 on miss.
+3. **The home page** — hero, featured items (fetch in frontmatter → your components), brand
+   story.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// CmsItem — display-ready, fields FLAT on the item (never item.data.*):
+// { _id, _createdDate?, _updatedDate?, _owner?, ...fields }
+//   TEXT/URL/EMAIL → string · NUMBER → number · BOOLEAN → boolean
+//   DATE/DATETIME → ISO string (render: new Date(iso).toLocaleDateString())
+//   IMAGE → resolved https URL (straight into <img src>; guard the absent case)
+//   RICH_TEXT → the stored HTML string (render via set:html on a wrapper you control)
+//   REFERENCE/MULTI_REFERENCE → id(s); full CmsItem(s) when queried with include
+
+// queryItems(collectionId, { filters?, sort?, limit?, skip?, include?, withTotal? })
+//   → { items: CmsItem[], hasNext, total }        // filters: [{ field, op, value }]
+//     ops: eq ne gt ge lt le contains startsWith hasSome hasAll isEmpty isNotEmpty
+//     DATE comparands must be Date objects (an ISO string matches nothing)
+// getItemBy(collectionId, field, value) → CmsItem | null      // slug routing
+// getItemById(collectionId, id) → CmsItem | null
+// countItems(collectionId, filters?) → number
+
+// useCollection(collectionId, { filters?, sort?, limit?, include?, initialItems?, initialHasNext? })
+// → { items: CmsItem[]|null /* null = loading → skeletons */,
+//     hasNext, loadMore(), loadingMore, error }   // changing filters/sort refetches
+
+// useItem(collectionId, { id } | { by: { field, value } }, { initialItem? })
+// → { item: CmsItem|null, notFound, error }       // notFound → your 404/miss state
+
+// Writes (only when the collection's permissions allow the caller):
+// insertItem(collectionId, data)                  // dates as Date objects; never set _owner
+// patchItemFields(collectionId, id, fields)       // the safe partial change
+// updateItem(collectionId, item)                  // REPLACES the whole item — see hard rules
+// removeItem(collectionId, id)
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass) and add one nav
+   link per content surface.
+2. Author your pages under `src/pages/` — SSR fetch in the frontmatter, DTO props to your
+   islands (`client:load`; a page with no interactivity needs no island at all). Listing:
+
+   ```astro
+   ---
+   import SiteLayout from "../layouts/SiteLayout.astro";
+   import { queryItems } from "../wix/cms/items";
+   import type { CmsPage } from "../wix/cms/types";
+   let page: CmsPage = { items: [], hasNext: false, total: null };
+   try {
+     page = await queryItems("recipes", { sort: [{ field: "publishDate", direction: "desc" }] });
+   } catch {
+     // an unguarded SSR throw truncates the response mid-stream
+   }
+   ---
+   ```
+
+   Item page (`src/pages/recipes/[slug].astro`): `getItemBy("recipes", "slug", Astro.params.slug!)`
+   in the frontmatter; `return new Response(null, { status: 404 })` on null. SEO is plain
+   `<title>`/`<meta name="description">` from the DTO via the layout props — CMS collections
+   have **no owner-editable SEO item type**, so don't copy another vertical's
+   `wixMetadata`/`<SEO.Tags>` wiring.
+3. **Author your surfaces in as few messages as possible** — batch multiple Writes per
+   message (components and pages are independent files).
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes are yours: a list route per collection on
+`useCollection`, a detail route on `useItem` with `by: { field: "slug", value }`.
+
+## Hard rules
+
+- **Data only through the shipped exports** — never re-derive a Wix Data request, never
+  import `@wix/data` directly in your components, never hand-build a `static.wixstatic.com`
+  URL.
+- **The id is `_id`, fields are flat** — `item.id` is undefined; `item.data.title` is the
+  REST shape and reads undefined.
+- **Bind by the seed plan's ids and keys verbatim** — collection ids have no namespace; a
+  mistyped field key reads as a blank, not an error.
+- **An empty read on a PUBLIC collection is a seed permissions bug** (`read` must be
+  `ANYONE`) — fix the seed, never reach for `auth.elevate` (it doesn't exist on this path).
+  On a member-scoped collection an empty anonymous read is the gate working, not a bug.
+- **`updateItem` REPLACES the whole item** — omitted fields are wiped. Spread the full item,
+  or use `patchItemFields`. Date fields on any write are Date objects — a round-tripped ISO
+  string is silently stored as text and breaks date queries.
+- **Writes 403 unless the collection was seeded with that verb open** — surface a 403 as a
+  permissions setup step (which permission, where in the dashboard), not a code bug.
+- **RICH_TEXT is HTML, not plain text** — render it with `set:html` (Astro) /
+  `dangerouslySetInnerHTML` (React) on a wrapper; never interpolate it as text.
+- Reference fields hold ids unless the query passed `include` — don't render an id as
+  content.
+- Guard absent IMAGE fields — render a fallback, never an empty/broken `<img>`.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Live data or an honest empty state — never mock items or invent fields not in the plan.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link — the deploy step's JSON printed `dashboardUrl`; append
+`/wix-cms` for the collections area (items, fields, and More Actions → Permissions &
+Privacy live there).
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-cms.mjs` from the project root. The
+plan is the content model your pages bind to: design collections that exercise the UI
+(a `slug` field per detail page, an IMAGE field with a verified `imageUrl` per item, a DATE
+field when the content is chronological).
+
+## Verify (before declaring done)
+
+- [ ] Each listing page renders live items SSR (view-source shows titles) through YOUR
+      components; an empty collection shows your honest empty state (no mock items).
+- [ ] Item pages resolve by slug with a real 404 on a bad slug.
+- [ ] Images render (resolved https URLs, no raw `wix:image://`); absent images fall back
+      gracefully.
+- [ ] Dates render formatted (no "Invalid Date", no raw ISO strings in copy).
+- [ ] RICH_TEXT renders formatted (no visible HTML tags, no `[object Object]`).
+- [ ] Any 403 surfaced as a permissions step with the dashboard link.
+- [ ] Listing/item/home surfaces are YOUR designs on the tokens; data-layer/hook files
+      unedited.
+- [ ] Dashboard link handed to the owner.

--- a/skills/wix-headless-fast/references/cms/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/cms/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,41 @@
+---
+// The site chrome for every CMS page — THIS file (header/footer/nav) plus the @theme token
+// block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" /> in
+// <head> and the global.css import. Add one nav link per content surface you build (the
+// routes are yours — CMS ships no fixed pages). (If another vertical is also deployed, its
+// SiteLayout won; merge nav links there instead.)
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <!-- one link per content surface you build, e.g. <a href="/recipes">Recipes</a> -->
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/cms/app/components/cms/CollectionView.tsx
+++ b/skills/wix-headless-fast/references/cms/app/components/cms/CollectionView.tsx
@@ -1,0 +1,152 @@
+// REFERENCE listing surface: a generic card grid over any collection, driven by a field
+// map from the seed plan. Correct and complete; per the skill's model you design and build
+// your own on useCollection.
+import type { ComponentType, ReactNode } from "react";
+import { useCollection } from "../../hooks/cms/useCollection";
+import type { CmsFilter, CmsItem, CmsSort } from "../../wix/cms/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+/** Which field keys (from the seed plan) fill each card slot. */
+export interface CmsFieldMap {
+  /** TEXT field for the card title. */
+  title: string;
+  /** IMAGE field (DTO value is a resolved https URL). */
+  image?: string;
+  /** Short text under the title. */
+  subtitle?: string;
+  /** DATE/DATETIME field (DTO value is an ISO string). */
+  date?: string;
+  /** Field used in item URLs (default: the item's `_id`). */
+  slug?: string;
+}
+
+const text = (v: unknown): string => (typeof v === "string" ? v : "");
+
+export interface CollectionCardProps {
+  item: CmsItem;
+  fieldMap: CmsFieldMap;
+  itemHref: (item: CmsItem) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function CollectionCard({ item, fieldMap, itemHref, LinkComponent = PlainLink }: CollectionCardProps) {
+  const imageUrl = fieldMap.image ? text(item[fieldMap.image]) : "";
+  const dateIso = fieldMap.date ? text(item[fieldMap.date]) : "";
+  return (
+    <LinkComponent href={itemHref(item)} className="group block no-underline">
+      {imageUrl && (
+        <div className="aspect-[4/3] overflow-hidden rounded-lg bg-secondary">
+          <img
+            src={imageUrl}
+            alt={text(item[fieldMap.title])}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        </div>
+      )}
+      <p className="mt-3 text-sm font-medium text-foreground">{text(item[fieldMap.title])}</p>
+      {fieldMap.subtitle && text(item[fieldMap.subtitle]) && (
+        <p className="mt-0.5 text-xs text-muted-foreground">{text(item[fieldMap.subtitle])}</p>
+      )}
+      {dateIso && (
+        <p className="mt-1 text-xs text-muted-foreground">{new Date(dateIso).toLocaleDateString()}</p>
+      )}
+    </LinkComponent>
+  );
+}
+
+export interface CollectionViewProps {
+  collectionId: string;
+  fieldMap: CmsFieldMap;
+  filters?: CmsFilter[];
+  sort?: CmsSort[];
+  limit?: number;
+  initialItems?: CmsItem[];
+  initialHasNext?: boolean;
+  emptyMessage?: string;
+  /** Route shape is yours — default `/<collectionId>/<slug-or-_id>`. */
+  itemHref?: (item: CmsItem) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<CollectionCardProps>;
+}
+
+export default function CollectionView({
+  collectionId,
+  fieldMap,
+  filters,
+  sort,
+  limit,
+  initialItems,
+  initialHasNext,
+  emptyMessage = "Nothing here yet — check back soon.",
+  itemHref,
+  LinkComponent,
+  CardComponent = CollectionCard,
+}: CollectionViewProps) {
+  const { items, hasNext, loadMore, loadingMore, error } = useCollection(collectionId, {
+    filters,
+    sort,
+    limit,
+    initialItems,
+    initialHasNext,
+  });
+  const href =
+    itemHref ??
+    ((item: CmsItem) =>
+      `/${collectionId}/${encodeURIComponent(text(fieldMap.slug ? item[fieldMap.slug] : "") || item._id)}`);
+
+  return (
+    <div>
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {items === null ? (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i}>
+              <div className="aspect-[4/3] animate-pulse rounded-lg bg-secondary" />
+              <div className="mt-3 h-3.5 w-2/3 animate-pulse rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item) => (
+              <CardComponent
+                key={item._id}
+                item={item}
+                fieldMap={fieldMap}
+                itemHref={href}
+                LinkComponent={LinkComponent}
+              />
+            ))}
+          </div>
+          {hasNext && (
+            <div className="mt-10 text-center">
+              <button
+                type="button"
+                disabled={loadingMore}
+                onClick={loadMore}
+                className="rounded-lg border border-border px-6 py-2 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/cms/app/hooks/cms/useCollection.ts
+++ b/skills/wix-headless-fast/references/cms/app/hooks/cms/useCollection.ts
@@ -1,0 +1,83 @@
+// One collection as list state. SSR-friendly: pass server-fetched items as `initialItems`
+// (Astro frontmatter / server component) and no client fetch happens for the first page; a
+// SPA passes nothing. Changing filters/sort (by value) refetches; loadMore() appends the
+// next page (skip paging).
+import { useCallback, useEffect, useRef, useState } from "react";
+import { queryItems } from "../../wix/cms/items";
+import type { CmsFilter, CmsItem, CmsSort } from "../../wix/cms/types";
+
+export interface UseCollectionOptions {
+  filters?: CmsFilter[];
+  sort?: CmsSort[];
+  /** Page size (default 20). */
+  limit?: number;
+  /** Reference field keys to inline as full items. */
+  include?: string[];
+  /** Server-fetched first page — must come from the SAME query (filters/sort/limit/include). */
+  initialItems?: CmsItem[];
+  /** The server fetch's hasNext. Omitted → inferred (a full first page ⇒ assume more). */
+  initialHasNext?: boolean;
+}
+
+export interface UseCollection {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  items: CmsItem[] | null;
+  hasNext: boolean;
+  loadMore: () => void;
+  loadingMore: boolean;
+  error: string | null;
+}
+
+export function useCollection(collectionId: string, options: UseCollectionOptions = {}): UseCollection {
+  const { filters, sort, limit = 20, include, initialItems, initialHasNext } = options;
+  // Query identity by value — Dates in filters serialize to ISO, so this is stable.
+  const key = JSON.stringify([collectionId, filters ?? null, sort ?? null, limit, include ?? null]);
+  const initialKey = useRef<string | null>(initialItems ? key : null);
+  const [items, setItems] = useState<CmsItem[] | null>(initialItems ?? null);
+  const [hasNext, setHasNext] = useState<boolean>(
+    initialHasNext ?? (initialItems ? initialItems.length >= limit : false),
+  );
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const itemsRef = useRef<CmsItem[] | null>(items);
+  itemsRef.current = items;
+
+  useEffect(() => {
+    if (initialKey.current === key) return; // the SSR pass already answered this exact query
+    initialKey.current = null;
+    let alive = true;
+    setItems(null);
+    setError(null);
+    queryItems(collectionId, { filters, sort, limit, include })
+      .then((page) => {
+        if (!alive) return;
+        setItems(page.items);
+        setHasNext(page.hasNext);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setItems([]);
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const loadMore = useCallback(() => {
+    const current = itemsRef.current;
+    if (!current || loadingMore) return;
+    setLoadingMore(true);
+    queryItems(collectionId, { filters, sort, limit, include, skip: current.length })
+      .then((page) => {
+        setItems([...(itemsRef.current ?? []), ...page.items]);
+        setHasNext(page.hasNext);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoadingMore(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, loadingMore]);
+
+  return { items, hasNext, loadMore, loadingMore, error };
+}

--- a/skills/wix-headless-fast/references/cms/app/hooks/cms/useItem.ts
+++ b/skills/wix-headless-fast/references/cms/app/hooks/cms/useItem.ts
@@ -1,0 +1,57 @@
+// One item — by `_id` or by a field match (slug routing). SSR-friendly: pass the
+// server-fetched item as `initialItem` and no client fetch happens; a SPA passes nothing.
+import { useEffect, useState } from "react";
+import { getItemBy, getItemById } from "../../wix/cms/items";
+import type { CmsItem } from "../../wix/cms/types";
+
+/** Exactly one of `id` / `by`. */
+export interface UseItemRef {
+  id?: string;
+  by?: { field: string; value: string | number };
+}
+
+export interface UseItemOptions {
+  initialItem?: CmsItem;
+  /** Reference field keys to inline as full items. */
+  include?: string[];
+}
+
+export interface UseItem {
+  /** null while loading OR when not found — branch on notFound for the miss state. */
+  item: CmsItem | null;
+  notFound: boolean;
+  error: string | null;
+}
+
+export function useItem(collectionId: string, ref: UseItemRef, options: UseItemOptions = {}): UseItem {
+  const { initialItem, include } = options;
+  const [item, setItem] = useState<CmsItem | null>(initialItem ?? null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialItem) return;
+    let alive = true;
+    const fetching = ref.id
+      ? getItemById(collectionId, ref.id, { include })
+      : ref.by
+        ? getItemBy(collectionId, ref.by.field, ref.by.value, { include })
+        : Promise.reject(new Error("useItem: pass ref.id or ref.by"));
+    fetching
+      .then((found) => {
+        if (!alive) return;
+        setItem(found);
+        setNotFound(found === null);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionId, ref.id, ref.by?.field, ref.by?.value]);
+
+  return { item, notFound, error };
+}

--- a/skills/wix-headless-fast/references/cms/app/wix/cms/items.ts
+++ b/skills/wix-headless-fast/references/cms/app/wix/cms/items.ts
@@ -1,0 +1,149 @@
+// Wix Data reads/writes (@wix/data `items`) — the only file that touches raw data items.
+// CMS is schema-generic: every function takes the collection id from the seed plan
+// (seed/SEED.md) and returns plain CmsItem DTOs from ./types. Copy as-is; extend by adding
+// functions, not by editing these.
+import { items as itemsModule } from "@wix/data";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { CmsFilter, CmsItem, CmsPage, CmsQuery } from "./types";
+
+const items = wixModule(itemsModule);
+
+type Raw = Record<string, any>;
+
+// SDK → DTO: the SDK decodes date fields into Date objects (not serializable as island
+// props) and IMAGE fields arrive as wix:image:// identifiers a browser can't load
+// (ERR_UNKNOWN_URL_SCHEME). Normalize recursively — included reference items too.
+function toValue(v: unknown): unknown {
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === "string" && v.startsWith("wix:image://")) return imgSrc(v, 1200, 900);
+  if (Array.isArray(v)) return v.map(toValue);
+  if (v && typeof v === "object") {
+    const out: Raw = {};
+    for (const [k, val] of Object.entries(v as Raw)) out[k] = toValue(val);
+    return out;
+  }
+  return v;
+}
+
+const toItem = (raw: Raw): CmsItem => toValue(raw) as CmsItem;
+
+// An undefined comparand silently changes what a query matches (every row, or none) with no
+// server error — the classic "my items shows everyone's items" bug. Throw at the call site;
+// omit the filter entirely when you don't hold a value yet.
+function assertFilterValue(f: CmsFilter): void {
+  if (f.op !== "isEmpty" && f.op !== "isNotEmpty" && f.value === undefined) {
+    throw new Error(
+      `cms: filter on "${f.field}" (${f.op}) has an undefined value — pass a real value or omit the filter.`,
+    );
+  }
+}
+
+/**
+ * Query one page of a collection. An empty result on a PUBLIC collection is a seed
+ * permissions bug (read must be "ANYONE"), not a query bug — never reach for auth.elevate.
+ */
+export async function queryItems(collectionId: string, query: CmsQuery = {}): Promise<CmsPage> {
+  const { filters = [], sort = [], limit = 20, skip = 0, include = [], withTotal = false } = query;
+  let q = items.query(collectionId);
+  for (const f of filters) {
+    assertFilterValue(f);
+    const v = f.value as any;
+    switch (f.op) {
+      case "eq": q = q.eq(f.field, v); break;
+      case "ne": q = q.ne(f.field, v); break;
+      case "gt": q = q.gt(f.field, v); break;
+      case "ge": q = q.ge(f.field, v); break;
+      case "lt": q = q.lt(f.field, v); break;
+      case "le": q = q.le(f.field, v); break;
+      case "contains": q = q.contains(f.field, v); break;
+      case "startsWith": q = q.startsWith(f.field, v); break;
+      case "hasSome": q = q.hasSome(f.field, v); break;
+      case "hasAll": q = q.hasAll(f.field, v); break;
+      case "isEmpty": q = q.isEmpty(f.field); break;
+      case "isNotEmpty": q = q.isNotEmpty(f.field); break;
+    }
+  }
+  for (const s of sort) q = s.direction === "desc" ? q.descending(s.field) : q.ascending(s.field);
+  if (include.length) q = q.include(...include);
+  const res = await q.limit(limit).skip(skip).find(withTotal ? { returnTotalCount: true } : undefined);
+  return {
+    items: (res.items ?? []).map((r: Raw) => toItem(r)),
+    hasNext: res.hasNext(),
+    total: res.totalCount ?? null,
+  };
+}
+
+/** Fetch one item by `_id`. Null when not found. */
+export async function getItemById(
+  collectionId: string,
+  itemId: string,
+  { include = [] }: { include?: string[] } = {},
+): Promise<CmsItem | null> {
+  const raw = await items.get(collectionId, itemId, {
+    ...(include.length ? { includeReferences: include.map((field) => ({ field })) } : {}),
+  });
+  return raw ? toItem(raw as Raw) : null;
+}
+
+/**
+ * Fetch the first item whose `field` equals `value` — slug-style routing (Wix Data has no
+ * native get-by-slug). Null when not found → render a not-found state, never invent an item.
+ */
+export async function getItemBy(
+  collectionId: string,
+  field: string,
+  value: string | number,
+  { include = [] }: { include?: string[] } = {},
+): Promise<CmsItem | null> {
+  const page = await queryItems(collectionId, { filters: [{ field, op: "eq", value }], limit: 1, include });
+  return page.items[0] ?? null;
+}
+
+/** Count items matching the filters — empty-state logic and result counts. */
+export async function countItems(collectionId: string, filters: CmsFilter[] = []): Promise<number> {
+  const page = await queryItems(collectionId, { filters, limit: 1, withTotal: true });
+  return page.total ?? page.items.length;
+}
+
+/**
+ * Insert an item (visitor form / member submission). Succeeds only when the collection's
+ * insert permission covers the caller (403 otherwise — a seed permissions step, not a code
+ * bug). Never set `_owner` — Wix stamps it from the caller's identity.
+ * Date fields must be Date objects (an ISO string is stored as text and breaks date queries).
+ */
+export async function insertItem(collectionId: string, data: Record<string, unknown>): Promise<CmsItem> {
+  const created = await items.insert(collectionId, data as Raw);
+  return toItem(created as Raw);
+}
+
+/**
+ * REPLACE an item — fields omitted from `item` are WIPED (update does not patch). Spread the
+ * full item you hold and override; for an id + a few changed fields use patchItemFields.
+ * A round-tripped DTO carries dates as ISO strings — wrap each date field back
+ * (`new Date(iso)`) before updating, or the DATE field is silently rewritten as text.
+ */
+export async function updateItem(collectionId: string, item: CmsItem): Promise<CmsItem> {
+  const updated = await items.update(collectionId, item as Raw & { _id: string });
+  return toItem(updated as Raw);
+}
+
+/** Patch only the named fields — the safe partial change (no replace-wipes-fields footgun). */
+export async function patchItemFields(
+  collectionId: string,
+  itemId: string,
+  fields: Record<string, unknown>,
+): Promise<CmsItem> {
+  const entries = Object.entries(fields);
+  if (!entries.length) throw new Error("cms: patchItemFields called with no fields.");
+  let p = items.patch(collectionId, itemId);
+  for (const [k, v] of entries) p = p.setField(k, v);
+  const patched = await p.run();
+  return toItem(patched as Raw);
+}
+
+/** Remove an item by `_id`. Irreversible. Returns the removed item (null if it didn't exist). */
+export async function removeItem(collectionId: string, itemId: string): Promise<CmsItem | null> {
+  const removed = await items.remove(collectionId, itemId);
+  return removed ? toItem(removed as Raw) : null;
+}

--- a/skills/wix-headless-fast/references/cms/app/wix/cms/types.ts
+++ b/skills/wix-headless-fast/references/cms/app/wix/cms/types.ts
@@ -1,0 +1,75 @@
+// CMS DTOs — the serializable shapes every hook, component, and page consumes. CMS is
+// schema-generic: field keys come from the seed plan (seed/SEED.md), so an item is a flat
+// field map rather than a fixed interface. Plain JSON: safe as Astro island props or across
+// server/client boundaries. By the time an item leaves the data layer, Date fields are ISO
+// strings and IMAGE fields are resolved https URLs.
+
+/**
+ * One collection item: `_id` plus the collection's fields, flat on the item (there is no
+ * `item.data.*` — that is the REST shape and reads undefined here).
+ * Field values by type: TEXT/URL/EMAIL → string, NUMBER → number, BOOLEAN → boolean,
+ * DATE/DATETIME → ISO string, IMAGE → https URL ("" never happens — absent fields are
+ * undefined), RICH_TEXT → the stored HTML string, REFERENCE/MULTI_REFERENCE → id(s), or
+ * full CmsItem(s) when the query included the field.
+ */
+export interface CmsItem {
+  _id: string;
+  /** ISO string (the SDK's Date objects are serialized by the data layer). */
+  _createdDate?: string;
+  _updatedDate?: string;
+  /** Id of the member who created the row (member-scoped collections). */
+  _owner?: string;
+  [key: string]: unknown;
+}
+
+export type CmsFilterOp =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "ge"
+  | "lt"
+  | "le"
+  | "contains"
+  | "startsWith"
+  | "hasSome"
+  | "hasAll"
+  | "isEmpty"
+  | "isNotEmpty";
+
+/**
+ * One query predicate. Comparands must match the field's stored type — a DATE/DATETIME
+ * field only matches a Date object (an ISO string compares as text and matches nothing).
+ */
+export interface CmsFilter {
+  field: string;
+  op: CmsFilterOp;
+  /** Required except for isEmpty/isNotEmpty; hasSome/hasAll take an array. */
+  value?: string | number | boolean | Date | (string | number | Date)[];
+}
+
+export interface CmsSort {
+  field: string;
+  /** Default "asc". */
+  direction?: "asc" | "desc";
+}
+
+export interface CmsQuery {
+  filters?: CmsFilter[];
+  sort?: CmsSort[];
+  /** Page size (default 20). */
+  limit?: number;
+  /** Items to skip — page N is skip = N * limit. */
+  skip?: number;
+  /** Reference field keys to inline as full items (otherwise the field holds ids). */
+  include?: string[];
+  /** true → the page carries `total` (slower query; for counts/empty-state logic). */
+  withTotal?: boolean;
+}
+
+/** One page of items. Load the next page with skip = items shown so far. */
+export interface CmsPage {
+  items: CmsItem[];
+  hasNext: boolean;
+  /** Total matching items — only when the query asked `withTotal`, else null. */
+  total: number | null;
+}

--- a/skills/wix-headless-fast/references/cms/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/cms/lock/astro/package-lock.json
@@ -1,0 +1,11262 @@
+{
+ "name": "wix-headless-fast-cms",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-cms",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/data": "^1.0.512",
+    "@wix/sdk": "^1.21.5",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_backups": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_backups/-/@wix/auto_sdk_data_backups-1.0.69.tgz",
+   "integrity": "sha512-I6fQKHZqnnwugixuKis1bP+QUSgAGhsa/EU6re9fcL/qF4QWE089luNaDclxFw2NuE4DkApknmWQBimTc3mZog==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_collections": {
+   "version": "1.0.94",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_collections/-/@wix/auto_sdk_data_collections-1.0.94.tgz",
+   "integrity": "sha512-FtdUIcNqZbtwp2cM1heM643bi2ILn9NQFBtUZE0zRY5VF17nqNBneZpZ/IihKZbMHKxB0Deazmh5XhDZ7rpZNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_external-database": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database/-/@wix/auto_sdk_data_external-database-1.0.32.tgz",
+   "integrity": "sha512-ASLrBaGM2/kfrUc+FVfw2pGqNpd26XE5yXtczF2IEKTackWLWHk/vTCAJhIZO4SziiJKmr+4QA1DTBOtLIJhMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_external-database-connections": {
+   "version": "1.0.51",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database-connections/-/@wix/auto_sdk_data_external-database-connections-1.0.51.tgz",
+   "integrity": "sha512-MO+Xza005HbSk+3npgsU+9cJ1AnsYW1pBnf6iJQaTkE+0oCA56/k4+NNgK8asQKQY9aEW/UKwUpAwVWPhw81AA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_indexes": {
+   "version": "1.0.55",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_indexes/-/@wix/auto_sdk_data_indexes-1.0.55.tgz",
+   "integrity": "sha512-+L4iwriLernM6No4qzHS+zr6B5boo+6FwSZjm7PDbDFUleNwaCTRiTgmvSIpt01UwnqKxU/msxG9s9BfZjn3EA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_movement-jobs": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_movement-jobs/-/@wix/auto_sdk_data_movement-jobs-1.0.59.tgz",
+   "integrity": "sha512-Mz1Fh/U4+sIUwG8CIqOwJW4JZ1OzuTo6YcfWQygRFYL0qP5Im9bQzlKX290TN57FfkF+VgdQWPfCF6a2ysnwcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_permissions": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_permissions/-/@wix/auto_sdk_data_permissions-1.0.52.tgz",
+   "integrity": "sha512-KN7pGm54KVjnLDKD2j6MLfXYg35sUl2X204Tsga888jUwJi4Ta3djIF7ybn+zKlj0jeNfnAWpSc64Ume22oqaQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_scheduled-workflows": {
+   "version": "1.0.11",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_scheduled-workflows/-/@wix/auto_sdk_data_scheduled-workflows-1.0.11.tgz",
+   "integrity": "sha512-d8DkGwGMFVwg2ygUgq/hN6py6uj71kQFqgf/0MorO0SYU5JHe3yPBnFQwwH2Zwfn3PVbZ/KQp+zguNd3gllkig==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_sharing": {
+   "version": "1.0.26",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_sharing/-/@wix/auto_sdk_data_sharing-1.0.26.tgz",
+   "integrity": "sha512-aMlELsMlXCtlEVlu5AE+CZzBSj1Cxz1ZjFj2dxq4y3U3hZ4EPS34dOwBgthtHx1/RQQpLK0ZYaj9a8nMmOhlWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_data_tasks": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_tasks/-/@wix/auto_sdk_data_tasks-1.0.42.tgz",
+   "integrity": "sha512-ILRyAHqykahNE7CP3OUu2yJFraZo3wzEkM+MyBNzK2MoTqkXjpFB3BLQuuAbd/ISzRGq2crg1b2exLKo88QXQg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout": {
+   "version": "1.0.168",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart": {
+   "version": "1.0.184",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/data": {
+   "version": "1.0.512",
+   "resolved": "https://registry.npmjs.org/@wix/data/-/@wix/data-1.0.512.tgz",
+   "integrity": "sha512-Zgwd0Z/WRyMwEUVttlfz7NRglRDkK3/lsBOA07b93sFRF3/7pH27A8moUdPIL/aPbIDcm9DIcKhdKh/P4/HsXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_data_backups": "1.0.69",
+    "@wix/auto_sdk_data_collections": "1.0.94",
+    "@wix/auto_sdk_data_external-database": "1.0.32",
+    "@wix/auto_sdk_data_external-database-connections": "1.0.51",
+    "@wix/auto_sdk_data_indexes": "1.0.55",
+    "@wix/auto_sdk_data_movement-jobs": "1.0.59",
+    "@wix/auto_sdk_data_permissions": "1.0.52",
+    "@wix/auto_sdk_data_scheduled-workflows": "1.0.11",
+    "@wix/auto_sdk_data_sharing": "1.0.26",
+    "@wix/auto_sdk_data_tasks": "1.0.42",
+    "@wix/headless-cms": "^0.0.45",
+    "@wix/wix-data-items-sdk": "1.0.545"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/filter-builder": {
+   "version": "1.0.248",
+   "resolved": "https://registry.npmjs.org/@wix/filter-builder/-/@wix/filter-builder-1.0.248.tgz",
+   "integrity": "sha512-06lIiDP+0rLIWL2+513fkr7ONKw61s89XVnX1f9Xyg/aaGjmPqqTYRcLUUQqPOedmOJmr//IuLpA+nTDD1+JNg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/headless-cms": {
+   "version": "0.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/headless-cms/-/@wix/headless-cms-0.0.45.tgz",
+   "integrity": "sha512-wSX5M8axWYFw3DI1OUBoMrrU1mqzfranSAB4qBonXcM0/M8O3ciZ3rzYhNIVwHXgiNW580ptjmq8yX6ERGiJwA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/data": "^1.0.0",
+    "@wix/headless-ecom": "0.0.40",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-components/node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-ecom": {
+   "version": "0.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.40.tgz",
+   "integrity": "sha512-ib8dYXCeHlo/UYck/CE9v3AkFXI0r5Dn+6ZRH1I2ylxrZMy7Lqj2GF0gwvoOwEKdDbjuNhWEvTY9X4tg6tN0Qg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/auto_sdk_ecom_checkout": "^1.0.61",
+    "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
+    "@wix/headless-media": "0.0.20",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/media/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/wix-data-items-common": {
+   "version": "1.0.324",
+   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-common/-/@wix/wix-data-items-common-1.0.324.tgz",
+   "integrity": "sha512-qHa8aSEBz5A1v5pgR06lz02TSCcXn3I29BDZoXIpIveTmV5QPYEL2WFAgdYhAcGKtSAy55qmnKmhrkAjG3Nmng==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/filter-builder": "1.0.248",
+    "@wix/sdk-runtime": "^1.0.17"
+   }
+  },
+  "node_modules/@wix/wix-data-items-sdk": {
+   "version": "1.0.545",
+   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-sdk/-/@wix/wix-data-items-sdk-1.0.545.tgz",
+   "integrity": "sha512-8omSNIyI16L+SsfmOGsrDEBDl8DeF7Cuo1vyaIKwxBBwTZ5N/gqp+BY9WdVaeXfg0s5dWUbROG1I8/m2Wv30zQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.9",
+    "@wix/wix-data-items-common": "1.0.324"
+   }
+  },
+  "node_modules/@wix/wix-data-items-sdk/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/wix-data-items-sdk/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "peer": true,
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/cms/seed/SEED.md
+++ b/skills/wix-headless-fast/references/cms/seed/SEED.md
@@ -1,0 +1,100 @@
+# CMS — seeding
+
+Seed by **running `seed-cms.mjs` with a plan file** — don't hand-write the REST calls.
+The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
+required), installs the Wix Data (CMS) app if needed, and creates everything in order:
+per collection — create (schema + permissions) → import IMAGE urls into Wix Media →
+bulk-insert items → wire multi-references → verify persistence.
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/cms/seed/seed-cms.mjs plan.json
+```
+
+`plan.json` is plain data — **it IS the site's content model**: the collections, their field
+schemas, and the items the pages will render. Write it from the brief. Default to **one or
+two content collections with ~3–6 items each** (the seed shows the shape; the owner adds the
+rest in the dashboard). Give any collection that gets a detail page a `slug` TEXT field, and
+every content item a verified `imageUrl` on an IMAGE field (a content site without images
+looks broken).
+
+```json
+{
+  "collections": [
+    {
+      "id": "categories", "displayName": "Categories",
+      "fields": [{ "key": "name", "type": "TEXT" }],
+      "items": [{ "name": "Cakes" }, { "name": "Breads" }]
+    },
+    {
+      "id": "recipes", "displayName": "Recipes",
+      "fields": [
+        { "key": "title", "type": "TEXT" },
+        { "key": "slug", "type": "TEXT" },
+        { "key": "summary", "type": "TEXT" },
+        { "key": "body", "type": "RICH_TEXT" },
+        { "key": "photo", "type": "IMAGE" },
+        { "key": "publishDate", "type": "DATE" },
+        { "key": "categories", "type": "MULTI_REFERENCE", "referencedCollectionId": "categories" }
+      ],
+      "items": [
+        { "title": "Chocolate Layer Cake", "slug": "chocolate-layer-cake",
+          "summary": "Three layers, one ganache.", "body": "<p>Cream the butter…</p>",
+          "photo": "https://…", "publishDate": "2026-08-01", "categories": [0] },
+        { "title": "Country Sourdough", "slug": "country-sourdough",
+          "summary": "A 24-hour loaf.", "body": "<p>Feed the starter…</p>",
+          "photo": "https://…", "publishDate": "2026-08-10", "categories": [1] },
+        { "title": "Pavlova", "slug": "pavlova",
+          "summary": "Crisp shell, soft heart.", "body": "<p>Whip the whites…</p>",
+          "photo": "https://…", "publishDate": "2026-08-20", "categories": [0] }
+      ]
+    }
+  ]
+}
+```
+
+- `id` — the collection id the frontend binds to, verbatim (no namespace; Wix doesn't rename
+  it). Item keys must match the field `key`s exactly — the script fails loud on a key the
+  schema doesn't have (the API would silently drop it).
+- Field `type` — `TEXT`, `NUMBER`, `BOOLEAN`, `DATE`, `DATETIME`, `URL`, `EMAIL`, `IMAGE`,
+  `RICH_TEXT` (an HTML string, stored verbatim), `REFERENCE`, `MULTI_REFERENCE`.
+- `IMAGE` values are external image URLs (verified) — the script imports each into Wix Media
+  (`POST /site-media/v1/files/import`) and stores the permanent `file.url`; on import failure
+  the item stays text-only (never blocks).
+- `DATE`/`DATETIME` values are ISO strings — the script wraps them as `{ "$date": iso }`.
+- References: **order collections so targets come first.** A `REFERENCE` value is the target
+  item's index in its collection's `items` array; `MULTI_REFERENCE` is an array of indices
+  (set at insert it would be silently dropped — the script wires these via
+  `POST /wix-data/v2/bulk/items/insert-references`).
+- `permissions` — omit for the **public-read** default
+  (`read: ANYONE`, writes `ADMIN`). Other shapes (per action: `ANYONE` › `SITE_MEMBER` ›
+  `SITE_MEMBER_AUTHOR` › `ADMIN`):
+
+  | preset | `read` / `insert` / `update` / `remove` | use |
+  |---|---|---|
+  | public-read (default) | `ANYONE` / `ADMIN` / `ADMIN` / `ADMIN` | admin content, anyone reads |
+  | collaborative | `ANYONE` / `ANYONE` / `ANYONE` / `ANYONE` | visitor-written shared board (anonymous, unscoped) |
+  | member-private | `SITE_MEMBER_AUTHOR` / `SITE_MEMBER` / `SITE_MEMBER_AUTHOR` / `SITE_MEMBER_AUTHOR` | per-user "my…" rows — **seed it EMPTY** (rows seeded here would be owned by the admin, invisible to members) |
+  | member-shared-read-only | `SITE_MEMBER` / `ADMIN` / `ADMIN` / `ADMIN` | gated: any member reads, seed/admin writes |
+  | public-wall | `ANYONE` / `SITE_MEMBER` / `SITE_MEMBER_AUTHOR` / `SITE_MEMBER_AUTHOR` | members post, everyone reads |
+
+  `read` is the privacy decision — a public collection's `read` MUST be `ANYONE` or the
+  visitor frontend reads **zero items with no error**.
+
+**Seeding is additive — never delete or overwrite existing content** (an existing collection
+is left as-is; its items are appended); ask first if a cleanup seems needed.
+
+## Escape hatch — individual functions
+`setupCms` composes exported steps — `installDataApp`, `createCollection`, `importImage`,
+`bulkInsertItems`, `insertReferences`, `verifyItems`, plus `makeCtx()` — import them only
+for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-cms.md`.
+Endpoints used: `POST /wix-data/v2/collections` (Create Data Collection),
+`POST /wix-data/v2/bulk/items/insert` (Bulk Insert Data Items),
+`POST /wix-data/v2/bulk/items/insert-references` (Bulk Insert Data Item References),
+`POST /wix-data/v2/items/query` (Query Data Items — the verify step),
+`POST /site-media/v1/files/import` (Import File),
+`POST /apps-installer-service/v1/app-instance/install` (Install App).

--- a/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
+++ b/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
@@ -1,0 +1,289 @@
+// CMS seed — a BUILD-TIME script, never shipped in the app. Run from the project root
+// (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/cms/seed/seed-cms.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Data (CMS) app if needed,
+// creates each collection (field schema + permissions; an existing collection is left
+// as-is), imports IMAGE-field urls into Wix Media, bulk-inserts items, wires
+// multi-references, and verifies persistence. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "collections": [{ "id", "displayName"?, "permissions"?,
+//       "fields": [{ "key", "displayName"?, "type", "referencedCollectionId"? }],
+//       "items": [{ "<fieldKey>": value, ... }] }] }
+// Reference fields: order collections so targets come FIRST. A REFERENCE value is the
+// target item's index in ITS collection's items array; MULTI_REFERENCE is an array of
+// indices.
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
+// read the live API reference; authoritative source recipe:
+// wix-headless/references/inline-recipes/setup-cms.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const WIX_DATA_APP_ID = "e593b0bd-b783-45b8-97c2-873d42aacaf4";
+
+// Public collection default: read MUST be "ANYONE" or a visitor query silently returns 0
+// items (the single most common "empty page" cause). Other presets: SEED.md.
+const DEFAULT_PERMISSIONS = { insert: "ADMIN", update: "ADMIN", remove: "ADMIN", read: "ANYONE" };
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A fresh site's Wix Data backend can transiently fail its FIRST calls while provisioning —
+// 403, 400 WDE0117 ("MetaSite not found"), or 5xx. Retry the same body ONCE after ~3s, then
+// fail loud (never loop).
+async function reqRetryOnce(ctx, path, opts) {
+  try {
+    return await req(ctx, path, opts);
+  } catch (e) {
+    const m = String(e.message);
+    if (/-> (403|5\d\d):/.test(m) || m.includes("WDE0117")) {
+      await sleep(3000);
+      return req(ctx, path, opts);
+    }
+    throw e;
+  }
+}
+
+// ---- operations ----------------------------------------------------------------------------------
+
+// Idempotent; strictly only needed when a data call errors WDE0110 (app not installed).
+export async function installDataApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: WIX_DATA_APP_ID, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+// The binding key is referencedCollectionId — the docs' stale `referencedCollection` is
+// accepted with a 200 but stores an EMPTY target, leaving every later link silently dead.
+// MULTI_REFERENCE additionally REQUIRES referencingFieldKey — the auto-created back-reference
+// field on the referenced collection (400 without it); synthesized from the owning
+// collection + field when the plan doesn't name one.
+function buildField(f, collectionId) {
+  const out = { key: f.key, displayName: f.displayName ?? f.key, type: f.type };
+  if (f.type === "MULTI_REFERENCE" || f.type === "REFERENCE") {
+    if (!f.referencedCollectionId) {
+      throw new Error(`field "${f.key}": ${f.type} requires referencedCollectionId`);
+    }
+    out.typeMetadata =
+      f.type === "MULTI_REFERENCE"
+        ? { multiReference: {
+            referencedCollectionId: f.referencedCollectionId,
+            referencingFieldKey: f.referencingFieldKey ?? `${collectionId}_${f.key}`.replace(/[^a-zA-Z0-9_]/g, "_"),
+            referencingDisplayName: f.referencingDisplayName ?? `${displayNameOf(collectionId)} (${f.key})`,
+          } }
+        : { reference: { referencedCollectionId: f.referencedCollectionId } };
+  }
+  return out;
+}
+
+const displayNameOf = (id) => String(id).replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+// The permissions block is MANDATORY. 409 WDE0104 (already exists) is fine — additive.
+export async function createCollection(ctx, { id, displayName, fields = [], permissions }) {
+  try {
+    await reqRetryOnce(ctx, "/wix-data/v2/collections", { body: { collection: {
+      id,
+      displayName: displayName ?? id,
+      fields: fields.map((f) => buildField(f, id)),
+      permissions: permissions ?? DEFAULT_PERMISSIONS,
+    } } });
+    return { id, created: true };
+  } catch (e) {
+    const m = String(e.message);
+    if (m.includes("WDE0104") || m.includes("-> 409:")) return { id, created: false };
+    throw e;
+  }
+}
+
+// An IMAGE field stores a permanent Wix Media URL — an external url must be imported first.
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.url) throw new Error(`import-file returned no file url: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+// Ids come from results[].dataItem.id (there is no results[].item key).
+export async function bulkInsertItems(ctx, dataCollectionId, dataItems) {
+  const r = await reqRetryOnce(ctx, "/wix-data/v2/bulk/items/insert", { body: {
+    dataCollectionId,
+    dataItems: dataItems.map((data) => ({ data })),
+    returnEntity: true,
+  } });
+  const results = [...(r.results ?? [])].sort(
+    (a, b) => (a.itemMetadata?.originalIndex ?? 0) - (b.itemMetadata?.originalIndex ?? 0),
+  );
+  return {
+    ids: results.map((res) => res.dataItem?.id ?? res.itemMetadata?.id),
+    failures: r.bulkActionMetadata?.totalFailures ?? 0,
+  };
+}
+
+// Body key is dataItemReferences with referringItemFieldName/referringItemId/referencedItemId
+// — the natural-looking `references` shape is rejected with 400 WDE0080.
+export async function insertReferences(ctx, dataCollectionId, dataItemReferences) {
+  if (!dataItemReferences.length) return 0;
+  const r = await req(ctx, "/wix-data/v2/bulk/items/insert-references", {
+    body: { dataCollectionId, dataItemReferences },
+  });
+  return r.bulkActionMetadata?.totalSuccesses ?? dataItemReferences.length;
+}
+
+// A 200 on insert does NOT prove persistence — query back and count.
+export async function verifyItems(ctx, dataCollectionId) {
+  const r = await reqRetryOnce(ctx, "/wix-data/v2/items/query", { body: { dataCollectionId } });
+  return (r.dataItems ?? []).length;
+}
+
+// plan item -> insert `data`, per field type. MULTI_REFERENCE values are silently dropped by
+// the insert endpoint (200, no error) — stripped here and wired after; a single REFERENCE is
+// set at insert as the target item's _id. DATE/DATETIME wrap as { "$date": iso }; RICH_TEXT
+// is an HTML string stored verbatim; IMAGE urls are imported to Wix Media first.
+async function buildItemData(ctx, col, item, idsByCollection, multiRefs, itemIndex, counters) {
+  const fieldsByKey = new Map((col.fields ?? []).map((f) => [f.key, f]));
+  const data = {};
+  for (const [key, value] of Object.entries(item)) {
+    const f = fieldsByKey.get(key);
+    // A key the schema doesn't have is silently dropped by the API — fail loud instead.
+    if (!f) throw new Error(`"${col.id}" item ${itemIndex}: key "${key}" is not in the collection's fields`);
+    if (value == null) continue;
+    if (f.type === "MULTI_REFERENCE") {
+      for (const targetIndex of [].concat(value)) {
+        multiRefs.push({ itemIndex, fieldKey: key, targetCollectionId: f.referencedCollectionId, targetIndex });
+      }
+      continue;
+    }
+    if (f.type === "REFERENCE") {
+      const targetId = (idsByCollection.get(f.referencedCollectionId) ?? [])[value];
+      if (!targetId) {
+        throw new Error(
+          `"${col.id}" item ${itemIndex}: REFERENCE "${key}" -> "${f.referencedCollectionId}"[${value}] — ` +
+            `target not created yet (order collections so targets come first)`,
+        );
+      }
+      data[key] = targetId;
+      continue;
+    }
+    if (f.type === "IMAGE") {
+      try {
+        const file = await importImage(ctx, value, `${col.id}-${itemIndex}-${key}.png`);
+        data[key] = file.url;
+        counters.imagesImported++;
+      } catch {
+        /* never block on image failure — the item stays text-only */
+      }
+      continue;
+    }
+    if (f.type === "DATE" || f.type === "DATETIME") {
+      data[key] = { $date: new Date(value).toISOString() };
+      continue;
+    }
+    data[key] = value;
+  }
+  return data;
+}
+
+/**
+ * ONE-CALL seed: install → per collection (in plan order): create → import images →
+ * bulk-insert → wire multi-references → verify; ids threaded in memory. The default path.
+ */
+export async function setupCms(ctx, { collections = [] } = {}) {
+  await installDataApp(ctx);
+
+  const idsByCollection = new Map();
+  const out = { collections: [] };
+  for (const col of collections) {
+    const created = await createCollection(ctx, col);
+
+    const counters = { imagesImported: 0 };
+    const multiRefs = [];
+    const dataItems = [];
+    const planItems = col.items ?? [];
+    for (let i = 0; i < planItems.length; i++) {
+      dataItems.push(await buildItemData(ctx, col, planItems[i], idsByCollection, multiRefs, i, counters));
+    }
+
+    let ids = [];
+    let failures = 0;
+    if (dataItems.length) ({ ids, failures } = await bulkInsertItems(ctx, col.id, dataItems));
+    idsByCollection.set(col.id, ids);
+
+    const refs = multiRefs.map(({ itemIndex, fieldKey, targetCollectionId, targetIndex }) => {
+      const referringItemId = ids[itemIndex];
+      const referencedItemId = (idsByCollection.get(targetCollectionId) ?? [])[targetIndex];
+      if (!referringItemId || !referencedItemId) {
+        throw new Error(
+          `"${col.id}" item ${itemIndex}: multi-reference "${fieldKey}" -> "${targetCollectionId}"[${targetIndex}] ` +
+            `has no created id (order collections so targets come first)`,
+        );
+      }
+      return { referringItemFieldName: fieldKey, referringItemId, referencedItemId };
+    });
+    const referencesLinked = await insertReferences(ctx, col.id, refs);
+
+    out.collections.push({
+      id: col.id,
+      created: created.created,
+      inserted: ids.length,
+      failures,
+      imagesImported: counters.imagesImported,
+      referencesLinked,
+      itemsInCollection: await verifyItems(ctx, col.id),
+    });
+  }
+  return out;
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-cms.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupCms(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/events/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/events/INSTRUCTIONS.md
@@ -1,0 +1,149 @@
+# Events — playbook
+
+The events machinery ships as files — event reads (list, by slug, by id), the visitor-public
+ticket-tier read, the exact `reserve → hosted-checkout redirect` sequence, and RSVP, typed
+end-to-end. **The presentation is yours**: you design and implement the event card, the
+events index, and the event page's registration surface on the shipped hooks/DTOs, plus the
+home page and the brand. You never write registration logic; you never skip designing.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/events/types.ts` | the DTOs (`EventSummary`, `EventDetail`, `TicketTier`, `RegistrationResult`) — contracts below |
+| `wix/events/events.ts` | `fetchEvents`, `fetchEventBySlug`, `fetchEventById` (post-checkout confirmation read) |
+| `wix/events/registration.ts` | `fetchTicketTiers`, `startTicketCheckout`, `submitRsvp` — the exact reserve→redirect sequence lives here |
+| `hooks/events/useEvents.ts` | listing + category filter — contract below |
+| `hooks/events/useEventRegistration.ts` | the whole registration state machine — contract below |
+| `components/events/EventsView.tsx` (+ `EventCard`) · `EventRegistrationView.tsx` · `EventConfirmationView.tsx` | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot + global.css import). If another vertical is also deployed, its layout won — add an Events nav link there |
+| `pages/events.astro` | SSR listing — **keep the frontmatter**, swap the island import to YOUR component |
+| `pages/events/[slug].astro` | SSR detail + registration with owner-editable SEO — **keep the frontmatter and the SEO pieces** (`wixMetadata`, `loadSEOTagsServiceConfig`, `<SEO.Tags>`) exactly; swap the island import. The registration island stays `client:only="react"` |
+| `pages/event-confirmation.astro` | the hosted checkout's thank-you landing (`?orderNumber=&eventId=`) — **keep the route**; the shipped checkout callbacks point at it |
+
+## What you build — the design job
+
+1. **The event card + events index** — your tile (image, date eyebrow, title,
+   venue/online, price-from, sold-out badge) and rhythm, with the category filter (only when
+   >1 category), skeletons while loading, and an honest empty state — on `useEvents`.
+2. **The event page's registration surface** — branch on `event.registrationType`:
+   `TICKETING` → your tier picker (name, description, price, quantity stepper capped by
+   `limitPerCheckout`, non-`SALE_STARTED` tiers unbuyable) and the checkout CTA; `RSVP` →
+   the built-in first/last/email form (a "can't make it" option only when
+   `rsvpResponseType === "YES_AND_NO"`) and the confirmed/waitlist states; `EXTERNAL` →
+   link out; closed → an honest closed state — on `useEventRegistration`, which owns ALL
+   registration logic; you own how it looks.
+3. **The home page** — hero, featured/next events (fetch in frontmatter → your components),
+   brand story.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// EventSummary (tiles) — display-ready:
+// { id, slug, title, shortDescription /* plain text */, dateLabel /* "Sep 26, 2026, 7:00 PM" */,
+//   startDateIso, locationName, locationType: "VENUE"|"ONLINE"|"TBD", imageUrl,
+//   registrationType: "RSVP"|"TICKETING"|"EXTERNAL"|"NONE",
+//   priceLabel /* "From €25.00" | "Free" | "" */, soldOut, categories: [{id,name}] }
+// EventDetail adds: aboutParagraphs: string[], registrationOpen, rsvpResponseType,
+//   externalUrl, addToCalendar: { google, ics }.
+// TicketTier: { id, name, description, price /* "€45.00" | "Free" */, free,
+//   limitPerCheckout, saleStatus /* only "SALE_STARTED" is buyable */ }
+
+// useEvents({ initialEvents? }) →
+// { events: EventSummary[]|null /* null = loading → skeletons */,
+//   categories: [{id,name}] /* derived from the loaded events */,
+//   activeCategoryId, setActiveCategoryId(id|null), error }
+
+// useEventRegistration(event: EventDetail) →
+// { tiers: TicketTier[]|null,                    // TICKETING only; null = loading
+//   quantities, setQuantity(tierId, qty),        // clamped; sale-status gated
+//   ticketCount, canCheckout,                    // gate the tickets CTA on canCheckout
+//   checkout(): Promise<RegistrationResult>,     // reserve → the browser redirects to Wix checkout
+//   rsvpValues, setRsvpValue(field, value),      // built-in fields: firstName/lastName/email
+//   canRsvp,                                     // gate the RSVP CTA on this
+//   rsvp(attending?): Promise<RegistrationResult>, // attending=false only for YES_AND_NO
+//   submitting, confirmed, error }               // confirmed: rsvpConfirmed with status
+//                                                //   "YES" | "NO" | "WAITLIST" (tell the guest!)
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — merge into the
+   existing layout instead if another vertical is deployed).
+2. Write your components under `src/components/events/` (new names — don't overwrite the
+   references), swap the island imports in `pages/events.astro` and
+   `pages/events/[slug].astro`. Listing island: `client:load` with the SSR props;
+   registration island: `client:only="react"`. Keep `pages/event-confirmation.astro`'s route.
+   **Author your surfaces in as few messages as possible** — batch multiple Writes per
+   message.
+3. Write `pages/index.astro` (home) — it exists from the scaffold; Read it before overwriting.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/events` → your listing; `/events/:slug` → fetch
+with `fetchEventBySlug(slug)` client-side, then your registration surface;
+`/event-confirmation` → the confirmation view (the checkout callbacks point at that path).
+
+## Hard rules
+
+- **Registration logic only through the shipped exports** — `useEventRegistration` /
+  `startTicketCheckout` / `submitRsvp` own the sequence (visitor-public tier read, reserve,
+  `createRedirectSession({ eventsCheckout })`, rsvpV2). Never re-derive any of it, never
+  hand-build a checkout/ticket-form URL, never route it through an API route or elevate —
+  the whole flow runs client-side as the visitor.
+- **Branch on `registrationType`** — never render an RSVP event with a ticket picker or a
+  ticketed event with an RSVP form; respect `registrationOpen`.
+- **The RSVP form is built-in** — exactly first name, last name, email; never fetch a form
+  schema or add fields.
+- **Gate CTAs on `canCheckout` / `canRsvp`** and surface `error` — `checkout()`/`rsvp()` can
+  reject (sold out, sale ended, duplicate email, payment method not configured); the message
+  is for the visitor.
+- **Confirmed states reflect REAL success**: RSVP → render only from `confirmed` (and say
+  "waitlisted", not "confirmed", for status `WAITLIST`). Tickets → the only success surface
+  is `/event-confirmation` with Wix's `?orderNumber=` params; a visitor merely returning to
+  the event page is NOT a success signal.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Live data or an honest empty state — never mock events, tiers, or "X spots left".
+- Keep the detail page's SEO pieces exactly as shipped.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link plus the Events page — the deploy step's JSON printed
+`dashboardUrl`; append `/events` for event management. **Selling paid tickets needs a premium
+plan + a connected payment method** (free/RSVP events work without) — mention it.
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-events.mjs` from the project root.
+Seed events that exercise the UI (a ticketed event with 2 tiers, another ticketed one, a free
+RSVP event; future dates; an image per event).
+
+## Verify (before declaring done)
+
+- [ ] `/events` renders live events SSR (view-source shows titles) through YOUR components;
+      empty catalog shows your honest empty state.
+- [ ] An event page branches correctly: ticketed shows your tier picker (prices, steppers,
+      CTA disabled at zero tickets); RSVP shows the three-field form.
+- [ ] An RSVP submits end-to-end: `rsvp()` resolves, your confirmed state renders.
+- [ ] A ticketed checkout reserves and redirects to the Wix-hosted checkout (or surfaces the
+      "connect a payment method" message when the site has none — that's correct behavior).
+- [ ] `/event-confirmation` renders (the honest no-order state on a direct visit).
+- [ ] Event page view-source carries the SEO tags (Astro).
+- [ ] Card/index/registration surfaces/home are YOUR designs on the tokens; data-layer/hook
+      files unedited.
+- [ ] Dashboard links handed to the owner (+ the paid-tickets premium note when relevant).

--- a/skills/wix-headless-fast/references/events/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/events/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,40 @@
+---
+// The site chrome for every events page — THIS file (header/footer/nav) plus the @theme
+// token block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" />
+// in <head> and the global.css import. (Deploy is fill-only: if another vertical is already
+// deployed, its SiteLayout won — merge an Events nav link there instead.)
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <a href="/events" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Events</a>
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/events/app-astro/pages/event-confirmation.astro
+++ b/skills/wix-headless-fast/references/events/app-astro/pages/event-confirmation.astro
@@ -1,0 +1,12 @@
+---
+// Post-checkout thank-you page — the Wix-hosted checkout redirects here with
+// ?orderNumber=&eventId=. KEEP THIS ROUTE: the data layer's checkout callbacks point at
+// /event-confirmation. The island is client:only (it reads the browser URL); swap its
+// import to YOUR confirmation component if you design one.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import EventConfirmationView from "../components/events/EventConfirmationView";
+---
+
+<SiteLayout title="Order confirmed">
+  <EventConfirmationView client:only="react" />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/events/app-astro/pages/events.astro
+++ b/skills/wix-headless-fast/references/events/app-astro/pages/events.astro
@@ -1,0 +1,21 @@
+---
+// Events listing — data fetched SERVER-SIDE (SEO) and handed to the island as DTO props.
+// Keep this frontmatter; swap the island import to YOUR listing component.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import EventsView from "../components/events/EventsView";
+import { fetchEvents } from "../wix/events/events";
+import type { EventSummary } from "../wix/events/types";
+
+let events: EventSummary[] = [];
+try {
+  events = await fetchEvents();
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // empty state instead.
+}
+---
+
+<SiteLayout title="Events">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Events</h1>
+  <EventsView client:load initialEvents={events} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/events/app-astro/pages/events/[slug].astro
+++ b/skills/wix-headless-fast/references/events/app-astro/pages/events/[slug].astro
@@ -1,0 +1,80 @@
+---
+// Event detail + registration page.
+//
+// This is a Wix ITEM PAGE: the wixMetadata export + <SEO.Tags> below let the site owner edit
+// this page's title/description/OG in the dashboard and register the route in the sitemap.
+// Keep all three SEO pieces and this frontmatter; swap the island import to YOUR registration
+// component. The registration island is client:only — it runs visitor-session calls and
+// redirects.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import EventRegistrationView from "../../components/events/EventRegistrationView";
+import { fetchEventBySlug } from "../../wix/events/events";
+import { WIX_APPS } from "@wix/essentials";
+import { SEO } from "@wix/seo/components";
+import { loadSEOTagsServiceConfig } from "@wix/seo/services";
+import { seoTags } from "@wix/seo";
+
+export const wixMetadata = {
+  appDefId: WIX_APPS.events.id,
+  pageIdentifier: WIX_APPS.events.eventPageMetadata.pageIdentifier,
+  identifiers: {
+    slug: WIX_APPS.events.eventPageMetadata.identifiers.slug,
+  },
+};
+
+const slug = Astro.params.slug!;
+
+// Behind Wix's proxy the request URL is internal — the real public page URL arrives on
+// x-wix-forwarded-url; the SEO service needs the public one.
+const forwardedUrl = Astro.request.headers.get("x-wix-forwarded-url");
+const pageUrl =
+  forwardedUrl && URL.canParse(forwardedUrl) && /^https?:$/.test(new URL(forwardedUrl).protocol)
+    ? forwardedUrl
+    : Astro.url.href;
+
+let event = null;
+let seoTagsServiceConfig = null;
+try {
+  [event, seoTagsServiceConfig] = await Promise.all([
+    fetchEventBySlug(slug),
+    loadSEOTagsServiceConfig({
+      pageUrl,
+      itemType: seoTags.ItemType.EVENTS_PAGE,
+      itemData: { slug },
+    }).catch(() => null),
+  ]);
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!event) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<SiteLayout title={event.title}>
+  <SEO.Tags seoTagsServiceConfig={seoTagsServiceConfig} slot="seo-tags" />
+
+  <div class="grid gap-10 md:grid-cols-2">
+    <div>
+      {event.imageUrl && (
+        <div class="aspect-[3/2] overflow-hidden rounded-xl bg-secondary">
+          <img src={event.imageUrl} alt={event.title} class="h-full w-full object-cover" />
+        </div>
+      )}
+      {event.dateLabel && <p class="eyebrow mt-5">{event.dateLabel}</p>}
+      <h1 class="mt-1 text-2xl font-semibold tracking-tight">{event.title}</h1>
+      <p class="mt-1 text-sm text-muted-foreground">
+        {event.locationType === "ONLINE" ? "Online event" : event.locationName}
+        {event.priceLabel ? ` · ${event.priceLabel}` : ""}
+      </p>
+      {event.shortDescription && <p class="mt-4 text-sm leading-relaxed text-muted-foreground">{event.shortDescription}</p>}
+      {event.aboutParagraphs.map((p) => (
+        <p class="mt-3 text-sm leading-relaxed text-muted-foreground">{p}</p>
+      ))}
+    </div>
+    <div>
+      <EventRegistrationView client:only="react" event={event} />
+    </div>
+  </div>
+</SiteLayout>

--- a/skills/wix-headless-fast/references/events/app/components/events/EventConfirmationView.tsx
+++ b/skills/wix-headless-fast/references/events/app/components/events/EventConfirmationView.tsx
@@ -1,0 +1,66 @@
+// REFERENCE post-checkout confirmation: the Wix-hosted checkout redirects to
+// /event-confirmation?orderNumber=&eventId= on success — this island reads those params and
+// fetches the event for context. Mount client:only (it reads the browser URL). Landing here
+// IS the success signal for a ticket order (Wix redirects only after checkout completes);
+// the ticket PDF/QR arrives by email — echo the order number, don't invent order details.
+import { useEffect, useState } from "react";
+import { fetchEventById } from "../../wix/events/events";
+import type { EventDetail } from "../../wix/events/types";
+
+export default function EventConfirmationView({ eventsHref = "/events" }: { eventsHref?: string }) {
+  const [params] = useState(() => {
+    if (typeof window === "undefined") return { orderNumber: "", eventId: "" };
+    const q = new URLSearchParams(window.location.search);
+    return { orderNumber: q.get("orderNumber") ?? "", eventId: q.get("eventId") ?? "" };
+  });
+  const [event, setEvent] = useState<EventDetail | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (params.eventId) {
+      fetchEventById(params.eventId).then((e) => alive && setEvent(e));
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.eventId]);
+
+  if (!params.orderNumber) {
+    // Direct visit with no order in the URL — an honest state, not a fake confirmation.
+    return (
+      <div className="mx-auto max-w-lg py-16 text-center">
+        <p className="text-lg font-semibold">No order to show</p>
+        <a href={eventsHref} className="mt-4 inline-block text-sm text-foreground underline">
+          Browse events
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-lg py-16 text-center">
+      <p className="eyebrow">Order {params.orderNumber}</p>
+      <h1 className="mt-2 text-2xl font-semibold tracking-tight">You're going! 🎟️</h1>
+      <p className="mt-3 text-sm text-muted-foreground">
+        {event ? `${event.title}${event.dateLabel ? ` — ${event.dateLabel}` : ""}. ` : ""}
+        Your tickets are on their way to your email.
+      </p>
+      {event?.addToCalendar.google && (
+        <a
+          href={event.addToCalendar.google}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-6 inline-block rounded-full border border-border px-6 py-2.5 text-sm font-medium text-foreground no-underline transition-colors hover:bg-secondary"
+        >
+          Add to Google Calendar
+        </a>
+      )}
+      <div className="mt-4">
+        <a href={eventsHref} className="text-sm text-muted-foreground underline">
+          Back to events
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/events/app/components/events/EventRegistrationView.tsx
+++ b/skills/wix-headless-fast/references/events/app/components/events/EventRegistrationView.tsx
@@ -1,0 +1,176 @@
+// REFERENCE registration surface: branches on event.registrationType — TICKETING renders
+// the tier picker (quantity steppers → checkout CTA), RSVP the built-in name+email form,
+// EXTERNAL a link out, NONE/closed an honest closed state — on the @theme tokens. Correct
+// and complete; per the skill's model you design and build your own on useEventRegistration.
+// Mount client:only — it runs visitor-session SDK calls and redirects.
+import { useEventRegistration } from "../../hooks/events/useEventRegistration";
+import type { EventDetail } from "../../wix/events/types";
+
+const input =
+  "w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-shadow focus:ring-2 focus:ring-primary";
+const cta =
+  "mt-5 rounded-full bg-primary px-8 py-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50";
+
+export default function EventRegistrationView({ event }: { event: EventDetail }) {
+  const {
+    tiers,
+    quantities,
+    setQuantity,
+    ticketCount,
+    canCheckout,
+    checkout,
+    rsvpValues,
+    setRsvpValue,
+    canRsvp,
+    rsvp,
+    submitting,
+    confirmed,
+    error,
+  } = useEventRegistration(event);
+
+  if (confirmed && confirmed.kind === "rsvpConfirmed") {
+    return (
+      <div className="rounded-lg border border-border bg-secondary p-8 text-center">
+        <p className="text-lg font-semibold">
+          {confirmed.status === "WAITLIST"
+            ? "You're on the waitlist"
+            : confirmed.status === "NO"
+              ? "Thanks for letting us know"
+              : "You're in! 🎉"}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {confirmed.status === "WAITLIST"
+            ? `${event.title} is full — we'll email you if a spot opens up.`
+            : confirmed.status === "NO"
+              ? "We've recorded that you can't make it."
+              : `See you at ${event.title}${event.dateLabel ? ` — ${event.dateLabel}` : ""}. A confirmation email is on its way.`}
+        </p>
+      </div>
+    );
+  }
+
+  if (!event.registrationOpen) {
+    return (
+      <div className="rounded-lg border border-border p-6 text-sm text-muted-foreground">
+        {event.soldOut ? "This event is sold out." : "Registration for this event is closed."}
+      </div>
+    );
+  }
+
+  if (event.registrationType === "EXTERNAL") {
+    return (
+      <a href={event.externalUrl} className={`${cta} inline-block no-underline`} target="_blank" rel="noreferrer">
+        Register ↗
+      </a>
+    );
+  }
+
+  if (event.registrationType === "TICKETING") {
+    return (
+      <div>
+        <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Tickets</p>
+        {tiers === null ? (
+          <div className="space-y-3" aria-busy="true">
+            {Array.from({ length: 2 }, (_, i) => (
+              <div key={i} className="h-16 animate-pulse rounded-lg bg-secondary" />
+            ))}
+          </div>
+        ) : tiers.length === 0 ? (
+          <p className="rounded-md border border-border p-4 text-sm text-muted-foreground">
+            Tickets aren't available right now.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {tiers.map((t) => {
+              const onSale = t.saleStatus === "SALE_STARTED";
+              const qty = quantities[t.id] ?? 0;
+              return (
+                <div key={t.id} className="flex items-center justify-between gap-4 rounded-lg border border-border p-4">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{t.name}</p>
+                    {t.description && <p className="mt-0.5 text-xs text-muted-foreground">{t.description}</p>}
+                    <p className="mt-1 text-sm text-foreground">{t.price}</p>
+                    {!onSale && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {t.saleStatus === "SALE_SCHEDULED" ? "Sale hasn't started yet" : "Sale ended"}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      aria-label={`Fewer ${t.name}`}
+                      disabled={!onSale || qty === 0}
+                      onClick={() => setQuantity(t.id, qty - 1)}
+                      className="h-8 w-8 rounded-full border border-border text-foreground transition-colors hover:bg-secondary disabled:opacity-40"
+                    >
+                      −
+                    </button>
+                    <span className="w-6 text-center text-sm tabular-nums">{qty}</span>
+                    <button
+                      type="button"
+                      aria-label={`More ${t.name}`}
+                      disabled={!onSale || qty >= t.limitPerCheckout}
+                      onClick={() => setQuantity(t.id, qty + 1)}
+                      className="h-8 w-8 rounded-full border border-border text-foreground transition-colors hover:bg-secondary disabled:opacity-40"
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        <button type="button" disabled={!canCheckout || submitting} onClick={() => checkout().catch(() => {})} className={cta}>
+          {submitting ? "Reserving…" : ticketCount > 0 ? `Get ${ticketCount} ticket${ticketCount > 1 ? "s" : ""}` : "Get tickets"}
+        </button>
+      </div>
+    );
+  }
+
+  if (event.registrationType === "RSVP") {
+    return (
+      <div>
+        <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">RSVP</p>
+        <div className="grid max-w-md gap-3">
+          <label className="block">
+            <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">First name</span>
+            <input type="text" value={rsvpValues.firstName} onChange={(e) => setRsvpValue("firstName", e.target.value)} className={input} />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">Last name</span>
+            <input type="text" value={rsvpValues.lastName} onChange={(e) => setRsvpValue("lastName", e.target.value)} className={input} />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">Email</span>
+            <input type="email" value={rsvpValues.email} onChange={(e) => setRsvpValue("email", e.target.value)} className={input} />
+          </label>
+        </div>
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        <div className="flex items-center gap-3">
+          <button type="button" disabled={!canRsvp || submitting} onClick={() => rsvp(true).catch(() => {})} className={cta}>
+            {submitting ? "Sending…" : "Count me in"}
+          </button>
+          {event.rsvpResponseType === "YES_AND_NO" && (
+            <button
+              type="button"
+              disabled={!canRsvp || submitting}
+              onClick={() => rsvp(false).catch(() => {})}
+              className="mt-5 rounded-full border border-border px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+            >
+              Can't make it
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border p-6 text-sm text-muted-foreground">
+      Registration isn't open for this event.
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/events/app/components/events/EventsView.tsx
+++ b/skills/wix-headless-fast/references/events/app/components/events/EventsView.tsx
@@ -1,0 +1,118 @@
+// REFERENCE listing surface: category filter + events grid on the @theme tokens.
+// Correct and complete; per the skill's model you design and build your own on useEvents.
+import type { ComponentType, ReactNode } from "react";
+import { useEvents } from "../../hooks/events/useEvents";
+import type { EventSummary } from "../../wix/events/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface EventCardProps {
+  event: EventSummary;
+  eventHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function EventCard({
+  event,
+  eventHref = (slug) => `/events/${slug}`,
+  LinkComponent = PlainLink,
+}: EventCardProps) {
+  return (
+    <LinkComponent href={eventHref(event.slug)} className="group block no-underline">
+      <div className="relative aspect-[3/2] overflow-hidden rounded-lg bg-secondary">
+        {event.imageUrl && (
+          <img
+            src={event.imageUrl}
+            alt={event.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        )}
+        {event.soldOut && (
+          <span className="absolute left-3 top-3 rounded-full bg-background/90 px-3 py-1 text-xs font-semibold text-foreground backdrop-blur">
+            Sold out
+          </span>
+        )}
+      </div>
+      {event.dateLabel && <p className="eyebrow mt-3">{event.dateLabel}</p>}
+      <p className="mt-1 text-sm font-medium text-foreground">{event.title}</p>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        {event.locationType === "ONLINE" ? "Online" : event.locationName}
+        {event.priceLabel ? ` · ${event.priceLabel}` : ""}
+      </p>
+    </LinkComponent>
+  );
+}
+
+export interface EventsViewProps {
+  initialEvents?: EventSummary[];
+  emptyMessage?: string;
+  eventHref?: EventCardProps["eventHref"];
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<EventCardProps>;
+}
+
+const pill = (active: boolean) =>
+  `rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+    active
+      ? "border-primary bg-primary text-primary-foreground"
+      : "border-border text-foreground hover:bg-secondary"
+  }`;
+
+export default function EventsView({
+  initialEvents,
+  emptyMessage = "No upcoming events — check back soon.",
+  eventHref,
+  LinkComponent,
+  CardComponent = EventCard,
+}: EventsViewProps) {
+  const { events, categories, activeCategoryId, setActiveCategoryId, error } = useEvents({
+    initialEvents,
+  });
+
+  return (
+    <div>
+      {categories.length > 1 && (
+        <div className="mb-8 flex flex-wrap gap-2" role="group" aria-label="Categories">
+          <button type="button" className={pill(activeCategoryId === null)} onClick={() => setActiveCategoryId(null)}>
+            All
+          </button>
+          {categories.map((c) => (
+            <button key={c.id} type="button" className={pill(activeCategoryId === c.id)} onClick={() => setActiveCategoryId(c.id)}>
+              {c.name}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {events === null ? (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i}>
+              <div className="aspect-[3/2] animate-pulse rounded-lg bg-secondary" />
+              <div className="mt-3 h-3.5 w-2/3 animate-pulse rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      ) : events.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {events.map((e) => (
+            <CardComponent key={e.id} event={e} eventHref={eventHref} LinkComponent={LinkComponent} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/events/app/hooks/events/useEventRegistration.ts
+++ b/skills/wix-headless-fast/references/events/app/hooks/events/useEventRegistration.ts
@@ -1,0 +1,117 @@
+// The whole registration state machine for one event, branched on event.registrationType:
+// TICKETING loads the tier picker and checkout() reserves → redirects to Wix's hosted
+// checkout; RSVP is the built-in name+email form submitted in place. All correctness (the
+// visitor-public tier read, the reservation payload, the redirect callbacks, rsvpV2) lives
+// in the data layer — this hook orchestrates; you own how it looks.
+import { useEffect, useMemo, useState } from "react";
+import { fetchTicketTiers, startTicketCheckout, submitRsvp } from "../../wix/events/registration";
+import type { EventDetail, RegistrationResult, TicketTier } from "../../wix/events/types";
+
+export interface UseEventRegistration {
+  /** TICKETING: tiers for the picker — null while loading (skeletons), [] honest empty. Other types: []. */
+  tiers: TicketTier[] | null;
+  /** Selected quantity per tier id (0 when untouched). */
+  quantities: Record<string, number>;
+  /** Clamped to 0..limitPerCheckout; ignored for tiers not on sale (saleStatus gate). */
+  setQuantity: (tierId: string, quantity: number) => void;
+  ticketCount: number;
+  /** True when ≥ 1 ticket is selected — gate the checkout CTA on this. */
+  canCheckout: boolean;
+  /** Reserves + redirects to the Wix-hosted checkout. On "redirect" the browser is navigating. */
+  checkout: () => Promise<RegistrationResult>;
+  /** RSVP form state — the built-in fields, exactly these. */
+  rsvpValues: { firstName: string; lastName: string; email: string };
+  setRsvpValue: (field: "firstName" | "lastName" | "email", value: string) => void;
+  /** True when every RSVP field is filled — gate the RSVP CTA on this. */
+  canRsvp: boolean;
+  /** attending=false only when event.rsvpResponseType is "YES_AND_NO". */
+  rsvp: (attending?: boolean) => Promise<RegistrationResult>;
+  submitting: boolean;
+  /** Set after an RSVP completes (kind "rsvpConfirmed"; status may be "WAITLIST"). */
+  confirmed: RegistrationResult | null;
+  error: string | null;
+}
+
+export function useEventRegistration(event: EventDetail): UseEventRegistration {
+  const ticketed = event.registrationType === "TICKETING";
+  const [tiers, setTiers] = useState<TicketTier[] | null>(ticketed ? null : []);
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [rsvpValues, setRsvpValues] = useState({ firstName: "", lastName: "", email: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmed, setConfirmed] = useState<RegistrationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ticketed) return;
+    let alive = true;
+    setTiers(null);
+    setQuantities({});
+    fetchTicketTiers(event.id)
+      .then((t) => alive && setTiers(t))
+      .catch((e) => {
+        if (!alive) return;
+        setTiers([]);
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event.id, ticketed]);
+
+  const setQuantity = (tierId: string, quantity: number) => {
+    const tier = (tiers ?? []).find((t) => t.id === tierId);
+    if (!tier || tier.saleStatus !== "SALE_STARTED") return;
+    const clamped = Math.max(0, Math.min(quantity, tier.limitPerCheckout || 20));
+    setQuantities((q) => ({ ...q, [tierId]: clamped }));
+  };
+
+  const ticketCount = useMemo(
+    () => Object.values(quantities).reduce((sum, q) => sum + q, 0),
+    [quantities],
+  );
+  const canRsvp = (["firstName", "lastName", "email"] as const).every(
+    (f) => rsvpValues[f].trim().length > 0,
+  );
+
+  async function run(op: () => Promise<RegistrationResult>): Promise<RegistrationResult> {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await op();
+      if (result.kind === "redirect") {
+        window.location.href = result.url;
+      } else {
+        setConfirmed(result);
+      }
+      return result;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return {
+    tiers,
+    quantities,
+    setQuantity,
+    ticketCount,
+    canCheckout: ticketCount > 0,
+    checkout: () =>
+      run(() =>
+        startTicketCheckout(
+          event,
+          Object.entries(quantities).map(([tierId, quantity]) => ({ tierId, quantity })),
+        ),
+      ),
+    rsvpValues,
+    setRsvpValue: (field, value) => setRsvpValues((v) => ({ ...v, [field]: value })),
+    canRsvp,
+    rsvp: (attending = true) => run(() => submitRsvp(event.id, rsvpValues, attending ? "YES" : "NO")),
+    submitting,
+    confirmed,
+    error,
+  };
+}

--- a/skills/wix-headless-fast/references/events/app/hooks/events/useEvents.ts
+++ b/skills/wix-headless-fast/references/events/app/hooks/events/useEvents.ts
@@ -1,0 +1,59 @@
+// Events listing + category filter. SSR-friendly: pass server-fetched data as `initialEvents`
+// (Astro frontmatter / server component) and no client fetch happens; a SPA passes nothing.
+// The category menu is DERIVED from the loaded events (the categories management API is
+// admin-scope — visitors can't query it); filtering is client-side.
+import { useEffect, useMemo, useState } from "react";
+import { fetchEvents } from "../../wix/events/events";
+import type { EventSummary } from "../../wix/events/types";
+
+export interface UseEventsOptions {
+  initialEvents?: EventSummary[];
+}
+
+export interface UseEvents {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  events: EventSummary[] | null;
+  /** Unique assigned categories in listing order — render a filter bar only when > 1. */
+  categories: { id: string; name: string }[];
+  activeCategoryId: string | null;
+  setActiveCategoryId: (id: string | null) => void;
+  error: string | null;
+}
+
+export function useEvents({ initialEvents }: UseEventsOptions = {}): UseEvents {
+  const [all, setAll] = useState<EventSummary[] | null>(initialEvents ?? null);
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialEvents) {
+      fetchEvents()
+        .then((e) => alive && setAll(e))
+        .catch((e) => {
+          if (!alive) return;
+          setAll([]);
+          setError(e instanceof Error ? e.message : String(e));
+        });
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const categories = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const e of all ?? []) for (const c of e.categories) if (!seen.has(c.id)) seen.set(c.id, c.name);
+    return [...seen.entries()].map(([id, name]) => ({ id, name }));
+  }, [all]);
+
+  const events = useMemo(() => {
+    if (all === null) return null;
+    return activeCategoryId
+      ? all.filter((e) => e.categories.some((c) => c.id === activeCategoryId))
+      : all;
+  }, [all, activeCategoryId]);
+
+  return { events, categories, activeCategoryId, setActiveCategoryId, error };
+}

--- a/skills/wix-headless-fast/references/events/app/wix/events/events.ts
+++ b/skills/wix-headless-fast/references/events/app/wix/events/events.ts
@@ -1,0 +1,134 @@
+// Event reads (Wix Events V3, the `wixEventsV2` module) — the only file that touches raw
+// event entities. Everything it returns is a plain DTO from ./types. Copy as-is; extend by
+// adding functions, not by editing these.
+import { wixEventsV2 } from "@wix/events";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { EventDetail, EventSummary, RegistrationType } from "./types";
+
+const events = wixModule(wixEventsV2);
+
+/** The Wix Events app id (reference only — frontend calls need no app-id constant). */
+export const EVENTS_APP_ID = "140603ad-af8d-84a5-2c80-a0f60cb47351";
+
+type Raw = Record<string, any>;
+
+// Fieldsets are opt-in: without REGISTRATION there's no registration type to branch on;
+// without CATEGORIES the category names never arrive; DETAILS carries the formatted date
+// and mainImage; TEXTS carries the long description.
+const LIST_FIELDS = ["DETAILS", "REGISTRATION", "CATEGORIES"];
+const DETAIL_FIELDS = ["DETAILS", "TEXTS", "REGISTRATION", "URLS", "CATEGORIES"];
+
+function lowestPriceLabel(reg: Raw): string {
+  const type = reg.type ?? reg.initialType;
+  if (type === "RSVP") return "Free";
+  if (type !== "TICKETING") return "";
+  const lowest: Raw | undefined = reg.tickets?.lowestPrice;
+  if (!lowest) return "";
+  if (Number(lowest.value ?? 0) === 0) return "Free";
+  if (lowest.formattedValue) return `From ${lowest.formattedValue}`;
+  try {
+    return `From ${new Intl.NumberFormat(undefined, { style: "currency", currency: lowest.currency || "USD" }).format(Number(lowest.value))}`;
+  } catch {
+    return `From ${lowest.value} ${lowest.currency ?? ""}`.trim();
+  }
+}
+
+// event.description is Ricos rich content ({ nodes: [...] }), NOT a string — calling string
+// methods on it crashes the page. Extract plain paragraphs; detailedDescription (legacy plain
+// text) is the fallback.
+function toParagraphs(rich: Raw | undefined, legacy: string | undefined): string[] {
+  const collect = (nodes: Raw[] | undefined): string =>
+    (nodes ?? [])
+      .map((n: Raw) => (typeof n.textData?.text === "string" ? n.textData.text : collect(n.nodes)))
+      .join("");
+  const out: string[] = [];
+  for (const node of rich?.nodes ?? []) {
+    const text = collect([node]).trim();
+    if (text) out.push(text);
+  }
+  if (!out.length && legacy) out.push(legacy);
+  return out;
+}
+
+function toSummary(raw: Raw): EventSummary {
+  const reg: Raw = raw.registration ?? {};
+  const dts: Raw = raw.dateAndTimeSettings ?? {};
+  return {
+    id: raw._id ?? "", // _id, never .id — `id` is a REST-view field and is undefined here
+    slug: raw.slug ?? "",
+    title: raw.title ?? "",
+    shortDescription: raw.shortDescription ?? "",
+    dateLabel: dts.formatted?.dateAndTime ?? "",
+    startDateIso: dts.startDate ? new Date(dts.startDate).toISOString() : "",
+    locationName: raw.location?.name ?? "",
+    locationType: raw.location?.locationTbd
+      ? "TBD"
+      : ((raw.location?.type as "VENUE" | "ONLINE") ?? "TBD"),
+    imageUrl: imgSrc(raw.mainImage, 1200, 800),
+    // `type` is the current flavor (can become EXTERNAL later); initialType is the immutable
+    // seeded one — read type first.
+    registrationType: (reg.type ?? reg.initialType ?? "NONE") as RegistrationType,
+    priceLabel: lowestPriceLabel(reg),
+    soldOut: reg.tickets?.soldOut === true,
+    // `categories` is absent on the typed Event (an SDK type gap) — the Raw boundary reads
+    // the runtime field the CATEGORIES fieldset populates.
+    categories: (raw.categories?.categories ?? [])
+      .map((c: Raw) => ({ id: c._id ?? "", name: c.name ?? "" }))
+      .filter((c: { id: string }) => c.id),
+  };
+}
+
+function toDetail(raw: Raw): EventDetail {
+  const summary = toSummary(raw);
+  const reg: Raw = raw.registration ?? {};
+  return {
+    ...summary,
+    aboutParagraphs: toParagraphs(raw.description, raw.detailedDescription),
+    // Only OPEN_* statuses (OPEN_RSVP, OPEN_TICKETS, OPEN_EXTERNAL, …) accept registrations.
+    registrationOpen: typeof reg.status === "string" && reg.status.startsWith("OPEN_"),
+    rsvpResponseType: reg.rsvp?.responseType === "YES_AND_NO" ? "YES_AND_NO" : "YES_ONLY",
+    externalUrl: reg.external?.url ?? "",
+    addToCalendar: { google: raw.calendarUrls?.google ?? "", ics: raw.calendarUrls?.ics ?? "" },
+  };
+}
+
+/** List live (UPCOMING/STARTED) events, soonest first, mapped to grid-ready DTOs. */
+export async function fetchEvents({ limit = 100 } = {}): Promise<EventSummary[]> {
+  // The query builder, never a flat/REST `{ query: {...} }` body (the SDK silently ignores
+  // the unknown key and returns zero events). Always set a positive limit — it defaults to 0,
+  // which also returns zero events with no error.
+  const res = await events
+    .queryEvents({ fields: LIST_FIELDS as any })
+    .in("status", ["UPCOMING", "STARTED"]) // never list or link a past event — it isn't registerable
+    .ascending("dateAndTimeSettings.startDate")
+    .limit(limit)
+    .find();
+  return (res.items ?? []).map((e: Raw) => toSummary(e));
+}
+
+/** Fetch one event by its URL slug. Null when not found. */
+export async function fetchEventBySlug(slug: string): Promise<EventDetail | null> {
+  try {
+    // getEventBySlug returns a WRAPPED { event } — unlike getEvent below.
+    const res: Raw = await events.getEventBySlug(slug, { fields: DETAIL_FIELDS as any });
+    const raw = res?.event;
+    return raw ? toDetail(raw as Raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch one event by id — the post-checkout confirmation read (the thank-you URL carries
+ * `?orderNumber=&eventId=`). getEvent returns the Event DIRECTLY (unwrapped) — the one read
+ * that isn't `{ event }`; assuming the wrapper crashes the page.
+ */
+export async function fetchEventById(eventId: string): Promise<EventDetail | null> {
+  try {
+    const raw: Raw = await events.getEvent(eventId, { fields: DETAIL_FIELDS as any });
+    return raw?._id ? toDetail(raw) : null;
+  } catch {
+    return null;
+  }
+}

--- a/skills/wix-headless-fast/references/events/app/wix/events/registration.ts
+++ b/skills/wix-headless-fast/references/events/app/wix/events/registration.ts
@@ -1,0 +1,124 @@
+// Ticket tiers, the reserve → hosted-checkout redirect, and RSVP. The payload shapes here
+// are exact and easy to get subtly wrong — copy as-is; extend by calling these exports,
+// never by editing them. Failures are loud. Everything runs as the anonymous VISITOR —
+// no server route, no elevation, anywhere.
+import { orders, rsvpV2, ticketReservations } from "@wix/events";
+import { redirects as redirectsModule } from "@wix/redirects";
+import { wixModule } from "../sdk";
+import type { EventDetail, RegistrationResult, TicketTier } from "./types";
+
+const availableTickets = wixModule(orders);
+const reservations = wixModule(ticketReservations);
+const rsvps = wixModule(rsvpV2);
+const redirects = wixModule(redirectsModule);
+
+type Raw = Record<string, any>;
+
+function formatTierPrice(price: Raw | undefined): string {
+  const value = price?.amount ?? price?.value;
+  if (value == null || value === "") return "";
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency: price?.currency || "USD" }).format(Number(value));
+  } catch {
+    return `${value} ${price?.currency ?? ""}`.trim();
+  }
+}
+
+function toTier(raw: Raw): TicketTier {
+  const free = raw.free === true || Number(raw.price?.amount ?? raw.price?.value ?? 0) === 0;
+  return {
+    id: raw._id ?? "", // _id, never .id
+    name: raw.name ?? "",
+    description: raw.description ?? "",
+    price: free ? "Free" : formatTierPrice(raw.price),
+    free,
+    limitPerCheckout: raw.limitPerCheckout ?? 20,
+    saleStatus: (raw.saleStatus ?? "SALE_STARTED") as TicketTier["saleStatus"],
+  };
+}
+
+/**
+ * Ticket tiers for a TICKETING event, in display order. Reads the VISITOR-public storefront
+ * endpoint (orders.queryAvailableTickets) — never ticketDefinitions*.queryTicketDefinitions:
+ * those are the management API and 403 the anonymous visitor (auth.elevate() is the wrong
+ * fix — wrong axis, SSR-only).
+ */
+export async function fetchTicketTiers(eventId: string): Promise<TicketTier[]> {
+  // limit is REQUIRED: it defaults to 0, which returns metadata only — zero tiers, no error.
+  const res: Raw = await availableTickets.queryAvailableTickets({ filter: { eventId }, limit: 100 });
+  return (res.definitions ?? [])
+    .slice()
+    .sort((a: Raw, b: Raw) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0))
+    .map((d: Raw) => toTier(d))
+    .filter((t: TicketTier) => t.id);
+}
+
+/**
+ * RSVP to a free (RSVP-type) event — completes fully client-side: no reservation, no
+ * redirect, no payment. The registration form is BUILT-IN: exactly firstName + lastName +
+ * email; never fetch a form schema or add fields. Send "NO" only when the event's
+ * rsvpResponseType is "YES_AND_NO". Throws on closed registration / duplicate email —
+ * surface the message. A full event with a waitlist returns status "WAITLIST" — tell the
+ * guest they're waitlisted, not confirmed.
+ */
+export async function submitRsvp(
+  eventId: string,
+  guest: { firstName: string; lastName: string; email: string },
+  status: "YES" | "NO" = "YES",
+): Promise<RegistrationResult> {
+  // rsvpV2 takes the rsvp object DIRECTLY as the first arg (never wrapped in { rsvp: … }),
+  // and only rsvpV2 works for visitors — the legacy v1 `rsvp` module 400s on these fields.
+  const res: Raw = await rsvps.createRsvp({ eventId, ...guest, status } as any);
+  return { kind: "rsvpConfirmed", status: (res?.status ?? status) as "YES" | "NO" | "WAITLIST" };
+}
+
+/**
+ * Ticketed checkout, the exact sequence: reserve the selected tiers (holds them, PENDING,
+ * auto-expires), then mint the Wix-hosted checkout redirect and return its URL — the caller
+ * navigates to it; Wix collects guest details + payment and emails the tickets. Call from
+ * the browser: it needs window.location.origin (the published https host — an http or
+ * server-derived origin isn't on the redirect allowlist and 403s the return), and
+ * createRedirectSession must run as the visitor (it embeds the headless OAuth client and
+ * rejects admin/elevated tokens). Never hand-build the checkout URL — the Wix-site
+ * `…/ticket-form?reservationId=` path 404s on a headless site.
+ */
+export async function startTicketCheckout(
+  event: Pick<EventDetail, "id" | "slug">,
+  selections: { tierId: string; quantity: number }[],
+): Promise<RegistrationResult> {
+  const tickets = selections
+    .filter((s) => s.quantity > 0)
+    .map((s) => ({ ticketDefinitionId: s.tierId, quantity: s.quantity }));
+  if (!tickets.length) throw new Error("Pick at least one ticket first.");
+
+  let reservation: Raw;
+  try {
+    reservation = await reservations.createTicketReservation({ tickets } as any);
+  } catch (e) {
+    // The real gate on paid tickets: until the site has a premium plan AND a configured
+    // payment method, reserving fails 403 "No payment method configured". Not a permissions
+    // bug — don't elevate (that just creates an unpayable order); surface it softly.
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/payment method|not configured|premium/i.test(msg)) {
+      throw new Error(
+        "Ticket sales aren't switched on yet — the organizer needs to connect a payment method in the dashboard.",
+      );
+    }
+    throw e;
+  }
+  const reservationId: string | undefined = reservation?._id; // _id, never .id
+  if (!reservationId) throw new Error("Those tickets couldn't be reserved — they may have just sold out.");
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const session: Raw = await redirects.createRedirectSession({
+    eventsCheckout: { reservationId, eventSlug: event.slug },
+    callbacks: {
+      // Wix appends ?orderNumber=&eventId= — the shipped /event-confirmation page reads them.
+      thankYouPageUrl: origin ? `${origin}/event-confirmation` : undefined,
+      postFlowUrl: origin ? `${origin}/events/${event.slug}` : undefined, // back here on abandon
+    },
+  });
+  const url = session?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Checkout couldn't start — please try again.");
+  return { kind: "redirect", url };
+}

--- a/skills/wix-headless-fast/references/events/app/wix/events/types.ts
+++ b/skills/wix-headless-fast/references/events/app/wix/events/types.ts
@@ -1,0 +1,61 @@
+// Events DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. Images are
+// resolved https URLs; every displayable price is a ready formatted string.
+
+/** The current registration flavor — every registration surface branches on this. */
+export type RegistrationType = "RSVP" | "TICKETING" | "EXTERNAL" | "NONE";
+
+/** An event as a listing/grid tile needs it. */
+export interface EventSummary {
+  id: string;
+  slug: string;
+  title: string;
+  /** Plain-text teaser, safe to render directly (the rich description never leaves the data layer). */
+  shortDescription: string;
+  /** Human-formatted date/time from Wix, e.g. "Sep 26, 2026, 7:00 PM" ("" when the date is TBD). */
+  dateLabel: string;
+  /** ISO start instant for custom formatting/grouping ("" when the date is TBD). */
+  startDateIso: string;
+  locationName: string;
+  locationType: "VENUE" | "ONLINE" | "TBD";
+  /** Resolved https URL ("" when the event has no image). */
+  imageUrl: string;
+  registrationType: RegistrationType;
+  /** "From €25.00" (ticketed), "Free" (RSVP / free tickets), "" when nothing applies. */
+  priceLabel: string;
+  soldOut: boolean;
+  /** Assigned category names (the seeded format/track grouping) — filter client-side. */
+  categories: { id: string; name: string }[];
+}
+
+/** An event as the detail/registration page needs it. */
+export interface EventDetail extends EventSummary {
+  /** Long description as plain paragraphs (extracted from the rich content; may be empty). */
+  aboutParagraphs: string[];
+  /** False → registration is closed (sold out / closed / ended) — show a closed state, no form. */
+  registrationOpen: boolean;
+  /** RSVP events: "YES_AND_NO" also allows a "can't make it" reply. */
+  rsvpResponseType: "YES_ONLY" | "YES_AND_NO";
+  /** EXTERNAL events: the outbound registration URL ("" otherwise). */
+  externalUrl: string;
+  addToCalendar: { google: string; ics: string };
+}
+
+/** A purchasable ticket tier (TICKETING events). */
+export interface TicketTier {
+  id: string;
+  name: string;
+  description: string;
+  /** Formatted price (e.g. "€45.00"); "Free" for free tiers. */
+  price: string;
+  free: boolean;
+  /** Max quantity per order for this tier. */
+  limitPerCheckout: number;
+  /** Only "SALE_STARTED" is buyable — gate the picker on this. */
+  saleStatus: "SALE_SCHEDULED" | "SALE_STARTED" | "SALE_ENDED";
+}
+
+/** The outcome of a registration: the browser is redirecting to Wix checkout, or the RSVP is in. */
+export type RegistrationResult =
+  | { kind: "redirect"; url: string }
+  | { kind: "rsvpConfirmed"; status: "YES" | "NO" | "WAITLIST" };

--- a/skills/wix-headless-fast/references/events/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/events/lock/astro/package-lock.json
@@ -1,0 +1,11884 @@
+{
+ "name": "wix-headless-fast-events",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-events",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/essentials": "^1.0.10",
+    "@wix/events": "^1.0.860",
+    "@wix/redirects": "^1.0.125",
+    "@wix/sdk": "^1.21.5",
+    "@wix/seo": "^1.0.79",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@internationalized/date": {
+   "version": "3.12.3",
+   "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+   "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/number": {
+   "version": "3.6.7",
+   "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+   "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/string": {
+   "version": "3.2.10",
+   "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+   "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@react-types/shared": {
+   "version": "3.36.1",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+   "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+   "license": "Apache-2.0",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@swc/helpers": {
+   "version": "0.5.23",
+   "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+   "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_categories": {
+   "version": "1.0.58",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_categories/-/@wix/auto_sdk_events_categories-1.0.58.tgz",
+   "integrity": "sha512-Sp7AA2sI422OuAxhnWdDTDR8qozKmh0NRZjchLlv0390l51oiDQTMqryMdFvhL6gsnaEEVFI2a+KwzrSEHllqQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_events-settings": {
+   "version": "1.0.51",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_events-settings/-/@wix/auto_sdk_events_events-settings-1.0.51.tgz",
+   "integrity": "sha512-VATXB7YerjTaCYNTF8jMd55qL8ODnGHBqyuDQZ2uEy6QFP7U23vieCbzbKwY29rhSSo/NIZUruh8h00bEa0ciw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_forms": {
+   "version": "1.0.110",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_forms/-/@wix/auto_sdk_events_forms-1.0.110.tgz",
+   "integrity": "sha512-8xfFueeJPD40M+P74XhvDbiAUrh5ZJNFbdwfqXXca37YNS1AttTW3XSgaoG6tWUdm5Bw/tp3VoEGk+5Gn9PxcQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_guests": {
+   "version": "1.0.63",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_guests/-/@wix/auto_sdk_events_guests-1.0.63.tgz",
+   "integrity": "sha512-O/WYimxL77K8c26EPnaQwmTz69ZI+JyoCtnF04JjFih2bpXKpLaUXoB53CQD9FZEQJ+LaKWXM37/xDqBXrxowQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_notifications": {
+   "version": "1.0.79",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_notifications/-/@wix/auto_sdk_events_notifications-1.0.79.tgz",
+   "integrity": "sha512-TzQnEKrd+3kKD8GVXuCt7CKjjfWVG6yKhiclKtIeRq0QYi0v1gC6dbEexCqvZ2M6O1g6/bpMIfG3zWfn5Qv59Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_orders": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_orders/-/@wix/auto_sdk_events_orders-1.0.69.tgz",
+   "integrity": "sha512-bGGMhwz/SNXjgTLvLRfyfqRc5oR0hbtYTGAkv4vqxn3GBOHPOnBp50P8groHjs6hU702Ry0Lmhx4wONhsHEhhw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_policies": {
+   "version": "1.0.50",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_policies/-/@wix/auto_sdk_events_policies-1.0.50.tgz",
+   "integrity": "sha512-Qq+hLP69yapIABZ1dptrFEKDeAzgTzkPS4dzeS+xcxwWZIJ+KTuFG0wByW+XNJ06Q41gub913XqHPm6ZFI2x1w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_rsvp": {
+   "version": "1.0.44",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp/-/@wix/auto_sdk_events_rsvp-1.0.44.tgz",
+   "integrity": "sha512-grcVSbqyD0h4yMUwiakC9yfTDf7+yzGWTafbU8mDTICj51B5dC5cla1Z6GN46xTBeIZ8Ou0yUf5qYALRL8vgPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_rsvp-v-2": {
+   "version": "1.0.114",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp-v-2/-/@wix/auto_sdk_events_rsvp-v-2-1.0.114.tgz",
+   "integrity": "sha512-axtsWJNdxU50B1SChVCTspfccyjQj2Ps9UK/aa1Di5swKwc/Vmy1pHj/nrq/h8B6rXFi+IminFaFIJB4BLz6+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_schedule": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule/-/@wix/auto_sdk_events_schedule-1.0.45.tgz",
+   "integrity": "sha512-ufOwvb3WHDYzgjFC82kVaZANyy6PmTv2F8QZMBF5BJA2PJ52kLF/pSg9/Z3ZQy2S32OuUQ6KgQ8ThFLqV2wiqw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_schedule-bookmarks": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule-bookmarks/-/@wix/auto_sdk_events_schedule-bookmarks-1.0.37.tgz",
+   "integrity": "sha512-IHtPONbjkMJpoKLFIX5Nj7SalV32EBAXvN8EiSqyyXH4Wo2/7QP2TYxpGHTcb6aPNsxZbRgT300sqUGp9fFHbg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_staff-members": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_staff-members/-/@wix/auto_sdk_events_staff-members-1.0.53.tgz",
+   "integrity": "sha512-J6AzL5ujvkV4/8VjFBHErczEWKgH3MOcuO1ugLLoCG/ym7PB8C0i+k4v9e88UQ4g3YGZ468fGioTsJPr3EGgZA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_ticket-definitions": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions/-/@wix/auto_sdk_events_ticket-definitions-1.0.53.tgz",
+   "integrity": "sha512-J6DFzkaJvk43kYXVk3y59xGvHRsrfEIHmONHxXuOnbNa9jr2An3tNriYzSPL57qigkf/cgHPzI8GGQTMMpJh0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_ticket-definitions-v-2": {
+   "version": "1.0.135",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions-v-2/-/@wix/auto_sdk_events_ticket-definitions-v-2-1.0.135.tgz",
+   "integrity": "sha512-50awcVdOUKURKwkQ5MCm9RW700mux/m3N2qH3/2bX/pAxx2m7xN38ZVvjtKX3KLv6+7GBsqoi3PWO4LNMfDNOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_ticket-reservations": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-reservations/-/@wix/auto_sdk_events_ticket-reservations-1.0.52.tgz",
+   "integrity": "sha512-NJm8RlvzvA5r0d9QYbLc5GjzQJ6nXhEOC4HiLxQqSxbOU8XHK4zpMO+3ekxpGGYkTmwDQfET3cwedETC0bI+8A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_tickets": {
+   "version": "1.0.51",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_tickets/-/@wix/auto_sdk_events_tickets-1.0.51.tgz",
+   "integrity": "sha512-L59XMp5X7pSzzYGBvKt3tH0neYCCgrJwy3NbARoXncFaZdpRlbkV7Wgbrumikc0hqSmVGgDJNMklCSt+CODxgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_events_wix-events-v-2": {
+   "version": "1.0.114",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_wix-events-v-2/-/@wix/auto_sdk_events_wix-events-v-2-1.0.114.tgz",
+   "integrity": "sha512-SU5JlVWE3RTstfItDZLkf0bOMfjo6iKt69XiGlbzTNuVEag6/UDts6IsBDeEPla9m/jJ9EwOOPxORgFDwdPuug==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_chat-settings": {
+   "version": "1.0.27",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_chat-settings/-/@wix/auto_sdk_forms_chat-settings-1.0.27.tgz",
+   "integrity": "sha512-xCXsDzVnRqf2X7FKYl0TCweL75eCkZk4v3DRGVoB6/I2OWze3Jh4wKp/No1ZorvTIK/kfqRURqrl45xlw+ACpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_form-spam-submission-reports": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-spam-submission-reports/-/@wix/auto_sdk_forms_form-spam-submission-reports-1.0.42.tgz",
+   "integrity": "sha512-o+m2UkldVgTxmR/QB1P6Ho0B7A/WO+KUOW2Ryp7o5GvuQNtjvIAbJQVEwVkTMcDTsWbkhZhws5P3ZId10ptYGg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_form-submissions": {
+   "version": "1.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-submissions/-/@wix/auto_sdk_forms_form-submissions-1.0.25.tgz",
+   "integrity": "sha512-t7DkTvX6ZIvu2xSuv2KnqDrBzeNFJxqBitgh9mm1Rx71KG7qTsOwb2vENKBPq/jz1z4K1W2McHrSm3DQe5vJvA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_forms": {
+   "version": "1.0.135",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_forms/-/@wix/auto_sdk_forms_forms-1.0.135.tgz",
+   "integrity": "sha512-5bLRkFzj+0lEr7cO1w257ZQK2tS3aLkYX5QaQJtuHKjveEHlM0vw6ppBBwInC21j5iVa8QuFW/J2Tw9xRvQ05Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_interactive-form-sessions": {
+   "version": "1.0.80",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_interactive-form-sessions/-/@wix/auto_sdk_forms_interactive-form-sessions-1.0.80.tgz",
+   "integrity": "sha512-15f0e/olrKlOIOoAK1JE+wwD0IKfTwpRbczPBeDiLUsZC/D69XUTzKZRM3ZF9B19Wd5sT7ztzOOt77JDojSknw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_submissions": {
+   "version": "1.0.154",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_submissions/-/@wix/auto_sdk_forms_submissions-1.0.154.tgz",
+   "integrity": "sha512-uE5UFW/bIHVJLfjdNha9n7lW6SsPmW+NwvqXZbUtCmNsya32yEC4qx2l+pqZ4tQdSgEFGaRyi6N2pAqwkB6lnQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_llms-txt": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_redirects": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
+   "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_robots-txt": {
+   "version": "1.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-patterns": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
+   "version": "1.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-tags": {
+   "version": "1.0.28",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/events": {
+   "version": "1.0.860",
+   "resolved": "https://registry.npmjs.org/@wix/events/-/@wix/events-1.0.860.tgz",
+   "integrity": "sha512-5vG7A+dpLCIVEiF3r65waMHGXauSH6z/7zpZ6cDV2mrQsxfXNCd5aIWKSFmvGHWAh9dLglbVyqPC5EG+c3dNrQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_events_categories": "1.0.58",
+    "@wix/auto_sdk_events_events-settings": "1.0.51",
+    "@wix/auto_sdk_events_forms": "1.0.110",
+    "@wix/auto_sdk_events_guests": "1.0.63",
+    "@wix/auto_sdk_events_notifications": "1.0.79",
+    "@wix/auto_sdk_events_orders": "1.0.69",
+    "@wix/auto_sdk_events_policies": "1.0.50",
+    "@wix/auto_sdk_events_rsvp": "1.0.44",
+    "@wix/auto_sdk_events_rsvp-v-2": "1.0.114",
+    "@wix/auto_sdk_events_schedule": "1.0.45",
+    "@wix/auto_sdk_events_schedule-bookmarks": "1.0.37",
+    "@wix/auto_sdk_events_staff-members": "1.0.53",
+    "@wix/auto_sdk_events_ticket-definitions": "1.0.53",
+    "@wix/auto_sdk_events_ticket-definitions-v-2": "1.0.135",
+    "@wix/auto_sdk_events_ticket-reservations": "1.0.52",
+    "@wix/auto_sdk_events_tickets": "1.0.51",
+    "@wix/auto_sdk_events_wix-events-v-2": "1.0.114",
+    "@wix/events_app-extensions": "1.0.49",
+    "@wix/headless-events": "^0.0.60"
+   }
+  },
+  "node_modules/@wix/events_app-extensions": {
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/@wix/events_app-extensions/-/@wix/events_app-extensions-1.0.49.tgz",
+   "integrity": "sha512-/NL1UHZgZvNbPn+lWdOWlglhhlAq1reC0nDf4BfKiJiaBcddPs+lhIe/Erg5bkMSazvxzqoeZA9I8h3Twt+nrQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/form-public": {
+   "version": "0.128.0",
+   "resolved": "https://registry.npmjs.org/@wix/form-public/-/@wix/form-public-0.128.0.tgz",
+   "integrity": "sha512-uk7NeZe0p2R8+WHHeXdid9hNb0cmYg+7j1lF3zVYpowsJxPPJCAPf5JpQxMQl92OQfvDdsd85zQ9OrmoDdWHKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/essentials": "^0.1.28",
+    "i18next": "^19.9.2",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.mapkeys": "^4.6.0",
+    "react-i18next": "^11.18.6"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/i18next": {
+   "version": "19.9.2",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+   "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.0"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/react-i18next": {
+   "version": "11.18.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+   "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.14.5",
+    "html-parse-stringify": "^3.0.1"
+   },
+   "peerDependencies": {
+    "i18next": ">= 19.0.0",
+    "react": ">= 16.8.0"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/forms": {
+   "version": "1.0.500",
+   "resolved": "https://registry.npmjs.org/@wix/forms/-/@wix/forms-1.0.500.tgz",
+   "integrity": "sha512-Vrc6Ld6i5TkePv9j263Oz8CWwcaiKlNl2E5APt8dXvM1fPYByNTuAIcwk0nKt26WN9P8dYgh2u41wzgP6jOH9A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_forms_chat-settings": "1.0.27",
+    "@wix/auto_sdk_forms_form-spam-submission-reports": "1.0.42",
+    "@wix/auto_sdk_forms_form-submissions": "1.0.25",
+    "@wix/auto_sdk_forms_forms": "1.0.135",
+    "@wix/auto_sdk_forms_interactive-form-sessions": "1.0.80",
+    "@wix/auto_sdk_forms_submissions": "1.0.154",
+    "@wix/headless-forms": "0.0.45"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/form-public": {
+   "version": "0.145.0",
+   "resolved": "https://registry.npmjs.org/@wix/form-public/-/@wix/form-public-0.145.0.tgz",
+   "integrity": "sha512-y/K5nWdM0x5oNQHFBgk5b4jtx7Jitu+kDHTbJ4lqFuYQaroekBrAcH2mOqDQB30cXwBMCz+wjtyAWdHOYDPwBA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/essentials": "^0.1.28",
+    "i18next": "^19.9.2",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.mapkeys": "^4.6.0",
+    "react-i18next": "^11.18.6"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/form-public/node_modules/i18next": {
+   "version": "19.9.2",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+   "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.0"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/form-public/node_modules/react-i18next": {
+   "version": "11.18.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+   "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.14.5",
+    "html-parse-stringify": "^3.0.1"
+   },
+   "peerDependencies": {
+    "i18next": ">= 19.0.0",
+    "react": ">= 16.8.0"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/headless-forms": {
+   "version": "0.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/@wix/headless-forms-0.0.45.tgz",
+   "integrity": "sha512-I/uXQlR6r7af7iWm5E4xXICXaUbqGmTziApXDlxlMeTOP+zqUyTFSXWcUL4uT683yRfcXH46jog4f8e2NVSHsg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/form-public": "^0.145.0",
+    "@wix/forms": "^1.0.399",
+    "@wix/headless-utils": "0.0.12",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "react-aria-components": "^1.13.0"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/headless-forms/node_modules/@wix/headless-utils": {
+   "version": "0.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.12.tgz",
+   "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/forms/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-events": {
+   "version": "0.0.60",
+   "resolved": "https://registry.npmjs.org/@wix/headless-events/-/@wix/headless-events-0.0.60.tgz",
+   "integrity": "sha512-VK2HA64bk5Wk3fNUFQvljYCY35MfeqEKkToShS1rvWHyhM4GRPHLJ7/G95wpiKIU0PO5sKDIMQaftTvrC6o9lA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/essentials": "^1.0.0",
+    "@wix/events": "^1.0.685",
+    "@wix/headless-forms": "0.0.39",
+    "@wix/headless-media": "0.0.24",
+    "@wix/headless-utils": "0.0.11",
+    "@wix/redirects": "^1.0.83",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-events/node_modules/@wix/headless-utils": {
+   "version": "0.0.11",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.11.tgz",
+   "integrity": "sha512-zmFqqlcFVXE7A/q4yxZhx5kYcofkZGaHeKTMMIRIgNWDLxTt7O2CBWnlW7wyKuJnqZfGEO84hQlWW0yirrzq9w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-forms": {
+   "version": "0.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/@wix/headless-forms-0.0.39.tgz",
+   "integrity": "sha512-6lFSw18ZjCM3M6L4KB4BMVM2HLHZkhUv9nb07QvLhU0ykJcNTQVafHuswRzxNjHJHtLHXQGldCJcEfAsxDgvaQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/form-public": "^0.128.0",
+    "@wix/forms": "^1.0.373",
+    "@wix/headless-utils": "0.0.11",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "react-aria-components": "^1.13.0"
+   }
+  },
+  "node_modules/@wix/headless-forms/node_modules/@wix/headless-utils": {
+   "version": "0.0.11",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.11.tgz",
+   "integrity": "sha512-zmFqqlcFVXE7A/q4yxZhx5kYcofkZGaHeKTMMIRIgNWDLxTt7O2CBWnlW7wyKuJnqZfGEO84hQlWW0yirrzq9w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.24.tgz",
+   "integrity": "sha512-1e/ZEv3y/xdYYgCikygZuBsn9FbBaktMBJYLma1zCAEH5r+jcoo1fvK3xAxd2bdQu/sreWxjewHVqpy+izV4rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-seo": {
+   "version": "0.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
+   "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/seo": "^1.0.14",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/media/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/seo": {
+   "version": "1.0.79",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
+   "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
+    "@wix/auto_sdk_seo_llms-txt": "1.0.0",
+    "@wix/auto_sdk_seo_redirects": "1.0.2",
+    "@wix/auto_sdk_seo_robots-txt": "1.0.21",
+    "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
+    "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
+    "@wix/auto_sdk_seo_seo-tags": "1.0.28",
+    "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
+    "@wix/headless-seo": "^0.0.16"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/client-only": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+   "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+   "license": "MIT"
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "peer": true,
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.camelcase": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+   "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.mapkeys": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
+   "integrity": "sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-aria": {
+   "version": "3.51.0",
+   "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+   "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "aria-hidden": "^1.2.3",
+    "clsx": "^2.0.0",
+    "react-stately": "3.49.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-aria-components": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.20.0.tgz",
+   "integrity": "sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "client-only": "^0.0.1",
+    "react-aria": "3.51.0",
+    "react-stately": "3.49.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-stately": {
+   "version": "3.49.0",
+   "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+   "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/events/seed/SEED.md
+++ b/skills/wix-headless-fast/references/events/seed/SEED.md
@@ -1,0 +1,81 @@
+# Events — seeding
+
+Seed by **running `seed-events.mjs` with a plan file** — don't hand-write the REST calls.
+The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
+required), installs the Wix Events app if needed, resolves the site currency, and creates
+everything in the one order that works (create DRAFT → tiers → publish — the registration
+type is immutable and publishing is one-way).
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/events/seed/seed-events.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief. **Default to 3 events** (the seed shows
+the shape; the owner adds the rest in the dashboard) and make them exercise the UI: mix
+`TICKETING` and `RSVP` (≥1 of each), give a ticketed event 2 tiers, and give every event an
+`imageUrl` (verified — an events page without images looks broken).
+
+```json
+{
+  "events": [
+    { "type": "TICKETING", "title": "Summer Synth Festival",
+      "shortDescription": "One night of analog sound under the stars.",
+      "startDate": "2026-11-07T03:30:00.000Z", "endDate": "2026-11-07T07:00:00.000Z",
+      "timeZoneId": "America/Los_Angeles",
+      "location": { "name": "The Echo Lot", "type": "VENUE",
+        "address": { "addressLine": "120 Harbor St", "city": "Seattle", "subdivision": "US-WA", "postalCode": "98101", "country": "US" } },
+      "ticketTiers": [
+        { "name": "General Admission", "price": "45.00", "initialLimit": 200 },
+        { "name": "Front Row", "price": "85.00", "description": "First two rows.", "initialLimit": 40 }
+      ],
+      "category": "Concerts", "imageUrl": "https://…" },
+    { "type": "TICKETING", "title": "Vinyl Mixing Workshop",
+      "shortDescription": "Hands-on turntable session, decks provided.",
+      "startDate": "2026-11-14T18:00:00.000Z", "endDate": "2026-11-14T20:00:00.000Z",
+      "timeZoneId": "America/Los_Angeles",
+      "location": { "name": "Studio B", "type": "VENUE",
+        "address": { "addressLine": "9 Pine Ave", "city": "Seattle", "subdivision": "US-WA", "postalCode": "98101", "country": "US" } },
+      "ticketTiers": [{ "name": "Workshop Seat", "price": "30.00", "initialLimit": 16 }],
+      "category": "Workshops", "imageUrl": "https://…" },
+    { "type": "RSVP", "title": "Community Listening Night",
+      "shortDescription": "Free open-deck evening — bring a record.",
+      "startDate": "2026-11-20T19:00:00.000Z", "endDate": "2026-11-20T22:00:00.000Z",
+      "timeZoneId": "America/Los_Angeles",
+      "location": { "name": "The Back Room", "type": "VENUE",
+        "address": { "addressLine": "120 Harbor St", "city": "Seattle", "subdivision": "US-WA", "postalCode": "98101", "country": "US" } },
+      "category": "Community", "imageUrl": "https://…" }
+  ]
+}
+```
+
+- `type` — `TICKETING` (paid tiers; buyers pay on Wix's hosted checkout) or `RSVP` (free;
+  the built-in name+email form — seed NO form fields). **Immutable after create** — decide
+  from the brief, never plan to convert.
+- **Dates are future ISO-8601 UTC** (`…Z`), `endDate` after `startDate`, `timeZoneId` an
+  IANA tz. A past event isn't registerable and won't show in the live listing; no date in
+  the brief → default ~60–90 days out and say so.
+- `ticketTiers` — TICKETING only, created before publish. `price` is a **decimal STRING**
+  (`"45.00"`, never a number), `name` ≤ 30 chars, omit `initialLimit` for unlimited. Tier
+  currency is the site currency (resolved automatically).
+- `location` — `{ name, type: "VENUE", address }` (address `subdivision` is ISO-3166-2 like
+  `US-WA`, `country` ISO alpha-2), `{ name, type: "ONLINE" }`, or
+  `{ locationTbd: true, name }`.
+- `category` — a name; created and assigned for you. Skip when the brief has no grouping.
+- `rsvpResponseType` — `"YES_AND_NO"` to let guests decline (default `"YES_ONLY"`).
+
+The result JSON carries a `notes` array — when any event is ticketed it reminds that
+**completing a paid purchase needs a premium plan + a configured payment method** in the
+dashboard. That's an owner step, not a seeding failure; relay it.
+
+**Seeding is additive — never delete or overwrite existing content**; ask first if a cleanup
+seems needed.
+
+## Escape hatch — individual functions
+`setupEvents` composes exported steps — `installEventsApp`, `getSiteCurrency`, `createEvent`,
+`createTicketTiers`, `publishEvent`, `createEventCategories`, `assignEventsToCategory`,
+`importImage`, `setEventMainImage`, plus `makeCtx()` — import them only for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.

--- a/skills/wix-headless-fast/references/events/seed/seed-events.mjs
+++ b/skills/wix-headless-fast/references/events/seed/seed-events.mjs
@@ -1,0 +1,262 @@
+// Events seed — a BUILD-TIME script, never shipped in the app. Run from the project root
+// (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/events/seed/seed-events.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Events app if needed,
+// resolves the site currency, then per event: create DRAFT → (TICKETING) add ticket tiers →
+// publish — the order two one-way constraints force (registration.initialType is immutable
+// after create; publishing is one-way). Then it creates + assigns categories and
+// imports+attaches images. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "events": [{ "title", "shortDescription"?, "type": "TICKETING"|"RSVP",
+//                  "startDate", "endDate" (future ISO-8601 UTC), "timeZoneId",
+//                  "location" ({name,type:"VENUE",address} | {name,type:"ONLINE"} | {locationTbd:true,name}),
+//                  "ticketTiers"?: [{ "name" (≤30 chars), "price" (decimal STRING), "description"?, "initialLimit"? }],
+//                  "category"? (name), "imageUrl"?, "rsvpResponseType"? }] }
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
+// read the live API reference; authoritative source recipe:
+// wix-headless/references/inline-recipes/setup-events.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const EVENTS_APP_ID = "140603ad-af8d-84a5-2c80-a0f60cb47351";
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// {type:"TICKETING"|"RSVP", …} -> the registration block. TICKETING carries a tickets{}
+// config; RSVP carries rsvp{responseType} and seeds NO form fields (name+email is built-in).
+// initialType is IMMUTABLE after create — set from the plan, never plan to convert.
+function buildRegistration(ev) {
+  if (ev.type === "TICKETING") {
+    return {
+      initialType: "TICKETING",
+      tickets: {
+        ticketLimitPerOrder: ev.ticketLimitPerOrder ?? 8,
+        currency: ev.currency ?? "USD", // setupEvents threads the site currency; USD is the last resort
+        reservationDurationInMinutes: ev.reservationDurationInMinutes ?? 20,
+      },
+    };
+  }
+  return {
+    initialType: "RSVP",
+    rsvp: { responseType: ev.rsvpResponseType ?? "YES_ONLY" }, // "YES_ONLY" | "YES_AND_NO"
+  };
+}
+
+// ---- operations ----------------------------------------------------------------------------------
+
+// Idempotent: re-installing an already-installed app returns 200.
+export async function installEventsApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: EVENTS_APP_ID, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+// The ticket-definitions API REQUIRES currency and uses whatever you pass verbatim (it does
+// NOT fall back to the site currency) — resolve it once, or a non-USD site gets mis-priced.
+export async function getSiteCurrency(ctx) {
+  try {
+    const r = await req(ctx, "/site-properties/v4/properties", { method: "GET" });
+    return r?.properties?.paymentCurrency || "USD";
+  } catch {
+    return "USD";
+  }
+}
+
+/**
+ * STEP 1 — create ONE event as a draft (no bulk endpoint; loop for multiple). Dates MUST be
+ * in the future — a past event isn't registerable and won't show in the live listing.
+ * Returns { id, slug } — id feeds the tier/publish steps; slug is the URL identifier.
+ */
+export async function createEvent(ctx, ev) {
+  const body = {
+    draft: true,
+    event: {
+      title: ev.title,
+      shortDescription: ev.shortDescription,
+      location: ev.location,
+      dateAndTimeSettings: {
+        startDate: ev.startDate,
+        endDate: ev.endDate,
+        timeZoneId: ev.timeZoneId,
+        showTimeZone: ev.showTimeZone ?? true,
+      },
+      registration: buildRegistration(ev),
+    },
+    fields: ["DETAILS", "TEXTS", "REGISTRATION", "URLS"],
+  };
+  const r = await req(ctx, "/events/v3/events", { body });
+  return { id: r.event?.id, slug: r.event?.slug };
+}
+
+/**
+ * STEP 2 — ticket tiers for a TICKETING event (skip for RSVP). Must run BEFORE publish —
+ * publishing a ticketed event with no tiers ships an event with nothing to buy, and there is
+ * no un-publish. price is a decimal STRING ("65.00", never a number); name ≤ 30 chars; omit
+ * initialLimit for unlimited. Tiers are independent — fired as one parallel batch.
+ */
+export async function createTicketTiers(ctx, eventId, tiers) {
+  return Promise.all(tiers.map(async (t) => {
+    const body = {
+      ticketDefinition: {
+        eventId,
+        name: t.name,
+        description: t.description,
+        ...(t.initialLimit != null ? { initialLimit: t.initialLimit } : {}),
+        pricingMethod: { fixedPrice: { value: String(t.price), currency: t.currency ?? "USD" } },
+        feeType: t.feeType ?? "FEE_INCLUDED",
+      },
+      fields: ["SALES_DETAILS"],
+    };
+    const r = await req(ctx, "/events/v3/ticket-definitions", { body });
+    return { id: r.ticketDefinition?.id };
+  }));
+}
+
+// STEP 3 — publish (one-way; for TICKETING only after its tiers exist).
+export async function publishEvent(ctx, eventId) {
+  return req(ctx, `/events/v3/events/${eventId}/publish`, { body: {} });
+}
+
+// STEP 4 (optional) — group events by a format/track. Categories are the v1 API (NOT v3).
+export async function createEventCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/events/v1/categories", { body: { category: { name } } });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+// Assign events to a category. Path is /{categoryId}/events (NOT /assign); body key is
+// `eventId` — an ARRAY despite the singular name.
+export async function assignEventsToCategory(ctx, categoryId, eventIds) {
+  return req(ctx, `/events/v1/categories/${categoryId}/events`, { body: { eventId: eventIds } });
+}
+
+// Events binds mainImage by Wix Media file ID — an external url must be imported first
+// (a raw url as the id stores 200 but renders nothing).
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+// mainImage is an Image OBJECT; height/width are REQUIRED or it won't render. Events V3 uses
+// NO revision — partial PATCH keyed by event.id. Works before OR after publish.
+export async function setEventMainImage(ctx, it) {
+  return req(ctx, `/events/v3/events/${it.eventId}`, {
+    method: "PATCH",
+    body: {
+      event: {
+        id: it.eventId,
+        mainImage: { id: it.id, url: it.url, height: it.height ?? 1024, width: it.width ?? 1024, altText: it.altText },
+      },
+      fields: ["DETAILS"], // mainImage reads back only under DETAILS
+    },
+  });
+}
+
+/**
+ * ONE-CALL seed: install → site currency → per event create DRAFT → tiers → publish →
+ * categories → images, ids threaded in memory. The default path.
+ */
+export async function setupEvents(ctx, { events = [] } = {}) {
+  await installEventsApp(ctx);
+  const siteCurrency = await getSiteCurrency(ctx);
+
+  const created = [];
+  for (const ev of events) {
+    const e = await createEvent(ctx, { ...ev, currency: ev.currency ?? siteCurrency });
+    if (!e.id) throw new Error(`Event "${ev.title}" was not created — no id returned.`);
+    const tiers = ev.type === "TICKETING" && ev.ticketTiers?.length
+      ? await createTicketTiers(ctx, e.id, ev.ticketTiers.map((t) => ({ ...t, currency: t.currency ?? siteCurrency })))
+      : [];
+    await publishEvent(ctx, e.id);
+    created.push({ ...e, category: ev.category, imageUrl: ev.imageUrl, ticketCount: tiers.length });
+  }
+
+  const names = [...new Set(created.map((e) => e.category).filter(Boolean))];
+  const categories = names.length ? await createEventCategories(ctx, names) : [];
+  for (const c of categories) {
+    const eventIds = created.filter((e) => e.category === c.name).map((e) => e.id);
+    if (eventIds.length) await assignEventsToCategory(ctx, c.id, eventIds);
+  }
+
+  let imagesAttached = 0;
+  for (const e of created) {
+    if (!e.imageUrl) continue;
+    try {
+      const file = await importImage(ctx, e.imageUrl, `${e.slug || "event"}.png`);
+      await setEventMainImage(ctx, { eventId: e.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: e.slug });
+      imagesAttached++;
+    } catch {
+      /* never block on image failure — the event stays text-only */
+    }
+  }
+
+  return {
+    events: created.map((e) => ({ id: e.id, slug: e.slug, ticketCount: e.ticketCount, category: e.category ?? null })),
+    categories,
+    imagesAttached,
+    // Completing a PAID purchase needs a premium plan + a configured payment method in the
+    // dashboard — not a seeding failure; surface it to the owner. Free/RSVP need neither.
+    notes: created.some((e) => e.ticketCount > 0)
+      ? ["Paid tickets require a premium plan + a configured payment method in the dashboard to complete a purchase."]
+      : [],
+  };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-events.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupEvents(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/members/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/members/INSTRUCTIONS.md
@@ -1,0 +1,150 @@
+# Members — playbook
+
+The member-auth machinery ships as files — the Wix-hosted login/sign-up flow (one flow, not
+three: the login page registers a new member or logs in an existing one), logout, the shared
+session store, and the current-member read, typed end-to-end and working identically on both
+stacks. **The presentation is yours**: you design the header account control's placement, the
+account surface, and which pages/actions are member-gated. You never write auth logic.
+
+**Scope — the Wix-hosted login page only.** A custom/branded in-app login form, custom
+sign-up fields, and social login buttons are OUT OF SCOPE for this vertical — if the brief
+explicitly asks for them, route to the `wix-headless` skill
+(`references/inline-recipes/how-to-code-members-custom-login.md`); don't improvise them here.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/members/types.ts` | the DTO (`CurrentMember`) — contract below |
+| `wix/members/members.ts` | `fetchCurrentMember` — null for anonymous, never throws |
+| `wix/members/auth.ts` | login/logout, both stacks — `startLogin`, `logoutMember`, `completeLogin`, `CALLBACK_PATH` |
+| `wix/members/member-store.ts` | shared session state (module store — spans Astro islands) |
+| `hooks/members/useMember.ts` | the session hook — contract below |
+| `components/members/MemberMenu.tsx` · `AccountView.tsx` · `RequireAuth.tsx` | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `components/members/LoginCallback.tsx` | react-stack `/callback` handler — mount as-is, don't redesign |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot, the global.css import, and a `<MemberMenu client:only="react">` in the header). If another vertical is also deployed, its layout won — mount MemberMenu there |
+| `pages/account.astro` | the SSR-gated account page — **keep the frontmatter** (the gate), swap the island import to YOUR account component |
+
+## What you build — the design job
+
+1. **The header account control** — where the login/account affordance lives in your chrome,
+   on `useMember` (or mount the shipped `MemberMenu` and restyle your own later).
+2. **The account surface** — the member's identity presented in the brand (photo, name,
+   email, member-since; the log-out affordance) — on `useMember`.
+3. **The gated surfaces** — which pages or actions are members-only comes from the brief:
+   Astro pages gate in SSR frontmatter (copy `account.astro`'s shape); react routes wrap in
+   `RequireAuth`.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// CurrentMember — display-ready:
+// { id, loginEmail, displayName /* nickname → first+last → email local part */,
+//   firstName, lastName, nickname, photoUrl /* https or "" */, contactId,
+//   memberSince /* "YYYY-MM-DD" | "" */ }
+
+// useMember({ initialMember? /* SSR-resolved member; omit to resolve client-side */ }) →
+// { member: CurrentMember | null,   // null for a visitor — AND for a logged-in member
+//                                   // when the Members Area app is absent (setup, not a bug)
+//   loggedIn,                       // the gate signal
+//   loading,                        // true until the first session read — skeletons, not logged-out UI
+//   error,                          // last failed operation's message — render it
+//   login(returnTo?),               // → Wix login page (login AND sign-up); navigates away
+//   logout(returnTo?),              // → Wix logout flow; navigates away
+//   refresh() }
+
+// RequireAuth: { children, fallback? /* replaces the default login prompt */ }
+// MemberMenu:  { accountHref? = "/account", LinkComponent? }
+// AccountView: { initialMember? }
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — or mount
+   `<MemberMenu client:only="react">` in the winning vertical's layout when several are
+   deployed).
+2. Write your account component under `src/components/members/` (a new name — don't
+   overwrite the reference), swap the island import in `pages/account.astro` — **keep its
+   frontmatter exactly**: the server-side gate and the `returnToUrl` param are the mechanism.
+   Gate any other members-only page the same way. **Author your surfaces in as few messages
+   as possible** — batch multiple Writes per message.
+3. Login/logout need **zero routes from you** — `@wix/astro` ships `/api/auth/login` and
+   `/api/auth/logout`; the shipped code already targets them.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/account` → your account surface wrapped in
+`<RequireAuth>`; **`/callback` → the shipped `LoginCallback`, mounted at exactly that path**
+(it finishes the login handshake). Gate any members-only route with `RequireAuth`.
+
+**Post-release, once (owner-visible step — surface it, don't skip it):** the login callback
+`<deployed-origin>/callback` must be added to the OAuth app's **`allowedRedirectUris`**
+(exact match). `wix release` auto-registers the *origin* but not this *callback* — until it's
+added, login dies at the redirect. Also: **the site must be published** before login works at
+all. Setting: `https://manage.wix.com/dashboard/<siteId>/oauth-apps-settings`.
+
+## Hard rules
+
+- **Auth only through the shipped exports** — `useMember` / `auth.ts` own the flow (routes,
+  handshake, token persistence, `returnToUrl`). Never build a login form, an OAuth handshake,
+  or a logout URL by hand; never instantiate an `OAuthStrategy` client yourself (on the Astro
+  stack that 500s at SSR).
+- **The return param is `returnToUrl`** on the built-in routes — `returnUrl` is silently
+  dropped and the member lands on `/`. The shipped code gets it right; keep it right in any
+  frontmatter you write.
+- **Gate server-side on Astro** (SSR frontmatter, like `account.astro`), client-side with
+  `RequireAuth` only on the react stack.
+- **Never fake a member** — no mock logged-in state, invented profile, or roles. Render the
+  real member or the real logged-out state; gate on `loggedIn`, skeleton on `loading`.
+- **No `auth.elevate()` for member features.** Login is the identity axis; elevation is the
+  admin axis. A member reading their own data is already authorized under the member token.
+- **Identity vs. profile:** login/gating need no app install; *displaying* member data needs
+  the **Wix Members Area app** (the seed installs it). `member` null while `loggedIn` is true
+  → the app is missing, not a code bug. The Astro `account.astro` gate additionally NEEDS the
+  app (a logged-in member reads null without it and loops through login).
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Custom login forms and social buttons are out of scope (see Scope above) — don't add them
+  unprompted.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link (`https://manage.wix.com/dashboard/<siteId>`), plus:
+- **Members / permissions** (profile data, roles): `…/member-permissions`
+- **Signup security** (email verification, owner approval, reCAPTCHA — dashboard-governed,
+  never code): Dashboard → Settings → Login & Security
+- React stack only: **oauth-apps-settings** for the `allowedRedirectUris` step above.
+
+## Seeding
+
+Per `seed/SEED.md` — members self-register, so the seed creates no members; it installs the
+Wix Members Area app (profile data for the account page). Run it before verifying `/account`.
+
+## Verify (before declaring done)
+
+- [ ] Header shows the account control: "Log in" for a visitor, the member's name after login.
+- [ ] Clicking log in lands on the Wix login page and back on the page the visitor started
+      from (the `returnToUrl` round-trip).
+- [ ] `/account` (or your gated route) bounces a visitor to login, and renders the REAL
+      member — name/email/photo — after login.
+- [ ] Log out returns a clean anonymous visitor; the session survives a reload while logged in.
+- [ ] React stack: `/callback` mounts `LoginCallback`; the `allowedRedirectUris` step is done
+      (or handed to the owner with the exact URI).
+- [ ] Account/header surfaces are YOUR designs on the tokens; the wix/members + hook files
+      are unedited.
+- [ ] No mocked member state anywhere; seed result JSON shows the Members Area install.
+- [ ] Dashboard links handed to the owner.

--- a/skills/wix-headless-fast/references/members/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/members/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,42 @@
+---
+// The site chrome for every members page — THIS file (header/footer/nav) plus the @theme
+// token block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" />
+// in <head>, the global.css import, and one <MemberMenu client:only="react"> in the header
+// (it reads browser session state and must not server-render). (If another vertical is also
+// deployed, its SiteLayout won — mount MemberMenu in that header instead.)
+import MemberMenu from "../components/members/MemberMenu";
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <MemberMenu client:only="react" />
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/members/app-astro/pages/account.astro
+++ b/skills/wix-headless-fast/references/members/app-astro/pages/account.astro
@@ -1,0 +1,18 @@
+---
+// Member-gated account page — the gate lives HERE, server-side (a client-side check flashes
+// gated UI). fetchCurrentMember never throws: null = anonymous → bounce to the built-in
+// login route. ⚠️ The return param is `returnToUrl` — NOT `returnUrl` (silently dropped,
+// the member lands on "/"). This page needs the Wix Members Area app installed (the seed
+// installs it) — without it a LOGGED-IN member also reads null here and loops through login.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import AccountView from "../components/members/AccountView";
+import { fetchCurrentMember } from "../wix/members/members";
+
+const member = await fetchCurrentMember();
+if (!member) return Astro.redirect(`/api/auth/login?returnToUrl=${encodeURIComponent("/account")}`);
+---
+
+<SiteLayout title="My account">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">My account</h1>
+  <AccountView client:load initialMember={member} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/members/app/components/members/AccountView.tsx
+++ b/skills/wix-headless-fast/references/members/app/components/members/AccountView.tsx
@@ -1,0 +1,60 @@
+// REFERENCE account surface: profile card + log-out on the @theme tokens. Correct and
+// complete; per the skill's model you design your own on useMember. On Astro the page
+// passes the SSR-resolved member as initialMember; a SPA mounts it inside <RequireAuth>.
+import { useMember } from "../../hooks/members/useMember";
+import type { CurrentMember } from "../../wix/members/types";
+
+export interface AccountViewProps {
+  initialMember?: CurrentMember | null;
+}
+
+export default function AccountView({ initialMember }: AccountViewProps) {
+  const { member, loggedIn, loading, error, logout } = useMember({ initialMember });
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-md" aria-busy="true">
+        <div className="h-40 animate-pulse rounded-lg bg-secondary" />
+      </div>
+    );
+  }
+
+  if (!loggedIn) {
+    return <p className="py-16 text-center text-muted-foreground">You're logged out.</p>;
+  }
+
+  return (
+    <div className="mx-auto max-w-md rounded-lg border border-border p-8">
+      <div className="flex items-center gap-4">
+        {member?.photoUrl ? (
+          <img src={member.photoUrl} alt="" className="h-16 w-16 rounded-full object-cover" />
+        ) : (
+          <span className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary text-xl font-semibold">
+            {(member?.displayName ?? "M").slice(0, 1).toUpperCase()}
+          </span>
+        )}
+        <div>
+          <p className="text-lg font-semibold text-foreground">{member?.displayName ?? "Member"}</p>
+          {member?.loginEmail && <p className="text-sm text-muted-foreground">{member.loginEmail}</p>}
+          {member?.memberSince && (
+            <p className="mt-0.5 text-xs text-muted-foreground">Member since {member.memberSince}</p>
+          )}
+        </div>
+      </div>
+      {!member && (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Logged in, but profile details are unavailable — the Wix Members Area app isn't installed
+          on this site.
+        </p>
+      )}
+      {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+      <button
+        type="button"
+        onClick={() => void logout()}
+        className="mt-6 rounded-full border border-border px-5 py-2 text-sm font-medium text-foreground transition-colors hover:bg-secondary"
+      >
+        Log out
+      </button>
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/members/app/components/members/LoginCallback.tsx
+++ b/skills/wix-headless-fast/references/members/app/components/members/LoginCallback.tsx
@@ -1,0 +1,35 @@
+// REFERENCE /callback handler — REACT stack only. Mount at exactly CALLBACK_PATH ("/callback");
+// ambient Astro never uses it (@wix/astro owns /api/auth/callback itself). Finishes the login
+// handshake and sends the member back to where they started.
+import { useEffect, useRef, useState } from "react";
+import { completeLogin } from "../../wix/members/auth";
+
+export default function LoginCallback() {
+  const [error, setError] = useState<string | null>(null);
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return; // completeLogin consumes the one-shot OAuth state — never run it twice
+    ran.current = true;
+    completeLogin()
+      .then((returnTo) => window.location.replace(returnTo))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-md rounded-lg border border-border p-8 text-center">
+        <p className="text-sm text-red-600">{error}</p>
+        <a href="/" className="mt-4 inline-block text-sm text-muted-foreground underline">
+          Back to the site
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <p className="py-16 text-center text-muted-foreground" aria-busy="true">
+      Signing you in…
+    </p>
+  );
+}

--- a/skills/wix-headless-fast/references/members/app/components/members/MemberMenu.tsx
+++ b/skills/wix-headless-fast/references/members/app/components/members/MemberMenu.tsx
@@ -1,0 +1,67 @@
+// REFERENCE header account control on the @theme tokens: "Log in" for a visitor; account
+// link + log-out for a member. Correct and complete; per the skill's model you design your
+// own on useMember. Mount client:only="react" — it reads browser session state.
+import type { ComponentType, ReactNode } from "react";
+import { useMember } from "../../hooks/members/useMember";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface MemberMenuProps {
+  accountHref?: string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export default function MemberMenu({ accountHref = "/account", LinkComponent = PlainLink }: MemberMenuProps) {
+  const { member, loggedIn, loading, login, logout } = useMember();
+
+  if (loading) {
+    return <span className="inline-block h-8 w-16 animate-pulse rounded-full bg-secondary" aria-hidden="true" />;
+  }
+
+  if (!loggedIn) {
+    return (
+      <button
+        type="button"
+        onClick={() => void login()}
+        className="rounded-full bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+      >
+        Log in
+      </button>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-3">
+      <LinkComponent
+        href={accountHref}
+        className="flex items-center gap-2 text-sm font-medium text-foreground no-underline transition-colors hover:text-muted-foreground"
+      >
+        {member?.photoUrl ? (
+          <img src={member.photoUrl} alt="" className="h-7 w-7 rounded-full object-cover" />
+        ) : (
+          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-secondary text-xs font-semibold">
+            {(member?.displayName ?? "M").slice(0, 1).toUpperCase()}
+          </span>
+        )}
+        {member?.displayName ?? "My account"}
+      </LinkComponent>
+      <button
+        type="button"
+        onClick={() => void logout()}
+        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        Log out
+      </button>
+    </span>
+  );
+}

--- a/skills/wix-headless-fast/references/members/app/components/members/RequireAuth.tsx
+++ b/skills/wix-headless-fast/references/members/app/components/members/RequireAuth.tsx
@@ -1,0 +1,46 @@
+// REFERENCE gate for member-only surfaces on the REACT stack — on Astro, gate server-side
+// in frontmatter instead (pages/account.astro shows the shape); a client-side check there
+// flashes gated UI. Renders children only for a logged-in member; a visitor gets a login
+// prompt in place (routing-free — no router or redirect assumptions).
+import type { ReactNode } from "react";
+import { useMember } from "../../hooks/members/useMember";
+
+export interface RequireAuthProps {
+  children: ReactNode;
+  /** Rendered for an anonymous visitor instead of the default login prompt. */
+  fallback?: ReactNode;
+}
+
+export default function RequireAuth({ children, fallback }: RequireAuthProps) {
+  const { loggedIn, loading, login } = useMember();
+
+  // Wait for the initial session read — deciding early bounces a logged-in member on first paint.
+  if (loading) {
+    return (
+      <div className="py-16 text-center text-muted-foreground" aria-busy="true">
+        Loading…
+      </div>
+    );
+  }
+
+  if (!loggedIn) {
+    return (
+      <>
+        {fallback ?? (
+          <div className="mx-auto max-w-md rounded-lg border border-border p-8 text-center">
+            <p className="text-sm text-muted-foreground">This page is for members.</p>
+            <button
+              type="button"
+              onClick={() => void login(window.location.pathname)}
+              className="mt-4 rounded-full bg-primary px-5 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+            >
+              Log in / Sign up
+            </button>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/skills/wix-headless-fast/references/members/app/hooks/members/useMember.ts
+++ b/skills/wix-headless-fast/references/members/app/hooks/members/useMember.ts
@@ -1,0 +1,40 @@
+// React binding for the member store. Works in any React root — Astro islands (several on
+// one page share the same session) and SPAs alike. SSR-friendly: pass a server-resolved
+// member as `initialMember` (Astro island props) and no client re-fetch happens.
+import { useRef, useSyncExternalStore } from "react";
+import {
+  getMemberState,
+  hydrateMember,
+  login,
+  logout,
+  refreshMember,
+  subscribeMember,
+  type MemberState,
+} from "../../wix/members/member-store";
+import type { CurrentMember } from "../../wix/members/types";
+
+export interface UseMemberOptions {
+  /** Server-resolved member (null = a known-anonymous visitor); omit to resolve client-side. */
+  initialMember?: CurrentMember | null;
+}
+
+export interface UseMember extends MemberState {
+  /** Send the visitor to the Wix login page (logs in OR signs up); navigates away. */
+  login: (returnTo?: string) => Promise<void>;
+  /** Log out through the Wix logout flow; navigates away. */
+  logout: (returnTo?: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useMember({ initialMember }: UseMemberOptions = {}): UseMember {
+  // Adopt SSR props into the shared store before the first subscription (a no-op once any
+  // island has settled the session).
+  if (typeof window !== "undefined" && initialMember !== undefined) hydrateMember(initialMember);
+  const server = useRef<MemberState | null>(null);
+  server.current ??=
+    initialMember !== undefined
+      ? { member: initialMember, loggedIn: initialMember !== null, loading: false, error: null }
+      : getMemberState();
+  const state = useSyncExternalStore(subscribeMember, getMemberState, () => server.current as MemberState);
+  return { ...state, login, logout, refresh: refreshMember };
+}

--- a/skills/wix-headless-fast/references/members/app/wix/members/auth.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/auth.ts
@@ -1,0 +1,85 @@
+// Member login/logout — the ONE stack-branched file. Sign-up, log-in, and log-out are the
+// same Wix-hosted flow: the login page registers a new member or logs in an existing one;
+// never build a separate sign-up call.
+//
+// Ambient (Wix-managed Astro): `@wix/astro` ships the whole mechanism as built-in routes —
+// GET /api/auth/login and POST /api/auth/logout — and keeps the session in a cookie shared
+// by SSR and every client island. startLogin/logoutMember just navigate into those routes.
+// ⚠️ The routes' return param is `returnToUrl` — NOT `returnUrl`: unknown params are
+// silently dropped and the member lands on "/".
+//
+// Manual (any other React setup): the same hosted login page, driven by hand on the shared
+// OAuthStrategy client — generateOAuthData → getAuthUrl → redirect → (on /callback)
+// parseFromUrl → getMemberTokens → setTokens. Member tokens are the same shape as visitor
+// tokens and persist through sdk.ts's token storage, so the session survives reloads.
+// ⚠️ Manual preconditions: the connected site must be PUBLISHED, and `<origin>/callback`
+// must be in the OAuth app's allowedRedirectUris — a manual post-release step; `wix release`
+// registers only the origin. See INSTRUCTIONS → "Wiring — React SPA".
+import type { OauthData } from "@wix/sdk";
+import { WIX_CLIENT_ID } from "../config";
+import { wixAuth } from "../sdk";
+
+const OAUTH_STASH_KEY = `wix-oauth-data-${WIX_CLIENT_ID ?? "ambient"}`;
+
+/** Where the manual handshake returns to — mount LoginCallback on exactly this route (react stack). */
+export const CALLBACK_PATH = "/callback";
+
+/**
+ * Synchronous session check: manual mode → exact; ambient → null (unknown — the member
+ * store resolves it by fetching the current member).
+ */
+export function loggedInHint(): boolean | null {
+  const auth = wixAuth();
+  return auth ? auth.loggedIn() : null;
+}
+
+/** Send the visitor to the Wix login page (logs in OR signs up). `returnTo` is a relative path. */
+export async function startLogin(returnTo?: string): Promise<void> {
+  const dest = returnTo ?? window.location.pathname + window.location.search;
+  const auth = wixAuth();
+  if (!auth) {
+    window.location.href = `/api/auth/login?returnToUrl=${encodeURIComponent(dest)}`;
+    return;
+  }
+  const oauthData = auth.generateOAuthData(window.location.origin + CALLBACK_PATH, dest);
+  window.localStorage.setItem(OAUTH_STASH_KEY, JSON.stringify(oauthData)); // survives the redirect
+  const { authUrl } = await auth.getAuthUrl(oauthData);
+  window.location.href = authUrl;
+}
+
+/**
+ * Finish a manual-mode login on the CALLBACK_PATH route. Resolves to the path the member
+ * started from. Throws with the provider's message on a failed login — surface it; do NOT
+ * loop back into startLogin automatically.
+ */
+export async function completeLogin(): Promise<string> {
+  const auth = wixAuth();
+  if (!auth) throw new Error("completeLogin is manual-mode only — ambient auth handles its own /api/auth/callback.");
+  const stashed = window.localStorage.getItem(OAUTH_STASH_KEY);
+  if (!stashed) throw new Error("No login in progress — the stored OAuth state is gone. Start the login again.");
+  const oauthData = JSON.parse(stashed) as OauthData;
+  const returned = auth.parseFromUrl(); // default responseMode: the code rides in the URL fragment
+  if (returned.error) throw new Error(returned.errorDescription || returned.error);
+  const tokens = await auth.getMemberTokens(returned.code, returned.state, oauthData);
+  auth.setTokens(tokens); // persists via sdk.ts token storage — later SDK calls run as the member
+  window.localStorage.removeItem(OAUTH_STASH_KEY);
+  return oauthData.originalUri || "/";
+}
+
+/** Log out and navigate through the Wix logout flow back to `returnTo` (relative path). */
+export async function logoutMember(returnTo = "/"): Promise<void> {
+  const auth = wixAuth();
+  if (!auth) {
+    // The built-in logout is a POST route answering with a redirect chain — submit a real
+    // form so the browser follows it as navigation (fetch can't).
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = `/api/auth/logout?returnToUrl=${encodeURIComponent(returnTo)}`;
+    document.body.appendChild(form);
+    form.submit();
+    return;
+  }
+  // logout() clears the strategy's tokens itself — the next load is a clean anonymous visitor.
+  const { logoutUrl } = await auth.logout(new URL(returnTo, window.location.origin).href);
+  window.location.href = logoutUrl;
+}

--- a/skills/wix-headless-fast/references/members/app/wix/members/member-store.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/member-store.ts
@@ -1,0 +1,84 @@
+// Member session state — a module-scope store, deliberately NOT a React context.
+// A context can't span Astro islands (each island is its own React root); a module
+// singleton is shared by every island in the page bundle, and works identically in a
+// single-root SPA. Consume it through useMember() (hooks/), or subscribe directly.
+import { fetchCurrentMember } from "./members";
+import { loggedInHint, logoutMember, startLogin } from "./auth";
+import type { CurrentMember } from "./types";
+
+export interface MemberState {
+  member: CurrentMember | null;
+  /** True for a logged-in member — can be true with `member` null when the Members Area app is absent. */
+  loggedIn: boolean;
+  /** True until the first session read settles — render skeletons, not the logged-out state. */
+  loading: boolean;
+  /** Last failed operation's message — render it; a new operation clears it. */
+  error: string | null;
+}
+
+const EMPTY: MemberState = { member: null, loggedIn: false, loading: true, error: null };
+
+let state: MemberState = EMPTY;
+const listeners = new Set<() => void>();
+let started = false;
+
+function setState(patch: Partial<MemberState>): void {
+  state = { ...state, ...patch };
+  for (const l of listeners) l();
+}
+
+export function getMemberState(): MemberState {
+  return state;
+}
+
+/** Adopt an SSR-resolved member (Astro island props) so no client re-fetch happens. */
+export function hydrateMember(member: CurrentMember | null): void {
+  if (started) return;
+  started = true;
+  state = { member, loggedIn: member !== null, loading: false, error: null };
+}
+
+export function subscribeMember(listener: () => void): () => void {
+  listeners.add(listener);
+  // First subscriber triggers the initial session read (browser only — SSR renders `loading`).
+  if (!started && typeof window !== "undefined") {
+    started = true;
+    void refreshMember();
+  }
+  return () => listeners.delete(listener);
+}
+
+/** Re-read the session — call after anything that may have changed it. */
+export async function refreshMember(): Promise<void> {
+  setState({ loading: true, error: null });
+  const hint = loggedInHint();
+  if (hint === false) {
+    setState({ member: null, loggedIn: false, loading: false });
+    return;
+  }
+  // hint true → read the profile (null = profile data missing, still logged in).
+  // hint null (ambient) → the member read IS the session check: null = anonymous.
+  const member = await fetchCurrentMember();
+  setState({ member, loggedIn: hint ?? member !== null, loading: false });
+}
+
+/** Kick off login (navigates away). Throws (and sets .error) when the redirect can't start. */
+export async function login(returnTo?: string): Promise<void> {
+  try {
+    await startLogin(returnTo);
+  } catch (e) {
+    setState({ error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+/** Log out (navigates away); local state resets for the instant before the redirect lands. */
+export async function logout(returnTo?: string): Promise<void> {
+  setState({ member: null, loggedIn: false });
+  try {
+    await logoutMember(returnTo);
+  } catch (e) {
+    setState({ error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}

--- a/skills/wix-headless-fast/references/members/app/wix/members/members.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/members.ts
@@ -1,0 +1,51 @@
+// Current-member read (Wix Members) — the only file that touches raw member entities.
+// Identity vs. profile are different layers: "is this caller logged in?" needs no app
+// install, but getCurrentMember returns profile DATA only once the Wix Members Area app is
+// installed (the seed installs it). Copy as-is; extend by adding functions, not by editing
+// these.
+import { members } from "@wix/members";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { CurrentMember } from "./types";
+
+const membersApi = wixModule(members);
+
+type Raw = Record<string, any>;
+
+function toCurrentMember(raw: Raw): CurrentMember {
+  const nickname = raw.profile?.nickname ?? "";
+  const firstName = raw.contact?.firstName ?? "";
+  const lastName = raw.contact?.lastName ?? "";
+  const loginEmail = raw.loginEmail ?? "";
+  const fullName = [firstName, lastName].filter(Boolean).join(" ");
+  return {
+    id: raw._id ?? "",
+    loginEmail,
+    displayName: nickname || fullName || loginEmail.split("@")[0] || "Member",
+    firstName,
+    lastName,
+    nickname,
+    photoUrl: imgSrc(raw.profile?.photo, 200, 200),
+    contactId: raw.contactId ?? "",
+    memberSince: raw._createdDate ? new Date(raw._createdDate).toISOString().slice(0, 10) : "",
+  };
+}
+
+/**
+ * The current member, or null for an anonymous visitor — and null for a LOGGED-IN member
+ * when the Members Area app isn't installed (setup, not a code bug; the seed installs it).
+ * Never throws: anonymous is a normal state, and an unguarded throw in Astro frontmatter
+ * truncates the response mid-stream.
+ * ⚠️ The SDK export is getCurrentMember — the REST name "Get My Member" does not exist on
+ * the module; getMyMember(...) throws `is not a function`, and only once a real member
+ * loads the page.
+ */
+export async function fetchCurrentMember(): Promise<CurrentMember | null> {
+  try {
+    const res = await membersApi.getCurrentMember({ fieldsets: ["FULL"] });
+    const raw = res.member as Raw | undefined;
+    return raw?._id ? toCurrentMember(raw) : null;
+  } catch {
+    return null;
+  }
+}

--- a/skills/wix-headless-fast/references/members/app/wix/members/types.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/types.ts
@@ -1,0 +1,21 @@
+// Members DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. The photo is a
+// resolved https URL.
+
+/** The logged-in member as the header/account surfaces need it. */
+export interface CurrentMember {
+  id: string;
+  /** Email the member logs in with ("" when the fieldset hides it). */
+  loginEmail: string;
+  /** Best display name: nickname → first+last → the login email's local part. */
+  displayName: string;
+  firstName: string;
+  lastName: string;
+  nickname: string;
+  /** Resolved https URL ("" when the member has no photo). */
+  photoUrl: string;
+  /** Contact-list id — the key for member-owned CMS/content lookups. */
+  contactId: string;
+  /** "YYYY-MM-DD" the membership was created ("" when unknown). */
+  memberSince: string;
+}

--- a/skills/wix-headless-fast/references/members/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/members/lock/astro/package-lock.json
@@ -1,0 +1,10329 @@
+{
+ "name": "wix-headless-fast-members",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-members",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/members": "^1.0.511",
+    "@wix/sdk": "^1.21.5",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "dev": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_authentication": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/@wix/auto_sdk_members_authentication-1.0.45.tgz",
+   "integrity": "sha512-rYbM07KLz3FQgjxb1tUO/7Ns+ZnI15XCdXQI13NZRmWLLU6NhxfVuy7EyHNxb+IgeEXzAyiqB1taGY4IriMx9g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_authorization": {
+   "version": "1.0.36",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/@wix/auto_sdk_members_authorization-1.0.36.tgz",
+   "integrity": "sha512-hpaTseJXSv9CpQWwFItXjmIPgq0NjNBBm98XX6We7m+lDMXkoDHvIgo645xS/jIMpWbwRS26/iY61W9A9Is02g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badge-assignments": {
+   "version": "1.0.30",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/@wix/auto_sdk_members_badge-assignments-1.0.30.tgz",
+   "integrity": "sha512-0RggesluwvfP8lEpLTaJlKtz9LKEuuPzIKpxce+iGbSZin6CyvmaV9HIGEO+G64QSOdWCzXUY8JU+9/4ni1xPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badges": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/@wix/auto_sdk_members_badges-1.0.52.tgz",
+   "integrity": "sha512-vJPXfwIKobCLFvW6EalpbP9mZe/fTL7WiZsdlZJUX7igr64udS65JAnnDb73Ge7l9SoiWtXUDLPcvbMMF+mw8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_badges-v-2": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/@wix/auto_sdk_members_badges-v-2-1.0.37.tgz",
+   "integrity": "sha512-KHy7ZizF1KW+icDRabv3swQtR0i+WQ43XcqQ3sFYVowpXsb73rg9XgpZ8/3gc+d5sEedIh9OuCOtYfzZi2htsg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-field-applications": {
+   "version": "1.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/@wix/auto_sdk_members_custom-field-applications-1.0.41.tgz",
+   "integrity": "sha512-GnCIAZ7ATgCr9gEqxuClE4y9VHEN1ayxq2nJrdHatIkxsoElvWp2E/Uw9e7O0TUdkNXLLlBvd3mjeKpdrUhUvQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-field-suggestions": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/@wix/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
+   "integrity": "sha512-2LCuljSdthAoIoiw4A+ZjSIOqCam4TnsJI1meZLmvOUBenQghzeflwvFvmIG13h+lkKWiLc0WmkhrmEo8Iosog==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_custom-fields": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/@wix/auto_sdk_members_custom-fields-1.0.59.tgz",
+   "integrity": "sha512-e0Gj3mWXzv1VDGY95CMh1zVp6YQGbLuURD4TTDuxETvqEYMFzTtDXfTuGi90MbEWAwTk1aqYF8BR0gKL0ILV8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_default-privacy": {
+   "version": "1.0.34",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/@wix/auto_sdk_members_default-privacy-1.0.34.tgz",
+   "integrity": "sha512-pgAe1M898aSSnYKn0mIf8SdGNeA2lK8OI9vncLv9kV1wknP5ue6/eNr3GEBl5JawspoifxbyuD7C+c1R8WiLBw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-followers": {
+   "version": "1.0.44",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/@wix/auto_sdk_members_member-followers-1.0.44.tgz",
+   "integrity": "sha512-LVxdoeXewsZul72frlyLY5PYU6Ycz6ddbvYkhZr09TCgP6sPvwCuI+br/r3sxGwJ3XlM3w9cFtwOc6cZf40+eA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-privacy-settings": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/@wix/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
+   "integrity": "sha512-JpcWY+fppyjBXfwcIX7ztlo34ZpA+b7Cbhh62oaH8fzQq7PpfVk9zc94FT2EEiwutaipgJOU4SyrLl3/JULwGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-report": {
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/@wix/auto_sdk_members_member-report-1.0.49.tgz",
+   "integrity": "sha512-kx+netTOEhPS32d98pgko+fbwyR4HT87TlxdKqg1aBaJBrDEz2M533wc8wTJX1TArj9B41ew39k/fXdbfCEozA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-role-definition": {
+   "version": "1.0.47",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/@wix/auto_sdk_members_member-role-definition-1.0.47.tgz",
+   "integrity": "sha512-PpGcfee/QCqtCU4U7KdGjqe8CB8ereXnMxLleisyapNWhwfWo1r1XBfq4EaVc0GF9uLdozWWx6Oums/bB42E6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_member-to-member-block": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/@wix/auto_sdk_members_member-to-member-block-1.0.35.tgz",
+   "integrity": "sha512-U5Z5l7KGpYztXtz0E3V7JNogdJGNCPmcR5yjeEZdT0u8yZTQKsnF7hNvMxxyv2RMGJwCNmdYLHbFYj/ic/Futw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_members": {
+   "version": "1.0.131",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/@wix/auto_sdk_members_members-1.0.131.tgz",
+   "integrity": "sha512-kgPFRm1faDjRsCv7kOcALlZiHpBJ9Ix5PZy8NJxzJEu2kKBdkdH6kVBTk+R13lRO6XkK5NRPytY9cinu2suP2g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_members-about": {
+   "version": "1.0.78",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/@wix/auto_sdk_members_members-about-1.0.78.tgz",
+   "integrity": "sha512-HPXMekpWcexRubnf5gA0flYiYktEcsj4kMi0oyC47zTTIO7tmpqjJULH365y8rzDx6vPLUb25Lzyb+rCZPTxwA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_members_user-member": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/@wix/auto_sdk_members_user-member-1.0.56.tgz",
+   "integrity": "sha512-FMiVGhE+F6psLwXTKC4Rz2W/dDl1Sa2Fj/P80+jDkTZ5IDR5c4Qq5M3Prlj7MmHIjSx7OsEX6zdRVoGFBjfA0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/members": {
+   "version": "1.0.511",
+   "resolved": "https://registry.npmjs.org/@wix/members/-/@wix/members-1.0.511.tgz",
+   "integrity": "sha512-n30tjMx6LAiDiCVT2jnenoFIxEwgIwbn7S5pWbesVvo73+mDuyn0+bxVJJw0acGY00nvnmpJsdrU28VMOz5CKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_members_authentication": "1.0.45",
+    "@wix/auto_sdk_members_authorization": "1.0.36",
+    "@wix/auto_sdk_members_badge-assignments": "1.0.30",
+    "@wix/auto_sdk_members_badges": "1.0.52",
+    "@wix/auto_sdk_members_badges-v-2": "1.0.37",
+    "@wix/auto_sdk_members_custom-field-applications": "1.0.41",
+    "@wix/auto_sdk_members_custom-field-suggestions": "1.0.40",
+    "@wix/auto_sdk_members_custom-fields": "1.0.59",
+    "@wix/auto_sdk_members_default-privacy": "1.0.34",
+    "@wix/auto_sdk_members_member-followers": "1.0.44",
+    "@wix/auto_sdk_members_member-privacy-settings": "1.0.59",
+    "@wix/auto_sdk_members_member-report": "1.0.49",
+    "@wix/auto_sdk_members_member-role-definition": "1.0.47",
+    "@wix/auto_sdk_members_member-to-member-block": "1.0.35",
+    "@wix/auto_sdk_members_members": "1.0.131",
+    "@wix/auto_sdk_members_members-about": "1.0.78",
+    "@wix/auto_sdk_members_user-member": "1.0.56"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/members/seed/SEED.md
+++ b/skills/wix-headless-fast/references/members/seed/SEED.md
@@ -1,0 +1,39 @@
+# Members — seeding
+
+**Members self-register — there is no member content to seed.** The Wix login page registers
+or logs in members at runtime; creating members at build time is intentionally out of scope
+(a headless run must never stall on an interactive login, and Create Member needs an
+elevated credential).
+
+What `seed-members.mjs` does is the one build-time setup the vertical needs: **install the
+Wix Members Area app** — the *profile* layer. Identity (log in / log out / "logged-in vs
+not" gating) needs no install; profile data does: without the app, `getCurrentMember()`
+returns nothing for a logged-in member and the account page can't render who they are.
+
+```bash
+# from the project root (where wix.config.json lives) — the plan file is optional:
+node <SKILL_ROOT>/references/members/seed/seed-members.mjs
+```
+
+```json
+{ "installMembersArea": true }
+```
+
+- `installMembersArea` — default `true`; set `false` only when the run needs pure
+  "logged-in vs not" gating and will never display member data.
+- Re-running is safe: an already-installed app is recorded in the result JSON
+  (`membersAreaInstall.note`), never thrown.
+
+**Seeding is additive — never delete or overwrite existing content**; ask first if a cleanup
+seems needed.
+
+## Escape hatch — individual functions
+`setupMembers` composes the exported steps — `installMembersAreaApp`, plus `makeCtx()` —
+import them for a partial re-run.
+
+## Reference
+The appDefId and the identity/profile split come from
+`wix-headless/references/SETUP.md` (§ members). Signup security (email verification, owner
+approval, reCAPTCHA) is dashboard-governed — never seeded. If a run's prompt explicitly needs
+a pre-created member (rare), the admin Create Member shape is in the live Wix API reference —
+read it via the `wix-docs` skill; don't guess it here.

--- a/skills/wix-headless-fast/references/members/seed/seed-members.mjs
+++ b/skills/wix-headless-fast/references/members/seed/seed-members.mjs
@@ -1,0 +1,93 @@
+// Members seed — a BUILD-TIME script, never shipped in the app. Run from the project root
+// (where wix.config.json lives); the plan file is optional:
+//
+//   node <SKILL_ROOT>/references/members/seed/seed-members.mjs [plan.json]
+//
+// Members SELF-REGISTER — there is no member content to create (see SEED.md). The one
+// build-time setup this vertical needs is installing the Wix Members Area app, which serves
+// member PROFILE data: without it getCurrentMember() returns nothing for a logged-in member,
+// so the account page can't render who they are. Identity alone (log in / log out / gating)
+// needs no install. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md): { "installMembersArea": true }   // default true
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. Authoritative source:
+// wix-headless/references/SETUP.md § members (the appDefId and the identity/profile split).
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+// The Wix Members Area app (the profile layer). Not in the "Apps Created by Wix" table —
+// the GUID comes from the App Market listing; recorded in wix-headless/references/SETUP.md.
+// Installing it pulls in its Site-Members dependency automatically.
+const MEMBERS_AREA_APP_ID = "14cc59bc-f0b7-15b8-e1c7-89ce41d0e0c9";
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// ---- operations ----------------------------------------------------------------------------------
+
+/**
+ * Install the Wix Members Area app (idempotent in effect: re-running against a site that
+ * already has it errors — recorded in the result, not thrown, since "already installed" and
+ * a real failure aren't distinguishable from the response).
+ */
+export async function installMembersAreaApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: MEMBERS_AREA_APP_ID, enabled: true },
+    } });
+    return { requested: true, note: null };
+  } catch (e) {
+    return { requested: false, note: String(e.message).slice(0, 300) };
+  }
+}
+
+/** ONE-CALL seed: install the Members Area app (the profile layer). The default path. */
+export async function setupMembers(ctx, { installMembersArea = true } = {}) {
+  return {
+    membersAreaAppId: MEMBERS_AREA_APP_ID,
+    membersAreaInstall: installMembersArea ? await installMembersAreaApp(ctx) : { skipped: true },
+    membersCreated: 0, // members self-register — never created at build time
+  };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  const plan = planPath ? JSON.parse(readFileSync(planPath, "utf8")) : {};
+  const ctx = makeCtx();
+  setupMembers(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/portfolio/INSTRUCTIONS.md
@@ -1,0 +1,134 @@
+# Portfolio — playbook
+
+The portfolio machinery ships as files — collections, projects, the per-project media gallery
+(image AND video items), typed end-to-end. Portfolio is **read-only**: no cart, no checkout,
+no `@wix/ecom`. **The presentation is yours**: you design and implement the collection card,
+the project card + grid, the project-detail gallery, and the home page on the shipped
+hooks/DTOs, plus the brand. You never write read logic; you never skip designing.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/portfolio/types.ts` | the DTOs (`CollectionSummary`, `ProjectSummary`, `ProjectDetail`, `ProjectDetailRow`, `GalleryItem`) — contracts below |
+| `wix/portfolio/portfolio.ts` | `fetchCollections`, `fetchCollectionBySlug`, `fetchProjects`, `fetchProjectBySlug`, `fetchProjectGallery` |
+| `hooks/portfolio/useCollections.ts` | collections gallery — contract below |
+| `hooks/portfolio/useCollectionProjects.ts` | one collection + its projects, by slug — contract below |
+| `hooks/portfolio/useProjectDetail.ts` | one project + its media gallery, by slug — contract below |
+| `components/portfolio/CollectionsView.tsx` (+ `CollectionCard`) · `CollectionProjectsView.tsx` (+ `ProjectCard`) · `ProjectDetailView.tsx` (+ `GalleryMedia`) | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot + global.css import). If another vertical is also deployed, its layout won — add a Portfolio nav link there |
+| `pages/portfolio.astro` | SSR collections gallery — **keep the frontmatter**, swap the island import to YOUR component |
+| `pages/portfolio/[slug].astro` | SSR collection page (header + projects) — **keep the frontmatter**, swap the island import |
+| `pages/projects/[slug].astro` | SSR project detail + gallery — **keep the frontmatter**, swap the island import. Portfolio has no documented Wix SEO item type, so these pages carry plain `<title>`/`<meta>` from the DTO (no `wixMetadata`/`<SEO.Tags>`) |
+
+## What you build — the design job
+
+1. **The collection card + gallery surface** — your tile (cover, title, description) and
+   rhythm, with skeletons while loading and an honest empty state — on `useCollections`.
+2. **The project card + collection page** — the collection header and your project grid — on
+   `useCollectionProjects` (route a not-found state off `notFound`, never off a transient
+   null).
+3. **The project-detail surface** — title/description, the `details` rows (text or link, as
+   given), and the media gallery: `kind: "image"` → `<img>`; `kind: "video"` → `<video>` with
+   `videoUrl` + `imageUrl` as poster; wrap in a link when `linkUrl` is set; empty gallery →
+   the project cover when it exists, else an honest empty note — on `useProjectDetail`.
+4. **The home page** — hero, featured collections or projects (fetch in frontmatter → your
+   components), brand story.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// CollectionSummary (tiles): { id, slug, title, description, imageUrl /* "" when none */ }
+// ProjectSummary (tiles): { id, slug, title, description, imageUrl /* cover or video poster */,
+//   collectionIds: string[] }
+// ProjectDetail adds: details: [{ label, text, url|null, target|null /* url set → link row */ }]
+// GalleryItem: { id, kind: "image"|"video", title, description,
+//   imageUrl /* image, or the video's poster; may be "" */,
+//   videoUrl /* video only, else null */, linkUrl|null, linkTarget|null }
+
+// useCollections({ initialCollections? }) →
+// { collections: CollectionSummary[]|null /* null = loading → skeletons */, error }
+
+// useCollectionProjects(slug, { initialCollection?, initialProjects? }) →
+// { collection: CollectionSummary|null,       // null while loading AND when notFound
+//   notFound,                                 // the real 404 signal
+//   projects: ProjectSummary[]|null,          // null = loading → skeletons
+//   error }
+
+// useProjectDetail(slug, { initialProject?, initialItems? }) →
+// { project: ProjectDetail|null, notFound,
+//   items: GalleryItem[]|null,                // dashboard order; null = loading
+//   error }
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — merge into the
+   existing layout instead if another vertical is deployed).
+2. Write your components under `src/components/portfolio/` (new names — don't overwrite the
+   references), swap the island imports in `pages/portfolio.astro`,
+   `pages/portfolio/[slug].astro`, and `pages/projects/[slug].astro`. Islands are
+   `client:load` with the SSR props. **Author your surfaces in as few messages as possible** —
+   batch multiple Writes per message.
+3. Write `pages/index.astro` (home) — it exists from the scaffold; Read it before overwriting.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/portfolio` → your gallery; `/portfolio/:slug` →
+your collection page on `useCollectionProjects(slug)`; `/projects/:slug` → your detail
+surface on `useProjectDetail(slug)`.
+
+## Hard rules
+
+- **Reads only through the shipped exports** — they filter `hidden`, sort collections by the
+  owner's `sortOrder` (projects have none — list order), and resolve every `wix:image://` /
+  `wix:video://` value. Never hand-build a `wixstatic.com` URL, never render a raw media
+  string into `src`.
+- **This vertical sells nothing** — no cart, no checkout, no `@wix/ecom`/`@wix/redirects`
+  imports. A "contact about this project" CTA is a link, not a purchase flow.
+- **Route not-found off `notFound`**, and surface `error` — a transient `null` is loading,
+  not a 404.
+- **Render `details` rows as given** (text or link per row); don't invent metadata.
+- **Gallery items branch on `kind`** — an image never gets a `<video>` tag and vice versa;
+  nothing renderable → skip the item, never a broken tag.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Live data or an honest empty state — never mock collections, projects, or media.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link — the deploy step's JSON printed `dashboardUrl`; append
+`/wix-portfolio/projects` for Portfolio management (Projects and Collections are tabs on that
+one page: Projects adds projects and their media galleries; Collections groups them).
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-portfolio.mjs` from the project root.
+Seed collections + projects that exercise the UI (covers on everything, 2–3 gallery images
+per project, `details` rows on a couple of projects). A fresh install ships sample content —
+seeding never deletes it; ask the owner before any cleanup.
+
+## Verify (before declaring done)
+
+- [ ] `/portfolio` renders live collections SSR (view-source shows titles) through YOUR
+      components; empty portfolio shows your honest empty state.
+- [ ] A collection page lists its projects (and only its); an unknown slug 404s.
+- [ ] A project page renders the gallery in order, the `details` rows, and — if any project
+      has a video item — a playing `<video>` with poster.
+- [ ] Card/grid/detail/home are YOUR designs on the tokens; data-layer/hook files unedited.
+- [ ] No `@wix/ecom` import anywhere; no mocked content.
+- [ ] Dashboard link handed to the owner.

--- a/skills/wix-headless-fast/references/portfolio/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/portfolio/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,40 @@
+---
+// The site chrome for every portfolio page — THIS file (header/footer/nav) plus the @theme
+// token block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" />
+// in <head> and the global.css import. (Deploy is fill-only: if another vertical is already
+// deployed, its SiteLayout won — merge a Portfolio nav link there instead.)
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <a href="/portfolio" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Portfolio</a>
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/portfolio/app-astro/pages/portfolio.astro
+++ b/skills/wix-headless-fast/references/portfolio/app-astro/pages/portfolio.astro
@@ -1,0 +1,21 @@
+---
+// Collections gallery — data fetched SERVER-SIDE (SEO) and handed to the island as DTO props.
+// Keep this frontmatter; swap the island import to YOUR gallery component.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import CollectionsView from "../components/portfolio/CollectionsView";
+import { fetchCollections } from "../wix/portfolio/portfolio";
+import type { CollectionSummary } from "../wix/portfolio/types";
+
+let collections: CollectionSummary[] = [];
+try {
+  collections = await fetchCollections();
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // empty state instead.
+}
+---
+
+<SiteLayout title="Portfolio">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Portfolio</h1>
+  <CollectionsView client:load initialCollections={collections} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/portfolio/app-astro/pages/portfolio/[slug].astro
+++ b/skills/wix-headless-fast/references/portfolio/app-astro/pages/portfolio/[slug].astro
@@ -1,0 +1,30 @@
+---
+// Collection page — header + its projects, resolved by slug SERVER-SIDE.
+// Portfolio has no documented Wix SEO item type, so this page carries plain
+// <title>/<meta description> from the DTO (no wixMetadata / <SEO.Tags> — unlike
+// storefront/bookings item pages). Keep the frontmatter; swap the island import to YOUR
+// collection-page component.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import CollectionProjectsView from "../../components/portfolio/CollectionProjectsView";
+import { fetchCollectionBySlug, fetchProjects } from "../../wix/portfolio/portfolio";
+import type { CollectionSummary, ProjectSummary } from "../../wix/portfolio/types";
+
+const slug = Astro.params.slug!;
+
+let collection: CollectionSummary | null = null;
+let projects: ProjectSummary[] = [];
+try {
+  collection = await fetchCollectionBySlug(slug);
+  if (collection) projects = await fetchProjects({ collectionId: collection.id });
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!collection) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<SiteLayout title={collection.title} description={collection.description}>
+  <CollectionProjectsView client:load slug={slug} initialCollection={collection} initialProjects={projects} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/portfolio/app-astro/pages/projects/[slug].astro
+++ b/skills/wix-headless-fast/references/portfolio/app-astro/pages/projects/[slug].astro
@@ -1,0 +1,29 @@
+---
+// Project detail page — project + media gallery, resolved by slug SERVER-SIDE.
+// Portfolio has no documented Wix SEO item type, so this page carries plain
+// <title>/<meta description> from the DTO (no wixMetadata / <SEO.Tags>). Keep the
+// frontmatter; swap the island import to YOUR detail component.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import ProjectDetailView from "../../components/portfolio/ProjectDetailView";
+import { fetchProjectBySlug, fetchProjectGallery } from "../../wix/portfolio/portfolio";
+import type { GalleryItem, ProjectDetail } from "../../wix/portfolio/types";
+
+const slug = Astro.params.slug!;
+
+let project: ProjectDetail | null = null;
+let items: GalleryItem[] = [];
+try {
+  project = await fetchProjectBySlug(slug);
+  if (project) items = await fetchProjectGallery(project.id);
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!project) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<SiteLayout title={project.title} description={project.description}>
+  <ProjectDetailView client:load slug={slug} initialProject={project} initialItems={items} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/portfolio/app/components/portfolio/CollectionProjectsView.tsx
+++ b/skills/wix-headless-fast/references/portfolio/app/components/portfolio/CollectionProjectsView.tsx
@@ -1,0 +1,110 @@
+// REFERENCE collection page: collection header + its projects grid on the @theme tokens.
+// Correct and complete; per the skill's model you design and build your own on
+// useCollectionProjects (ProjectCard is reusable for an all-work grid or a home strip).
+import type { ComponentType, ReactNode } from "react";
+import { useCollectionProjects } from "../../hooks/portfolio/useCollectionProjects";
+import type { CollectionSummary, ProjectSummary } from "../../wix/portfolio/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface ProjectCardProps {
+  project: ProjectSummary;
+  projectHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function ProjectCard({
+  project,
+  projectHref = (slug) => `/projects/${slug}`,
+  LinkComponent = PlainLink,
+}: ProjectCardProps) {
+  return (
+    <LinkComponent href={projectHref(project.slug)} className="group block no-underline">
+      <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-secondary">
+        {project.imageUrl && (
+          <img
+            src={project.imageUrl}
+            alt={project.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        )}
+      </div>
+      <p className="mt-3 text-sm font-medium text-foreground">{project.title}</p>
+      {project.description && (
+        <p className="mt-0.5 text-xs text-muted-foreground">{project.description}</p>
+      )}
+    </LinkComponent>
+  );
+}
+
+export interface CollectionProjectsViewProps {
+  slug: string;
+  initialCollection?: CollectionSummary;
+  initialProjects?: ProjectSummary[];
+  emptyMessage?: string;
+  projectHref?: ProjectCardProps["projectHref"];
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<ProjectCardProps>;
+}
+
+export default function CollectionProjectsView({
+  slug,
+  initialCollection,
+  initialProjects,
+  emptyMessage = "No projects in this collection yet.",
+  projectHref,
+  LinkComponent,
+  CardComponent = ProjectCard,
+}: CollectionProjectsViewProps) {
+  const { collection, notFound, projects, error } = useCollectionProjects(slug, {
+    initialCollection,
+    initialProjects,
+  });
+
+  if (notFound) {
+    return <p className="py-16 text-center text-muted-foreground">Collection not found.</p>;
+  }
+
+  return (
+    <div>
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {collection ? collection.title : <span className="inline-block h-7 w-48 animate-pulse rounded bg-secondary" />}
+        </h1>
+        {collection?.description && (
+          <p className="mt-2 max-w-2xl text-muted-foreground">{collection.description}</p>
+        )}
+      </header>
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {projects === null ? (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i}>
+              <div className="aspect-[4/3] animate-pulse rounded-lg bg-secondary" />
+              <div className="mt-3 h-3.5 w-2/3 animate-pulse rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      ) : projects.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {projects.map((p) => (
+            <CardComponent key={p.id} project={p} projectHref={projectHref} LinkComponent={LinkComponent} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/portfolio/app/components/portfolio/CollectionsView.tsx
+++ b/skills/wix-headless-fast/references/portfolio/app/components/portfolio/CollectionsView.tsx
@@ -1,0 +1,90 @@
+// REFERENCE gallery surface: collections grid on the @theme tokens.
+// Correct and complete; per the skill's model you design and build your own on useCollections.
+import type { ComponentType, ReactNode } from "react";
+import { useCollections } from "../../hooks/portfolio/useCollections";
+import type { CollectionSummary } from "../../wix/portfolio/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface CollectionCardProps {
+  collection: CollectionSummary;
+  collectionHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function CollectionCard({
+  collection,
+  collectionHref = (slug) => `/portfolio/${slug}`,
+  LinkComponent = PlainLink,
+}: CollectionCardProps) {
+  return (
+    <LinkComponent href={collectionHref(collection.slug)} className="group block no-underline">
+      <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-secondary">
+        {collection.imageUrl && (
+          <img
+            src={collection.imageUrl}
+            alt={collection.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        )}
+      </div>
+      <p className="mt-3 text-sm font-medium text-foreground">{collection.title}</p>
+      {collection.description && (
+        <p className="mt-0.5 text-xs text-muted-foreground">{collection.description}</p>
+      )}
+    </LinkComponent>
+  );
+}
+
+export interface CollectionsViewProps {
+  initialCollections?: CollectionSummary[];
+  emptyMessage?: string;
+  collectionHref?: CollectionCardProps["collectionHref"];
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<CollectionCardProps>;
+}
+
+export default function CollectionsView({
+  initialCollections,
+  emptyMessage = "No collections yet — check back soon.",
+  collectionHref,
+  LinkComponent,
+  CardComponent = CollectionCard,
+}: CollectionsViewProps) {
+  const { collections, error } = useCollections({ initialCollections });
+
+  return (
+    <div>
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {collections === null ? (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i}>
+              <div className="aspect-[4/3] animate-pulse rounded-lg bg-secondary" />
+              <div className="mt-3 h-3.5 w-2/3 animate-pulse rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      ) : collections.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {collections.map((c) => (
+            <CardComponent key={c.id} collection={c} collectionHref={collectionHref} LinkComponent={LinkComponent} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/portfolio/app/components/portfolio/ProjectDetailView.tsx
+++ b/skills/wix-headless-fast/references/portfolio/app/components/portfolio/ProjectDetailView.tsx
@@ -1,0 +1,115 @@
+// REFERENCE project detail: header, details[] rows (text or link), media gallery (image AND
+// video items) on the @theme tokens. Correct and complete; per the skill's model you design
+// and build your own on useProjectDetail. GalleryMedia's kind branching is the load-bearing
+// part — keep it (or its logic) in whatever you build.
+import type { ReactNode } from "react";
+import { useProjectDetail } from "../../hooks/portfolio/useProjectDetail";
+import type { GalleryItem, ProjectDetail } from "../../wix/portfolio/types";
+
+/** One gallery item: image, or video with poster. Nothing renderable → null (never a broken tag). */
+export function GalleryMedia({ item }: { item: GalleryItem }) {
+  if (item.kind === "video" && item.videoUrl) {
+    return (
+      <video
+        src={item.videoUrl}
+        poster={item.imageUrl || undefined}
+        controls
+        playsInline
+        className="block w-full rounded-lg bg-secondary"
+      />
+    );
+  }
+  if (item.imageUrl) {
+    return (
+      <img src={item.imageUrl} alt={item.title} loading="lazy" className="block w-full rounded-lg" />
+    );
+  }
+  return null;
+}
+
+function MaybeLink({ item, children }: { item: GalleryItem; children: ReactNode }) {
+  return item.linkUrl ? (
+    <a href={item.linkUrl} target={item.linkTarget ?? undefined} rel="noopener">
+      {children}
+    </a>
+  ) : (
+    <>{children}</>
+  );
+}
+
+export interface ProjectDetailViewProps {
+  slug: string;
+  initialProject?: ProjectDetail;
+  initialItems?: GalleryItem[];
+}
+
+export default function ProjectDetailView({ slug, initialProject, initialItems }: ProjectDetailViewProps) {
+  const { project, notFound, items, error } = useProjectDetail(slug, { initialProject, initialItems });
+
+  if (notFound) {
+    return <p className="py-16 text-center text-muted-foreground">Project not found.</p>;
+  }
+  if (!project) {
+    return (
+      <div aria-busy="true">
+        <div className="h-7 w-64 animate-pulse rounded bg-secondary" />
+        <div className="mt-6 aspect-[4/3] animate-pulse rounded-lg bg-secondary" />
+      </div>
+    );
+  }
+
+  return (
+    <article>
+      <header className="mb-8 max-w-2xl">
+        <h1 className="text-2xl font-semibold tracking-tight">{project.title}</h1>
+        {project.description && (
+          <p className="mt-2 leading-relaxed text-muted-foreground">{project.description}</p>
+        )}
+        {project.details.length > 0 && (
+          <dl className="mt-5 grid grid-cols-[auto_1fr] items-baseline gap-x-6 gap-y-1.5">
+            {project.details.map((d, i) => (
+              <div key={i} className="contents">
+                <dt className="text-sm text-muted-foreground">{d.label}</dt>
+                <dd className="m-0 text-sm text-foreground">
+                  {d.url ? (
+                    <a href={d.url} target={d.target ?? undefined} rel="noopener" className="underline">
+                      {d.text}
+                    </a>
+                  ) : (
+                    d.text
+                  )}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </header>
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {items === null ? (
+        <div className="flex flex-col gap-6" aria-busy="true">
+          <div className="aspect-[4/3] animate-pulse rounded-lg bg-secondary" />
+        </div>
+      ) : items.length === 0 ? (
+        // No gallery items — the cover is the project's only real media; text-only otherwise.
+        project.imageUrl ? (
+          <img src={project.imageUrl} alt={project.title} className="block w-full rounded-lg" />
+        ) : (
+          <p className="py-16 text-center text-muted-foreground">No media in this project yet.</p>
+        )
+      ) : (
+        <div className="flex flex-col gap-6">
+          {items.map((item) => (
+            <figure key={item.id} className="m-0">
+              <MaybeLink item={item}>
+                <GalleryMedia item={item} />
+              </MaybeLink>
+              {item.title && (
+                <figcaption className="mt-1.5 text-sm text-muted-foreground">{item.title}</figcaption>
+              )}
+            </figure>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useCollectionProjects.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useCollectionProjects.ts
@@ -1,0 +1,59 @@
+// One collection's header + its projects, by slug. SSR-friendly: pass both `initial*` and no
+// client fetch happens. `notFound` is the real not-found signal (collection stays null while
+// loading too) — route a 404 off it, never off a transient null.
+import { useEffect, useState } from "react";
+import { fetchCollectionBySlug, fetchProjects } from "../../wix/portfolio/portfolio";
+import type { CollectionSummary, ProjectSummary } from "../../wix/portfolio/types";
+
+export interface UseCollectionProjectsOptions {
+  initialCollection?: CollectionSummary;
+  initialProjects?: ProjectSummary[];
+}
+
+export interface UseCollectionProjects {
+  /** null while loading AND when not found — check `notFound` to tell them apart. */
+  collection: CollectionSummary | null;
+  notFound: boolean;
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  projects: ProjectSummary[] | null;
+  error: string | null;
+}
+
+export function useCollectionProjects(
+  slug: string,
+  { initialCollection, initialProjects }: UseCollectionProjectsOptions = {},
+): UseCollectionProjects {
+  const [collection, setCollection] = useState<CollectionSummary | null>(initialCollection ?? null);
+  const [notFound, setNotFound] = useState(false);
+  const [projects, setProjects] = useState<ProjectSummary[] | null>(initialProjects ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialCollection && initialProjects) return;
+    let alive = true;
+    (async () => {
+      try {
+        const col = initialCollection ?? (await fetchCollectionBySlug(slug));
+        if (!alive) return;
+        if (!col) {
+          setNotFound(true);
+          setProjects([]);
+          return;
+        }
+        setCollection(col);
+        const projs = await fetchProjects({ collectionId: col.id });
+        if (alive) setProjects(projs);
+      } catch (e) {
+        if (!alive) return;
+        setProjects([]);
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  return { collection, notFound, projects, error };
+}

--- a/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useCollections.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useCollections.ts
@@ -1,0 +1,39 @@
+// Collections gallery. SSR-friendly: pass server-fetched data as `initialCollections`
+// (Astro frontmatter / server component) and no client fetch happens; a SPA passes nothing.
+import { useEffect, useState } from "react";
+import { fetchCollections } from "../../wix/portfolio/portfolio";
+import type { CollectionSummary } from "../../wix/portfolio/types";
+
+export interface UseCollectionsOptions {
+  initialCollections?: CollectionSummary[];
+}
+
+export interface UseCollections {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  collections: CollectionSummary[] | null;
+  error: string | null;
+}
+
+export function useCollections({ initialCollections }: UseCollectionsOptions = {}): UseCollections {
+  const [collections, setCollections] = useState<CollectionSummary[] | null>(initialCollections ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialCollections) {
+      fetchCollections()
+        .then((c) => alive && setCollections(c))
+        .catch((e) => {
+          if (!alive) return;
+          setCollections([]);
+          setError(e instanceof Error ? e.message : String(e));
+        });
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { collections, error };
+}

--- a/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useProjectDetail.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/hooks/portfolio/useProjectDetail.ts
@@ -1,0 +1,58 @@
+// Project detail + media gallery, by slug. SSR-friendly: pass both `initial*` and no client
+// fetch happens. `notFound` is the real not-found signal (project stays null while loading).
+import { useEffect, useState } from "react";
+import { fetchProjectBySlug, fetchProjectGallery } from "../../wix/portfolio/portfolio";
+import type { GalleryItem, ProjectDetail } from "../../wix/portfolio/types";
+
+export interface UseProjectDetailOptions {
+  initialProject?: ProjectDetail;
+  initialItems?: GalleryItem[];
+}
+
+export interface UseProjectDetail {
+  /** null while loading AND when not found — check `notFound` to tell them apart. */
+  project: ProjectDetail | null;
+  notFound: boolean;
+  /** null while the gallery load is in flight — render skeletons, not an empty state. */
+  items: GalleryItem[] | null;
+  error: string | null;
+}
+
+export function useProjectDetail(
+  slug: string,
+  { initialProject, initialItems }: UseProjectDetailOptions = {},
+): UseProjectDetail {
+  const [project, setProject] = useState<ProjectDetail | null>(initialProject ?? null);
+  const [notFound, setNotFound] = useState(false);
+  const [items, setItems] = useState<GalleryItem[] | null>(initialItems ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialProject && initialItems) return;
+    let alive = true;
+    (async () => {
+      try {
+        const proj = initialProject ?? (await fetchProjectBySlug(slug));
+        if (!alive) return;
+        if (!proj) {
+          setNotFound(true);
+          setItems([]);
+          return;
+        }
+        setProject(proj);
+        const gallery = await fetchProjectGallery(proj.id);
+        if (alive) setItems(gallery);
+      } catch (e) {
+        if (!alive) return;
+        setItems([]);
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  return { project, notFound, items, error };
+}

--- a/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/portfolio.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/portfolio.ts
@@ -1,0 +1,161 @@
+// Portfolio reads (Wix Portfolio v1) — the only file that touches raw portfolio entities.
+// Read-only vertical: no cart, no checkout, no @wix/ecom. Everything it returns is a plain
+// DTO from ./types. Copy as-is; extend by adding functions, not by editing these.
+import {
+  collections as collectionsModule,
+  projects as projectsModule,
+  projectItems as projectItemsModule,
+} from "@wix/portfolio";
+import { media, VideoResolution } from "@wix/sdk";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type {
+  CollectionSummary,
+  GalleryItem,
+  ProjectDetail,
+  ProjectDetailRow,
+  ProjectSummary,
+} from "./types";
+
+const collections = wixModule(collectionsModule);
+const projects = wixModule(projectsModule);
+const projectItems = wixModule(projectItemsModule);
+
+type Raw = Record<string, any>;
+
+// The SDK types coverImage.imageInfo / item.image.imageInfo as a bare wix:image:// STRING
+// (the REST docs show an object with .url — the package wins); imgSrc resolves either shape.
+
+// videoInfo is likewise a bare wix:video:// string; getVideoUrl derives the mp4 rendition +
+// poster (a wix:image:// string → imgSrc again). 720p is the standard transcode. Tolerates
+// the REST-shaped object ({ resolutions, posters }) in case a surface returns it at runtime.
+function toVideo(value: unknown): { videoUrl: string | null; posterUrl: string } {
+  if (typeof value === "string" && value.startsWith("wix:video://")) {
+    try {
+      const v = media.getVideoUrl(value, VideoResolution.MID);
+      return { videoUrl: v.url, posterUrl: imgSrc(v.thumbnail, 1200, 675) };
+    } catch {
+      return { videoUrl: null, posterUrl: "" };
+    }
+  }
+  const raw = value as Raw | null | undefined;
+  const url = raw?.resolutions?.[0]?.url;
+  return {
+    videoUrl: typeof url === "string" ? url : null,
+    posterUrl: imgSrc(raw?.posters?.[0], 1200, 675),
+  };
+}
+
+function toCollection(raw: Raw): CollectionSummary {
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    title: raw.title ?? "",
+    description: raw.description ?? "",
+    imageUrl: imgSrc(raw.coverImage?.imageInfo, 1200, 900),
+  };
+}
+
+// coverImage is ONE-OF with coverVideo — a video-covered project falls back to its poster.
+function projectCover(raw: Raw): string {
+  return imgSrc(raw.coverImage?.imageInfo, 1200, 900) || toVideo(raw.coverVideo?.videoInfo).posterUrl;
+}
+
+function toProject(raw: Raw): ProjectSummary {
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    title: raw.title ?? "",
+    description: raw.description ?? "",
+    imageUrl: projectCover(raw),
+    collectionIds: raw.collectionIds ?? [],
+  };
+}
+
+// A details row is a one-of: { label, text } or { label, link: { text, url, target } }.
+function toDetailRow(raw: Raw): ProjectDetailRow {
+  return {
+    label: raw.label ?? "",
+    text: raw.link?.text ?? raw.text ?? "",
+    url: raw.link?.url ?? null,
+    target: raw.link?.target ?? null,
+  };
+}
+
+function toDetail(raw: Raw): ProjectDetail {
+  return { ...toProject(raw), details: (raw.details ?? []).map((d: Raw) => toDetailRow(d)) };
+}
+
+function toGalleryItem(raw: Raw): GalleryItem | null {
+  const base = {
+    id: raw._id ?? "",
+    title: raw.title ?? "",
+    description: raw.description ?? "",
+    linkUrl: raw.link?.url ?? null,
+    linkTarget: raw.link?.target ?? null,
+  };
+  if (raw.type === "IMAGE") {
+    const imageUrl = imgSrc(raw.image?.imageInfo, 1600, 1200);
+    return imageUrl ? { ...base, kind: "image", imageUrl, videoUrl: null } : null;
+  }
+  if (raw.type === "VIDEO") {
+    const { videoUrl, posterUrl } = toVideo(raw.video?.videoInfo);
+    return videoUrl ? { ...base, kind: "video", imageUrl: posterUrl, videoUrl } : null;
+  }
+  return null; // UNDEFINED — nothing renderable
+}
+
+/**
+ * List visible collections in the owner's dashboard order (sortOrder — collections have one,
+ * projects don't). An omitted `hidden` comes back ABSENT (proto3): test falsy, never === false.
+ */
+export async function fetchCollections({ limit = 100 } = {}): Promise<CollectionSummary[]> {
+  const res = await collections.listCollections({ paging: { limit } });
+  return (res.collections ?? [])
+    .filter((c: Raw) => !c.hidden)
+    .sort((a: Raw, b: Raw) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+    .map((c: Raw) => toCollection(c));
+}
+
+/** Fetch one visible collection by its URL slug. Null when not found or hidden. */
+export async function fetchCollectionBySlug(slug: string): Promise<CollectionSummary | null> {
+  const res = await collections.queryCollections().eq("slug", slug).limit(1).find();
+  const raw = res.items?.[0] as Raw | undefined;
+  return raw && !raw.hidden ? toCollection(raw) : null;
+}
+
+/**
+ * List visible projects (list order — Project exposes no sortOrder), optionally only one
+ * collection's. The collection filter is client-side over the one list call (portfolios are
+ * small; a project links to collections via collectionIds).
+ */
+export async function fetchProjects({
+  collectionId,
+  limit = 100,
+}: { collectionId?: string; limit?: number } = {}): Promise<ProjectSummary[]> {
+  const res = await projects.listProjects({ paging: { limit } });
+  return (res.projects ?? [])
+    .filter((p: Raw) => !p.hidden)
+    .filter((p: Raw) => !collectionId || (p.collectionIds ?? []).includes(collectionId))
+    .map((p: Raw) => toProject(p));
+}
+
+/** Fetch one visible project by its URL slug. Null when not found or hidden. */
+export async function fetchProjectBySlug(slug: string): Promise<ProjectDetail | null> {
+  const res = await projects.queryProjects().eq("slug", slug).limit(1).find();
+  const raw = res.items?.[0] as Raw | undefined;
+  return raw && !raw.hidden ? toDetail(raw) : null;
+}
+
+/**
+ * A project's media gallery in dashboard order (item sortOrder). IMAGE and VIDEO items only —
+ * UNDEFINED and unresolvable media are dropped. First arg is the project _id (positional).
+ */
+export async function fetchProjectGallery(projectId: string): Promise<GalleryItem[]> {
+  const res = await projectItems.listProjectItems(projectId, { paging: { limit: 100 } });
+  return (res.items ?? [])
+    .slice()
+    .sort((a: Raw, b: Raw) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+    .map((it: Raw) => toGalleryItem(it))
+    .filter((g: GalleryItem | null): g is GalleryItem => g !== null);
+}

--- a/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/types.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/types.ts
@@ -1,0 +1,55 @@
+// Portfolio DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. Images are
+// resolved https URLs; videos are playable mp4 URLs with a poster frame.
+
+/** A collection as the gallery grid needs it. */
+export interface CollectionSummary {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  /** Resolved https URL ("" when the collection has no cover). */
+  imageUrl: string;
+}
+
+/** A project as a grid tile needs it. */
+export interface ProjectSummary {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  /** Cover image; a video-covered project falls back to its poster frame ("" when neither). */
+  imageUrl: string;
+  /** The collections this project belongs to (a project can be in several). */
+  collectionIds: string[];
+}
+
+/** One row of a project's metadata (Role, Year, Client…): plain text or an outbound link. */
+export interface ProjectDetailRow {
+  label: string;
+  text: string;
+  /** Non-null → render the row's text as a link. */
+  url: string | null;
+  /** Link rows only: "_blank" | "_self". */
+  target: string | null;
+}
+
+/** A project as the detail page needs it. */
+export interface ProjectDetail extends ProjectSummary {
+  details: ProjectDetailRow[];
+}
+
+/** One media item of a project's gallery (dashboard order). */
+export interface GalleryItem {
+  id: string;
+  kind: "image" | "video";
+  title: string;
+  description: string;
+  /** image: the resolved image. video: the poster frame ("" when the video has none). */
+  imageUrl: string;
+  /** video only: playable mp4 URL. */
+  videoUrl: string | null;
+  /** Optional owner-attached outbound link for this item. */
+  linkUrl: string | null;
+  linkTarget: string | null;
+}

--- a/skills/wix-headless-fast/references/portfolio/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/portfolio/lock/astro/package-lock.json
@@ -1,0 +1,10197 @@
+{
+ "name": "wix-headless-fast-portfolio",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-portfolio",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/portfolio": "^1.0.229",
+    "@wix/sdk": "^1.21.5",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "dev": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_collections": {
+   "version": "1.0.44",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_collections/-/@wix/auto_sdk_portfolio_collections-1.0.44.tgz",
+   "integrity": "sha512-XrnVP9shj7IggnXRO4dkuUKbfjhQCFCu5HI7Llntj1mogiSkMCmuEN6HF9lVOFCwBY22m5+0qMJx8b0HtdsoaQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_portfolio-settings": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_portfolio-settings/-/@wix/auto_sdk_portfolio_portfolio-settings-1.0.38.tgz",
+   "integrity": "sha512-KmS+0vJpQMpKpZSaf1dtS3c3CxsDSZnBHl23BQ5TOHdCmF6gynygVWMlIF36cC0rE4nxpIbZEVLO10w/GiMzRQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_project-in-collections": {
+   "version": "1.0.43",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-in-collections/-/@wix/auto_sdk_portfolio_project-in-collections-1.0.43.tgz",
+   "integrity": "sha512-Sg1X8u5K7d1Ssa0JKgdVp1R5Kqw2JsjDbHF9HWV2VhaJxP2KTg3cvQuNNleFEx+T25ZWWeQ9E/2WNUXdtbx6Xw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_project-items": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-items/-/@wix/auto_sdk_portfolio_project-items-1.0.46.tgz",
+   "integrity": "sha512-Ps1XfzcB7b+bRZSAvXzdw3aeVvI34/efG3XV9jLHiDe4hDA7Ppkc1f4UprGkTCe+6KGy7A5j2bBimVy0iTAM4Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_projects": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_projects/-/@wix/auto_sdk_portfolio_projects-1.0.59.tgz",
+   "integrity": "sha512-VeuLjnpjtq/VygzqU+pmcKoPve0T3yRRT54LLeW/xb/D4sN51OapMXgGDhQZVs47VOBwbUbFU5iDrOxExlcgFw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_portfolio_synced-project": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_synced-project/-/@wix/auto_sdk_portfolio_synced-project-1.0.46.tgz",
+   "integrity": "sha512-kQMxHJeKIVMo0mxmwNlHc2O8CzB31jP6/QQdnCf7UhpaHJoDTLcPFXKz0Ton0rHjeenI/O3Xz54C/WByEFFshQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/portfolio": {
+   "version": "1.0.229",
+   "resolved": "https://registry.npmjs.org/@wix/portfolio/-/@wix/portfolio-1.0.229.tgz",
+   "integrity": "sha512-eAK3mRJ6q7Ca5/Ror6926jbZLqzfo7dNDG9A6iI1XAyuUwpDaFseLHgwFsz+EnH2y5y6mXRfwh8QS7/Pa78yMg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_portfolio_collections": "1.0.44",
+    "@wix/auto_sdk_portfolio_portfolio-settings": "1.0.38",
+    "@wix/auto_sdk_portfolio_project-in-collections": "1.0.43",
+    "@wix/auto_sdk_portfolio_project-items": "1.0.46",
+    "@wix/auto_sdk_portfolio_projects": "1.0.59",
+    "@wix/auto_sdk_portfolio_synced-project": "1.0.46"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/portfolio/seed/SEED.md
+++ b/skills/wix-headless-fast/references/portfolio/seed/SEED.md
@@ -1,0 +1,72 @@
+# Portfolio — seeding
+
+Seed by **running `seed-portfolio.mjs` with a plan file** — don't hand-write the REST calls.
+The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
+required), installs the Portfolio app if needed, and creates everything in the right order:
+collections first (a project's `collectionIds` are NOT validated — a wrong id silently
+orphans the project), then projects, gallery items, and covers.
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/portfolio/seed/seed-portfolio.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief. **Default to 2 collections × 2 projects
+each** (the seed shows the shape; the owner adds the rest in the dashboard) and make them
+exercise the UI: every collection and project gets a verified `coverImageUrl`, every project
+gets 2–3 gallery `items` (a portfolio without images looks broken), and a couple of projects
+get `details` rows (Role, Year, Client…).
+
+```json
+{
+  "collections": [
+    { "title": "Brand Identity", "description": "Logo systems and visual identities.",
+      "coverImageUrl": "https://…" },
+    { "title": "Editorial", "description": "Print and digital editorial design.",
+      "coverImageUrl": "https://…" }
+  ],
+  "projects": [
+    { "title": "Northwind Rebrand", "description": "Full identity refresh for a logistics firm.",
+      "collection": "Brand Identity",
+      "details": [ { "label": "Role", "text": "Brand & Art Direction" }, { "label": "Year", "text": "2025" } ],
+      "coverImageUrl": "https://…",
+      "items": [
+        { "sortOrder": 1, "title": "Logo system", "imageUrl": "https://…" },
+        { "sortOrder": 2, "title": "Stationery", "imageUrl": "https://…" }
+      ] },
+    { "title": "Harbor Coffee", "description": "Packaging and label suite.",
+      "collection": "Brand Identity", "coverImageUrl": "https://…",
+      "items": [ { "sortOrder": 1, "title": "Label set", "imageUrl": "https://…" } ] },
+    { "title": "Field Notes Quarterly", "description": "Magazine layout and typography.",
+      "collection": "Editorial", "coverImageUrl": "https://…",
+      "items": [ { "sortOrder": 1, "title": "Spread", "imageUrl": "https://…" } ] },
+    { "title": "City Guides", "description": "Travel series covers.",
+      "collection": "Editorial", "coverImageUrl": "https://…",
+      "items": [ { "sortOrder": 1, "title": "Covers", "imageUrl": "https://…" } ] }
+  ]
+}
+```
+
+- `collection` — a collection **title from this plan**; resolved to its created id. A project
+  without one belongs to no collection (reachable only from an all-projects list).
+- `details` — optional `[{ label, text }]` rows; render on the project page. Omit for none.
+- `coverImageUrl` / `items[].imageUrl` — plain image urls; the script imports each into Wix
+  Media (Portfolio binds by file id — a raw url renders nothing). The **cover** is the listing
+  thumbnail; **items** are the detail-page gallery — separate entities, both wanted. If a
+  project has only a cover, reuse its url as item 1 so the gallery isn't empty.
+- `sortOrder` (1, 2, 3…) sets the gallery render order.
+- `hidden` defaults to shown — omit it; send `hidden: true` only to hide an entity.
+- Gallery items seed as images only; the owner adds videos in the dashboard.
+- A fresh Portfolio install ships sample content ("My Portfolio" + sample projects). **Seeding
+  is additive — never delete or overwrite existing content**; if removing the samples seems
+  wanted, ask the owner first.
+
+## Escape hatch — individual functions
+`setupPortfolio` composes exported steps — `installPortfolioApp`, `createCollections`,
+`createProjects`, `importImage`, `attachProjectCovers`, `attachCollectionCovers`,
+`createProjectItems`, `listCollections`, `listProjects`, plus `makeCtx()` — import them only
+for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-portfolio.md`.

--- a/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
+++ b/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
@@ -1,0 +1,245 @@
+// Portfolio seed — a BUILD-TIME script, never shipped in the app. Run from the project root
+// (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/portfolio/seed/seed-portfolio.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Portfolio app if needed,
+// creates collections then projects (collections FIRST — a project's collectionIds are NOT
+// validated, so a wrong id is silently accepted and orphans the project), creates each
+// project's gallery items, and imports+attaches cover images. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "collections": [{ "title", "description"?, "hidden"?, "coverImageUrl"? }],
+//     "projects":    [{ "title", "description"?, "hidden"?,
+//                       "collection"? (title),        // resolved to that collection's id
+//                       "details"?: [{ "label", "text" }],
+//                       "coverImageUrl"?,
+//                       "items"?: [{ "sortOrder", "title"?, "imageUrl" }] }] }
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. A fresh Portfolio
+// install ships its own sample content ("My Portfolio" + sample projects); removing it is the
+// owner's call, not this script's. Unexpected shapes → read the live API reference;
+// authoritative source recipe: wix-headless/references/inline-recipes/setup-portfolio.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const PORTFOLIO_APP_ID = "d90652a2-f5a1-4c7c-84c4-d4cdcc41f130";
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// ---- operations ----------------------------------------------------------------------------------
+
+// Idempotent — re-installing returns 200.
+export async function installPortfolioApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: PORTFOLIO_APP_ID, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+// Read-only listing helpers (partial re-seeds, verification).
+export async function listCollections(ctx) {
+  const r = await req(ctx, "/portfolio/v1/collections", { method: "GET" });
+  return (r.collections ?? []).map((c) => ({ id: c.id, title: c.title, slug: c.slug }));
+}
+export async function listProjects(ctx) {
+  const r = await req(ctx, "/portfolio/v1/projects", { method: "GET" });
+  return (r.projects ?? []).map((p) => ({ id: p.id, title: p.title, slug: p.slug }));
+}
+
+// STEP 1 — collections. The display name is `title`, not `name`; `slug` auto-generates from
+// the title; `hidden` defaults to false = shown (omit it — send true only to hide). No
+// bulk-create: one call per collection.
+export async function createCollections(ctx, collections) {
+  const out = [];
+  for (const c of collections) {
+    const body = { collection: { title: c.title, description: c.description } };
+    if (c.hidden) body.collection.hidden = true;
+    const r = await req(ctx, "/portfolio/v1/collections", { body });
+    out.push({ id: r.collection?.id, slug: r.collection?.slug, revision: r.collection?.revision });
+  }
+  return out;
+}
+
+// STEP 2 — projects, AFTER collections: collectionIds must hold real ids from createCollections
+// (they are NOT validated — a wrong/missing id silently orphans the project). `details` is an
+// optional [{ label, text }] array. No bulk-create: one call per project.
+export async function createProjects(ctx, projects) {
+  const out = [];
+  for (const p of projects) {
+    const project = {
+      title: p.title,
+      description: p.description,
+      collectionIds: p.collectionIds ?? [],
+    };
+    if (p.details) project.details = p.details;
+    if (p.hidden) project.hidden = true;
+    const r = await req(ctx, "/portfolio/v1/projects", { body: { project } });
+    out.push({ id: r.project?.id, slug: r.project?.slug, revision: r.project?.revision });
+  }
+  return out;
+}
+
+// Portfolio binds covers + gallery items by Wix Media file ID — an external url must be
+// imported first; a raw url renders nothing.
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+// Cover = the listing-card thumbnail. PATCH per entity, echoing the current revision (missing/
+// stale revision fails); height + width are required alongside the imported file id.
+export async function attachProjectCovers(ctx, items) {
+  for (const it of items) {
+    await req(ctx, `/portfolio/v1/projects/${it.id}`, {
+      method: "PATCH",
+      body: { project: { id: it.id, revision: it.revision, coverImage: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+  }
+}
+export async function attachCollectionCovers(ctx, items) {
+  for (const it of items) {
+    await req(ctx, `/portfolio/v1/collections/${it.id}`, {
+      method: "PATCH",
+      body: { collection: { id: it.id, revision: it.revision, coverImage: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+  }
+}
+
+// The detail-page gallery is a SEPARATE `item` entity — one POST per image; sortOrder (1,2,3…)
+// sets render order. Lowercase `items` — `/Items` 404s. There is NO public list endpoint.
+export async function createProjectItems(ctx, items) {
+  const out = [];
+  for (const it of items) {
+    const r = await req(ctx, "/portfolio/v1/items", {
+      body: { item: { projectId: it.projectId, sortOrder: it.sortOrder, title: it.title, image: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+    out.push({ id: r.item?.id });
+  }
+  return out;
+}
+
+/**
+ * ONE-CALL seed: install → collections → projects (into collections) → gallery items →
+ * covers, ids threaded in memory. The default path.
+ */
+export async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
+  await installPortfolioApp(ctx);
+
+  const cols = await createCollections(ctx, collections);
+  const idByTitle = new Map(collections.map((c, i) => [c.title, cols[i].id]));
+
+  const projs = await createProjects(
+    ctx,
+    projects.map((p) => ({
+      title: p.title,
+      description: p.description,
+      details: p.details,
+      hidden: p.hidden,
+      collectionIds: p.collection ? [idByTitle.get(p.collection)].filter(Boolean) : [],
+    })),
+  );
+
+  const toImage = async (url, name) => {
+    const file = await importImage(ctx, url, name);
+    return { imageId: file.id, height: 1024, width: 1024 };
+  };
+
+  // Gallery items (import each image; a failed import skips just that item).
+  const itemsFlat = [];
+  for (let i = 0; i < projects.length; i++) {
+    for (const it of projects[i].items ?? []) {
+      if (!it.imageUrl) continue;
+      try {
+        const img = await toImage(it.imageUrl, `${it.title || "item"}.png`);
+        itemsFlat.push({ projectId: projs[i].id, sortOrder: it.sortOrder, title: it.title, ...img });
+      } catch {
+        /* skip this item's image */
+      }
+    }
+  }
+  const items = itemsFlat.length ? await createProjectItems(ctx, itemsFlat) : [];
+
+  // Covers (import each; a failed import skips just that cover — the entity stays text-only).
+  const projCovers = [];
+  for (let i = 0; i < projects.length; i++) {
+    if (!projects[i].coverImageUrl) continue;
+    try {
+      const img = await toImage(projects[i].coverImageUrl, `${projects[i].title || "project"}-cover.png`);
+      projCovers.push({ id: projs[i].id, revision: projs[i].revision, ...img });
+    } catch {
+      /* skip */
+    }
+  }
+  if (projCovers.length) await attachProjectCovers(ctx, projCovers);
+
+  const colCovers = [];
+  for (let i = 0; i < collections.length; i++) {
+    if (!collections[i].coverImageUrl) continue;
+    try {
+      const img = await toImage(collections[i].coverImageUrl, `${collections[i].title || "collection"}-cover.png`);
+      colCovers.push({ id: cols[i].id, revision: cols[i].revision, ...img });
+    } catch {
+      /* skip */
+    }
+  }
+  if (colCovers.length) await attachCollectionCovers(ctx, colCovers);
+
+  return {
+    collections: cols,
+    projects: projs,
+    itemsCreated: items.length,
+    coversAttached: projCovers.length + colCovers.length,
+  };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-portfolio.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupPortfolio(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/pricing-plans/INSTRUCTIONS.md
@@ -1,0 +1,133 @@
+# Pricing Plans — playbook
+
+The plans machinery ships as files — plan reads (grid + by-slug) and the hosted purchase
+redirect, typed end-to-end. **The presentation is yours**: you design and implement the plan
+card, the pricing grid, and the plan detail surface on the shipped hooks/DTOs, plus the home
+page and the brand. You never write purchase logic; you never skip designing.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/pricing-plans/types.ts` | the DTOs (`PlanSummary`, `PlanDetail`) — contracts below |
+| `wix/pricing-plans/plans.ts` | `fetchPlans`, `fetchPlanBySlug` |
+| `wix/pricing-plans/purchase.ts` | `purchasePlan` — the hosted-checkout redirect session lives here |
+| `hooks/pricing-plans/usePlans.ts` | plans listing — contract below |
+| `hooks/pricing-plans/usePlanPurchase.ts` | the purchase action — contract below |
+| `components/pricing-plans/PlansView.tsx` (+ `PlanCard`) · `PlanDetailView.tsx` | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot + global.css import). If another vertical is also deployed, its layout won — add a Plans nav link there |
+| `pages/plans.astro` | SSR pricing grid — **keep the frontmatter**, swap the island import to YOUR component |
+| `pages/plans/[slug].astro` | SSR plan detail — **keep the frontmatter** (plain `<title>`/`<meta>` from the DTO: Pricing Plans has no owner-editable SEO item type); swap the island import |
+
+## What you build — the design job
+
+1. **The plan card + pricing grid** — your tier card (name, price + billing cadence, trial
+   badge, perks list, Subscribe CTA — only when `buyable`) and grid rhythm (a highlighted
+   recommended tier is a classic), with skeletons while loading and an honest empty state —
+   on `usePlans` + `usePlanPurchase`.
+2. **The plan detail surface** — the full pitch: price block, perks, terms & conditions
+   (plain text — render pre-wrap), subscribe CTA — on `usePlanPurchase` (the plan itself
+   arrives as an SSR-fetched DTO prop).
+3. **The home page** — hero, a featured-plans strip (fetch in frontmatter → your components),
+   brand story.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// PlanSummary (cards) — display-ready:
+// { id, slug, name, description, price /* "$29.00" | "Free" */, free,
+//   billing /* "per month" | "every 3 months" | "one-time" | "" (free) */,
+//   freeTrialDays: number|null, perks: string[], buyable, imageUrl /* "" when none */ }
+// PlanDetail adds: termsAndConditions (plain text; "" when not set).
+
+// usePlans({ initialPlans? }) →
+// { plans: PlanSummary[]|null /* null = loading → skeletons */, error }
+
+// usePlanPurchase() →
+// { purchase(planId, { thankYouPageUrl?, postFlowUrl? }?): Promise<void>,
+//     // resolves as the browser navigates to the Wix-hosted checkout;
+//     // rejects with a visitor-facing message — surface it
+//   purchasingId,   // plan id in flight (null when idle) — key the CTA spinner off it
+//   error }
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — merge into the
+   other vertical's layout instead if both are deployed).
+2. Write your components under `src/components/pricing-plans/` (new names — don't overwrite
+   the references), swap the island imports in `pages/plans.astro` and
+   `pages/plans/[slug].astro`. Both islands: `client:load` with the SSR DTO props. **Author
+   your surfaces in as few messages as possible** — batch multiple Writes per message.
+3. Write `pages/index.astro` (home) — it exists from the scaffold; Read it before overwriting.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/plans` → your grid; `/plans/:slug` → fetch with
+`fetchPlanBySlug(slug)` client-side, then your detail surface (null → your not-found state).
+
+## Hard rules
+
+- **Purchase only through the shipped exports** — `usePlanPurchase`/`purchasePlan` own the
+  hosted redirect session. Never hand-build a checkout URL, never call
+  `orders.createOnlineOrder` (member-only, and it leaves payment unhandled), never mark
+  anything paid.
+- **Purchasing is members-only, and that's fine as-is**: the hosted flow handles member
+  login/signup, the order form, and payment, then returns to your site. Don't build a login
+  gate in front of the CTA.
+- **No success theater.** Returning from checkout is NOT a success signal — `postFlowUrl` is
+  hit on abandon too. Success arrives only at a `thankYouPageUrl` you pass, as
+  `?planOrderId=<GUID>`; if you build a thank-you page, read that param — never fake a
+  confirmation off the mere return.
+- **Prices are display-only.** `price`/`billing` come pre-formatted; never compute a charge,
+  discount, or proration — Wix settles price, tax, and schedule at the hosted checkout.
+- **Show the Subscribe CTA only when `buyable`** — a PUBLIC plan can be merchant-assigned.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+- Live data or an honest empty state — never mock plans, prices, or perks.
+
+## Out of scope (don't improvise these)
+
+Member-gated surfaces — a "my plans" page, the member's orders (`orders.memberListOrders`),
+cancel/pause flows, and booking a covered bookings service with a membership — require a
+logged-in member session this skill doesn't ship yet. Subscribers manage their plan through
+Wix's emails and hosted member flows. If the user asks for a member area, route to
+`wix-headless` (members recipes) rather than shipping code that returns nothing for visitors.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link plus the Pricing Plans page — the deploy step's JSON
+printed `dashboardUrl`; append `/pricing-plans` for plan management (edit plans, connect
+plans to content, see orders). Taking real payments needs a premium plan + a connected
+payment method — mention it.
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-pricing-plans.mjs` from the project
+root. Seed a tier ladder that exercises the UI (a free tier, a monthly, a yearly or
+one-time; 3–4 perks each).
+
+## Verify (before declaring done)
+
+- [ ] `/plans` renders live plans SSR (view-source shows names) through YOUR components;
+      empty catalog shows your honest empty state.
+- [ ] Every price shape reads right: free ("Free", no cadence), recurring ("$29.00 per
+      month"), one-time; Subscribe renders only on `buyable` plans.
+- [ ] A plan page loads by slug and 404s (Astro) / shows not-found (SPA) on a bad slug.
+- [ ] Subscribe redirects to the Wix-hosted checkout (login/signup + payment live there).
+- [ ] Card/grid/detail/home are YOUR designs on the tokens; data-layer/hook files unedited.
+- [ ] Dashboard links handed to the owner.

--- a/skills/wix-headless-fast/references/pricing-plans/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/pricing-plans/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,41 @@
+---
+// The site chrome for every pricing-plans page — THIS file (header/footer/nav) plus the
+// @theme token block in src/styles/global.css are what you brand. Keep the
+// <slot name="seo-tags" /> in <head> and the global.css import. (Deploy is fill-only: if
+// another vertical is already deployed, its SiteLayout won — merge a Plans nav link there
+// instead.)
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <a href="/plans" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Plans</a>
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/pricing-plans/app-astro/pages/plans.astro
+++ b/skills/wix-headless-fast/references/pricing-plans/app-astro/pages/plans.astro
@@ -1,0 +1,21 @@
+---
+// Plans & Pricing — data fetched SERVER-SIDE (SEO) and handed to the island as DTO props.
+// Keep this frontmatter; swap the island import to YOUR pricing component.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import PlansView from "../components/pricing-plans/PlansView";
+import { fetchPlans } from "../wix/pricing-plans/plans";
+import type { PlanSummary } from "../wix/pricing-plans/types";
+
+let plans: PlanSummary[] = [];
+try {
+  plans = await fetchPlans();
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // empty state instead.
+}
+---
+
+<SiteLayout title="Plans & Pricing">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Plans &amp; Pricing</h1>
+  <PlansView client:load initialPlans={plans} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/pricing-plans/app-astro/pages/plans/[slug].astro
+++ b/skills/wix-headless-fast/references/pricing-plans/app-astro/pages/plans/[slug].astro
@@ -1,0 +1,40 @@
+---
+// Plan detail page.
+//
+// Pricing Plans has no documented owner-editable SEO item type (unlike bookings services /
+// store products), so this page carries plain <title>/<meta> from the DTO — no wixMetadata,
+// no <SEO.Tags>. The island is client:load: the plan arrives as an SSR-fetched prop; only
+// the purchase action runs client-side.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import PlanDetailView from "../../components/pricing-plans/PlanDetailView";
+import { fetchPlanBySlug } from "../../wix/pricing-plans/plans";
+import type { PlanDetail } from "../../wix/pricing-plans/types";
+
+const slug = Astro.params.slug!;
+
+let plan: PlanDetail | null = null;
+try {
+  plan = await fetchPlanBySlug(slug);
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!plan) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<SiteLayout title={plan.name} description={plan.description || undefined}>
+  <div class="mx-auto max-w-2xl">
+    {plan.imageUrl && (
+      <div class="mb-6 aspect-[16/9] overflow-hidden rounded-xl bg-secondary">
+        <img src={plan.imageUrl} alt={plan.name} class="h-full w-full object-cover" />
+      </div>
+    )}
+    <h1 class="text-2xl font-semibold tracking-tight">{plan.name}</h1>
+    {plan.description && <p class="mt-2 text-muted-foreground">{plan.description}</p>}
+    <div class="mt-6">
+      <PlanDetailView client:load plan={plan} />
+    </div>
+  </div>
+</SiteLayout>

--- a/skills/wix-headless-fast/references/pricing-plans/app/components/pricing-plans/PlanDetailView.tsx
+++ b/skills/wix-headless-fast/references/pricing-plans/app/components/pricing-plans/PlanDetailView.tsx
@@ -1,0 +1,58 @@
+// REFERENCE detail surface: price/billing block + perks + terms + subscribe CTA, on the
+// @theme tokens. Correct and complete; per the skill's model you design and build your own
+// on usePlanPurchase (the plan itself arrives as an SSR-fetched DTO prop).
+import { usePlanPurchase } from "../../hooks/pricing-plans/usePlanPurchase";
+import type { PlanDetail } from "../../wix/pricing-plans/types";
+
+export default function PlanDetailView({ plan }: { plan: PlanDetail }) {
+  const { purchase, purchasingId, error } = usePlanPurchase();
+  const purchasing = purchasingId === plan.id;
+
+  return (
+    <div>
+      <p>
+        <span className="text-4xl font-bold tracking-tight text-foreground">{plan.price}</span>
+        {plan.billing && <span className="ml-2 text-muted-foreground">{plan.billing}</span>}
+      </p>
+      {plan.freeTrialDays !== null && (
+        <p className="mt-1 text-sm text-muted-foreground">{plan.freeTrialDays}-day free trial</p>
+      )}
+
+      {plan.perks.length > 0 && (
+        <ul className="mt-6 space-y-2.5">
+          {plan.perks.map((perk) => (
+            <li key={perk} className="flex gap-2 text-sm text-foreground">
+              <span className="text-muted-foreground" aria-hidden="true">
+                ✓
+              </span>
+              <span>{perk}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+      {plan.buyable ? (
+        <button
+          type="button"
+          disabled={purchasing}
+          onClick={() => void purchase(plan.id).catch(() => {})}
+          className="mt-6 rounded-full bg-primary px-8 py-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {purchasing ? "Redirecting…" : plan.free ? "Get this plan" : `Subscribe · ${plan.price}`}
+        </button>
+      ) : (
+        <p className="mt-6 text-sm text-muted-foreground">This plan is assigned by the site owner.</p>
+      )}
+
+      {plan.termsAndConditions && (
+        <div className="mt-10 border-t border-border pt-5">
+          <p className="eyebrow">Terms &amp; conditions</p>
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+            {plan.termsAndConditions}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/components/pricing-plans/PlansView.tsx
+++ b/skills/wix-headless-fast/references/pricing-plans/app/components/pricing-plans/PlansView.tsx
@@ -1,0 +1,126 @@
+// REFERENCE pricing surface: plan cards in a grid on the @theme tokens. Correct and
+// complete; per the skill's model you design and build your own on usePlans +
+// usePlanPurchase.
+import type { ComponentType, ReactNode } from "react";
+import { usePlans } from "../../hooks/pricing-plans/usePlans";
+import { usePlanPurchase } from "../../hooks/pricing-plans/usePlanPurchase";
+import type { PlanSummary } from "../../wix/pricing-plans/types";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export interface PlanCardProps {
+  plan: PlanSummary;
+  onSubscribe: (planId: string) => void;
+  purchasing: boolean;
+  planHref?: (slug: string) => string;
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+export function PlanCard({
+  plan,
+  onSubscribe,
+  purchasing,
+  planHref = (slug) => `/plans/${slug}`,
+  LinkComponent = PlainLink,
+}: PlanCardProps) {
+  return (
+    <div className="flex h-full flex-col rounded-lg border border-border bg-background p-6">
+      <p className="text-base font-semibold text-foreground">{plan.name}</p>
+      {plan.description && <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>}
+      <p className="mt-4">
+        <span className="text-3xl font-bold tracking-tight text-foreground">{plan.price}</span>
+        {plan.billing && <span className="ml-1.5 text-sm text-muted-foreground">{plan.billing}</span>}
+      </p>
+      {plan.freeTrialDays !== null && (
+        <p className="mt-1 text-xs font-medium text-muted-foreground">{plan.freeTrialDays}-day free trial</p>
+      )}
+      {plan.perks.length > 0 && (
+        <ul className="mt-4 space-y-2">
+          {plan.perks.map((perk) => (
+            <li key={perk} className="flex gap-2 text-sm text-foreground">
+              <span className="text-muted-foreground" aria-hidden="true">
+                ✓
+              </span>
+              <span>{perk}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-auto grid gap-2 pt-6">
+        {plan.buyable && (
+          <button
+            type="button"
+            disabled={purchasing}
+            onClick={() => onSubscribe(plan.id)}
+            className="rounded-full bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {purchasing ? "Redirecting…" : "Subscribe"}
+          </button>
+        )}
+        <LinkComponent
+          href={planHref(plan.slug)}
+          className="rounded-full border border-border px-6 py-2.5 text-center text-sm font-semibold text-foreground no-underline transition-colors hover:bg-secondary"
+        >
+          View details
+        </LinkComponent>
+      </div>
+    </div>
+  );
+}
+
+export interface PlansViewProps {
+  initialPlans?: PlanSummary[];
+  emptyMessage?: string;
+  planHref?: PlanCardProps["planHref"];
+  LinkComponent?: ComponentType<LinkLikeProps>;
+  CardComponent?: ComponentType<PlanCardProps>;
+}
+
+export default function PlansView({
+  initialPlans,
+  emptyMessage = "No plans yet — check back soon.",
+  planHref,
+  LinkComponent,
+  CardComponent = PlanCard,
+}: PlansViewProps) {
+  const { plans, error } = usePlans({ initialPlans });
+  const { purchase, purchasingId, error: purchaseError } = usePlanPurchase();
+
+  return (
+    <div>
+      {(error ?? purchaseError) && <p className="mb-4 text-sm text-red-600">{error ?? purchaseError}</p>}
+      {plans === null ? (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="h-80 animate-pulse rounded-lg bg-secondary" />
+          ))}
+        </div>
+      ) : plans.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {plans.map((p) => (
+            <CardComponent
+              key={p.id}
+              plan={p}
+              onSubscribe={(id) => void purchase(id).catch(() => {})}
+              purchasing={purchasingId === p.id}
+              planHref={planHref}
+              LinkComponent={LinkComponent}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/hooks/pricing-plans/usePlanPurchase.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/hooks/pricing-plans/usePlanPurchase.ts
@@ -1,0 +1,37 @@
+// The purchase action for any surface (grid card, detail CTA, home strip). All correctness
+// (the hosted redirect session, member login/signup, payment) lives in the data layer —
+// this hook tracks in-flight state; you own how it looks.
+import { useState } from "react";
+import { purchasePlan } from "../../wix/pricing-plans/purchase";
+import type { PurchaseOptions } from "../../wix/pricing-plans/purchase";
+
+export interface UsePlanPurchase {
+  /**
+   * Starts the hosted checkout — when it resolves the browser is already navigating away.
+   * Rejects with a visitor-facing message otherwise — surface it, don't swallow it.
+   */
+  purchase: (planId: string, options?: PurchaseOptions) => Promise<void>;
+  /** The plan id a purchase is in flight for (null when idle) — key CTA spinners off it. */
+  purchasingId: string | null;
+  error: string | null;
+}
+
+export function usePlanPurchase(): UsePlanPurchase {
+  const [purchasingId, setPurchasingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function purchase(planId: string, options?: PurchaseOptions): Promise<void> {
+    setPurchasingId(planId);
+    setError(null);
+    try {
+      window.location.href = await purchasePlan(planId, options);
+      // stays "purchasing" — the browser is leaving for the hosted checkout
+    } catch (e) {
+      setPurchasingId(null);
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
+  }
+
+  return { purchase, purchasingId, error };
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/hooks/pricing-plans/usePlans.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/hooks/pricing-plans/usePlans.ts
@@ -1,0 +1,39 @@
+// Plans listing. SSR-friendly: pass server-fetched data as `initialPlans` (Astro frontmatter
+// / server component) and no client fetch happens; a SPA passes nothing.
+import { useEffect, useState } from "react";
+import { fetchPlans } from "../../wix/pricing-plans/plans";
+import type { PlanSummary } from "../../wix/pricing-plans/types";
+
+export interface UsePlansOptions {
+  initialPlans?: PlanSummary[];
+}
+
+export interface UsePlans {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  plans: PlanSummary[] | null;
+  error: string | null;
+}
+
+export function usePlans({ initialPlans }: UsePlansOptions = {}): UsePlans {
+  const [plans, setPlans] = useState<PlanSummary[] | null>(initialPlans ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialPlans) {
+      fetchPlans()
+        .then((p) => alive && setPlans(p))
+        .catch((e) => {
+          if (!alive) return;
+          setPlans([]);
+          setError(e instanceof Error ? e.message : String(e));
+        });
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { plans, error };
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/plans.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/plans.ts
@@ -1,0 +1,74 @@
+// Plan reads (Wix Pricing Plans, Plans V3) — the only file that touches raw plan entities.
+// Everything it returns is a plain DTO from ./types. Copy as-is; extend by adding functions,
+// not by editing these.
+//
+// The read module is plansV3 — NOT `plans` (that's the V2 namespace; it has no queryPlans).
+import { plansV3 } from "@wix/pricing-plans";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type { PlanDetail, PlanSummary } from "./types";
+
+const plans = wixModule(plansV3);
+
+type Raw = Record<string, any>;
+
+function formatPrice(value: string | undefined, currency: string | undefined): string {
+  if (value == null || value === "" || Number(value) === 0) return "Free";
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency: currency || "USD" }).format(Number(value));
+  } catch {
+    return `${value} ${currency ?? ""}`.trim();
+  }
+}
+
+// billingTerms → a display label. billingCycle.count comes back as a STRING in SDK reads
+// ("1") — Number() it. endType CYCLES_COMPLETED with billingCycleCount 1 bills once.
+function billingLabel(terms: Raw | undefined): string {
+  const cycle = terms?.billingCycle;
+  if (!cycle) return "one-time";
+  const cyclesTotal = Number(terms?.cyclesCompletedDetails?.billingCycleCount ?? 0);
+  if (terms?.endType === "CYCLES_COMPLETED" && cyclesTotal === 1) return "one-time";
+  const count = Number(cycle.count ?? 1) || 1;
+  const period = String(cycle.period ?? "MONTH").toLowerCase();
+  const base = count === 1 ? `per ${period}` : `every ${count} ${period}s`;
+  return terms?.endType === "CYCLES_COMPLETED" && cyclesTotal > 1 ? `${base} × ${cyclesTotal}` : base;
+}
+
+// The price is DISPLAY-ONLY: a decimal string at pricingVariants[0].pricingStrategies[0]
+// .flatRate.amount ("0" = free), paired with plan.currency (site-derived — never assume
+// USD). Wix settles the actual charge, tax, and schedule at the hosted checkout.
+function toSummary(raw: Raw): PlanSummary {
+  const variant: Raw = raw.pricingVariants?.[0] ?? {};
+  const amount: string | undefined = variant.pricingStrategies?.[0]?.flatRate?.amount;
+  const free = amount == null || Number(amount) === 0;
+  return {
+    id: raw._id ?? "", // SDK entity id is _id, never id (that's the REST view)
+    slug: raw.slug ?? "",
+    name: raw.name ?? "",
+    description: raw.description ?? "",
+    price: free ? "Free" : formatPrice(amount, raw.currency),
+    free,
+    billing: free ? "" : billingLabel(variant.billingTerms),
+    freeTrialDays: variant.freeTrialDays || null,
+    perks: (raw.perks ?? []).map((p: Raw) => p.description ?? "").filter((d: string) => d),
+    buyable: raw.buyable === true,
+    imageUrl: imgSrc(raw.image, 800, 800),
+  };
+}
+
+function toDetail(raw: Raw): PlanDetail {
+  return { ...toSummary(raw), termsAndConditions: raw.termsAndConditions ?? "" };
+}
+
+/** List the public plans for the pricing grid, as card-ready DTOs. */
+export async function fetchPlans({ limit = 100 } = {}): Promise<PlanSummary[]> {
+  const res = await plans.queryPlans().eq("visibility", "PUBLIC").limit(limit).find();
+  return (res.items ?? []).map((p: Raw) => toSummary(p));
+}
+
+/** Fetch one public plan by its URL slug. Null when not found. */
+export async function fetchPlanBySlug(slug: string): Promise<PlanDetail | null> {
+  const res = await plans.queryPlans().eq("visibility", "PUBLIC").eq("slug", slug).limit(1).find();
+  const raw = res.items?.[0];
+  return raw ? toDetail(raw as Raw) : null;
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/purchase.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/purchase.ts
@@ -1,0 +1,44 @@
+// The purchase flow: one call that turns a plan id into a Wix-hosted checkout URL.
+// Purchasing a plan is a MEMBER action, but the hosted flow handles member login/signup,
+// the order form, and payment itself — so this works from an anonymous visitor session.
+// Never create the order yourself (orders.createOnlineOrder needs a logged-in member and
+// still leaves payment unhandled); never hand-build a checkout URL. Copy as-is.
+import { redirects as redirectsModule } from "@wix/redirects";
+import { wixModule } from "../sdk";
+
+const redirects = wixModule(redirectsModule);
+
+type Raw = Record<string, any>;
+
+export interface PurchaseOptions {
+  /**
+   * Success-only return URL — Wix appends `?planOrderId=<GUID>` to it. Omit → Wix shows its
+   * hosted thank-you page, then returns to postFlowUrl. Point it at a page of yours only if
+   * that page reads the param and renders a real confirmation.
+   */
+  thankYouPageUrl?: string;
+  /**
+   * Where a completed, abandoned, or interrupted flow returns (default: the current page).
+   * Landing here is NOT a success signal — only thankYouPageUrl carries one.
+   */
+  postFlowUrl?: string;
+}
+
+/** Start the hosted purchase for a plan; resolves to the URL to send the browser to. */
+export async function purchasePlan(
+  planId: string,
+  { thankYouPageUrl, postFlowUrl }: PurchaseOptions = {},
+): Promise<string> {
+  if (!planId) throw new Error("A plan id is required to start checkout.");
+  const href = typeof window !== "undefined" ? window.location.href : "";
+  const session: Raw = await redirects.createRedirectSession({
+    paidPlansCheckout: { planId },
+    callbacks: {
+      postFlowUrl: postFlowUrl ?? (href || undefined),
+      ...(thankYouPageUrl ? { thankYouPageUrl } : {}),
+    },
+  });
+  const url = session?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Checkout couldn't start — please try again.");
+  return url;
+}

--- a/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/types.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/types.ts
@@ -1,0 +1,30 @@
+// Pricing Plans DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. Images are
+// resolved https URLs; every displayable price is a ready formatted string.
+
+/** A plan as a pricing-grid card needs it. */
+export interface PlanSummary {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  /** Formatted price (e.g. "$29.00"); "Free" when the plan costs nothing. */
+  price: string;
+  free: boolean;
+  /** Display-ready cadence: "per month", "every 3 months", "one-time"; "" for free plans. */
+  billing: string;
+  /** Free-trial length in days (null when the plan has none). */
+  freeTrialDays: number | null;
+  /** Display-only feature bullets, in order. */
+  perks: string[];
+  /** False → a PUBLIC but merchant-assigned plan: show it without a subscribe CTA. */
+  buyable: boolean;
+  /** Resolved https URL ("" when the plan has no image). */
+  imageUrl: string;
+}
+
+/** A plan as the detail page needs it. */
+export interface PlanDetail extends PlanSummary {
+  /** Terms & conditions as plain text ("" when not set) — render as-is (pre-wrap). */
+  termsAndConditions: string;
+}

--- a/skills/wix-headless-fast/references/pricing-plans/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/pricing-plans/lock/astro/package-lock.json
@@ -1,0 +1,11226 @@
+{
+ "name": "wix-headless-fast-pricing-plans",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-pricing-plans",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/pricing-plans": "^1.0.378",
+    "@wix/redirects": "^1.0.125",
+    "@wix/sdk": "^1.21.5",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout": {
+   "version": "1.0.168",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart": {
+   "version": "1.0.184",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_pricing-plans_orders": {
+   "version": "1.0.123",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_orders/-/@wix/auto_sdk_pricing-plans_orders-1.0.123.tgz",
+   "integrity": "sha512-EbQCnpIZj1G3qmBpDKjjthxwmDq7KZHjZYkL/qipbCk/Bpzk4bcZPv3KLk6zePxDY4vARtayWjtWUL1qc5487w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_pricing-plans_plan-benefits": {
+   "version": "1.0.11",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plan-benefits/-/@wix/auto_sdk_pricing-plans_plan-benefits-1.0.11.tgz",
+   "integrity": "sha512-wcuZw3A1vBQ9EeW/i8mRXF3U6C98xz9Coa38Jvwx3EEhPQSY884CSIrtL/ceYK3oGiwLYjkHFbbAxukjrRIilQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_pricing-plans_plans": {
+   "version": "1.0.114",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans/-/@wix/auto_sdk_pricing-plans_plans-1.0.114.tgz",
+   "integrity": "sha512-5s78KfEzQ9ZPXPsLC4iF7KZZa0HJ3jruu9oMkcOlTLrbZvYrRQ5d/nPxWElvD/uvrThiWwe0LzYArY7YUMkbUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_pricing-plans_plans-v-3": {
+   "version": "1.0.109",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans-v-3/-/@wix/auto_sdk_pricing-plans_plans-v-3-1.0.109.tgz",
+   "integrity": "sha512-Cz8G41eYA3LVY7+OmHlP8Omi8sExn9QlXiAb7C/6MSWUZQYUPRhJlfe0JJhk3dUZkrE0uhMz6YagtvcJYyevTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_pricing-plans_pricing-plans-settings": {
+   "version": "1.0.50",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_pricing-plans-settings/-/@wix/auto_sdk_pricing-plans_pricing-plans-settings-1.0.50.tgz",
+   "integrity": "sha512-KcZNYW1ADc4shcy4IQYDY5AZEsPGAE5owjtq2eFOIYzCthd8cOoNBRNhG+GbEJcZn0jafprM6m7AtQMB/CsuWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-ecom": {
+   "version": "0.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.40.tgz",
+   "integrity": "sha512-ib8dYXCeHlo/UYck/CE9v3AkFXI0r5Dn+6ZRH1I2ylxrZMy7Lqj2GF0gwvoOwEKdDbjuNhWEvTY9X4tg6tN0Qg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/auto_sdk_ecom_checkout": "^1.0.61",
+    "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
+    "@wix/headless-media": "0.0.20",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-ecom/node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans": {
+   "version": "0.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/headless-pricing-plans/-/@wix/headless-pricing-plans-0.0.22.tgz",
+   "integrity": "sha512-UoEveDTVRuolrnu4b38cJi4DmTfndCcnfV3KCCvsdlX6ubo929gVJ2wEZ06m3Op4+cSldCNVQruk0ISIyCM/fA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/essentials": "^0.1.28",
+    "@wix/headless-ecom": "0.0.40",
+    "@wix/headless-media": "0.0.20",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/pricing-plans": "^1.0.221",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.27",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans/node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans/node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-pricing-plans/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/pricing-plans": {
+   "version": "1.0.378",
+   "resolved": "https://registry.npmjs.org/@wix/pricing-plans/-/@wix/pricing-plans-1.0.378.tgz",
+   "integrity": "sha512-eHYkjXxbnneilhlA2pNWGiS6eAR66yaQIb3SEdp4Afj4z3F1aYp5ETs6iwJOs1suVbQXsr2t74S8DUfiHzDq3w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_pricing-plans_orders": "1.0.123",
+    "@wix/auto_sdk_pricing-plans_plan-benefits": "1.0.11",
+    "@wix/auto_sdk_pricing-plans_plans": "1.0.114",
+    "@wix/auto_sdk_pricing-plans_plans-v-3": "1.0.109",
+    "@wix/auto_sdk_pricing-plans_pricing-plans-settings": "1.0.50",
+    "@wix/headless-pricing-plans": "^0.0.22"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "peer": true,
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-headless-fast/references/pricing-plans/seed/SEED.md
@@ -1,0 +1,71 @@
+# Pricing Plans — seeding
+
+Seed by **running `seed-pricing-plans.mjs` with a plan file** — don't hand-write the REST
+calls. The script mints its own site token via the Wix CLI (logged-in session +
+`wix.config.json` required), installs the Pricing Plans app if needed, and creates everything
+in the right order.
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/pricing-plans/seed/seed-pricing-plans.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief. **Default to 3 plans** — a tier ladder
+the grid can render (e.g. free / monthly / yearly), each with 3–4 perks; together they
+exercise every price shape the UI handles. Plans have no seedable images (the owner adds one
+per plan in the dashboard).
+
+```json
+{
+  "plans": [
+    { "name": "Community", "type": "free",
+      "description": "Get a taste — member perks, zero commitment.",
+      "perks": ["Member-only newsletter", "Community events access"] },
+    { "name": "Studio Membership", "price": "29.00",
+      "type": "recurring", "billingCycle": { "period": "MONTH", "count": 1 },
+      "description": "The full experience, month to month.",
+      "perks": ["Unlimited group classes", "10% off workshops", "Priority booking"] },
+    { "name": "Annual Pass", "price": "290.00",
+      "type": "recurring", "billingCycle": { "period": "YEAR", "count": 1 },
+      "description": "Two months free, billed yearly.",
+      "perks": ["Everything in Studio Membership", "2 guest passes", "Annual member gift"] }
+  ]
+}
+```
+
+- `type` — `"recurring"` (default; `billingCycle` defaults to `{ "period": "MONTH", "count": 1 }`),
+  `"one-time"` (bills once, then ends; `billingCycle: null` makes it never expire), or
+  `"free"` (amount forced to `"0"` + a per-member-lifetime purchase limit).
+- `price` — a decimal string (`"29.00"`; a number is stringified). Currency is site-derived —
+  never sent.
+- `perks` — display-only bullets on the plan card; they grant nothing by themselves.
+- `termsAndConditions` (plain text), `visibility` (`"PUBLIC"`), `buyable` (`true`) — optional
+  overrides. A `buyable: false` plan renders without a subscribe CTA (merchant-assigned).
+
+## Covering bookings services (only when bookings is also seeded)
+
+A plan can COVER bookings services — members then book them with the membership. The link
+goes through the Benefit Programs API, not the plan object, keyed by the **bookings seed's
+service ids** — so seed bookings FIRST, then pass the ids:
+
+```json
+{ "name": "Studio Membership", "price": "29.00",
+  "perks": ["Unlimited group classes"],
+  "coveredServiceIds": ["<bookings service id>", "…"] }
+```
+
+Unlimited coverage is the default; a limited pack (e.g. 8 sessions) instead uses
+`"bookingsCoverage": { "serviceIds": [...], "creditAmount": 8 }`. A plans-only run just
+omits both — coverage is skipped automatically.
+
+**Seeding is additive — never delete or overwrite existing content**; ask first if a cleanup
+seems needed.
+
+## Escape hatch — individual functions
+`setupPricingPlans` composes exported steps — `installPricingPlansApp`, `createPlans`,
+`attachBookingsCoverage` (and its `getProgramDefinition`, `createPoolDefinition`,
+`createBenefitItems` sub-steps), plus `makeCtx()` — import them only for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.

--- a/skills/wix-headless-fast/references/pricing-plans/seed/seed-pricing-plans.mjs
+++ b/skills/wix-headless-fast/references/pricing-plans/seed/seed-pricing-plans.mjs
@@ -1,0 +1,274 @@
+// Pricing Plans seed — a BUILD-TIME script, never shipped in the app. Run from the project
+// root (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/pricing-plans/seed/seed-pricing-plans.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Pricing Plans app if needed,
+// creates the plans (Plans V3 — one create call per plan; there is no bulk-create), and —
+// only when a plan carries bookings service ids — wires the plan to COVER those services
+// through the Benefit Programs API. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "plans": [{ "name", "description"?, "price"? (decimal string; a number is stringified),
+//                 "type"?: "recurring"|"one-time"|"free",
+//                 "billingCycle"?: { "period": "DAY"|"WEEK"|"MONTH"|"YEAR", "count" } | null,
+//                 "perks"?: ["..."], "termsAndConditions"?, "visibility"?, "buyable"?,
+//                 "coveredServiceIds"?: ["<bookings service id>"],
+//                 "bookingsCoverage"?: { "serviceIds"?, "creditAmount"? } }] }
+//
+// Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
+// read the live API reference; authoritative source recipe:
+// wix-headless/references/inline-recipes/setup-pricing-plans.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+const API = "https://www.wixapis.com";
+const PRICING_PLANS_APP_ID = "1522827f-c56c-a5c9-2ac9-00f9e6ae12d3";
+const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97"; // coverage providerAppId — NOT the Plans id
+const PP_NAMESPACE = "@wix/pricing-plans"; // literal, with the @ and the slash, in every coverage call
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// billingTerms selects the plan type (recurring | one-time | free). recurring: billingCycle
+// {period,count} (default MONTH/1) + ON_PURCHASE + UNTIL_CANCELLED. one-time: endType
+// CYCLES_COMPLETED + billingCycleCount 1 (bill once, then ends); an unlimited one-time
+// instead sets billingCycle:null + UNTIL_CANCELLED. free: MUST be the no-cycle unlimited
+// shape — a $0 variant with a billingCycle is rejected ("Free pricing variant cannot be
+// recurring").
+function buildBillingTerms(plan) {
+  const type = plan.type || "recurring";
+  if (type === "free") {
+    return { billingCycle: null, startType: "ON_PURCHASE", endType: "UNTIL_CANCELLED" };
+  }
+  if (type === "one-time") {
+    if (plan.billingCycle === null) {
+      return { billingCycle: null, startType: "ON_PURCHASE", endType: "UNTIL_CANCELLED" };
+    }
+    const cycle = plan.billingCycle || { period: "MONTH", count: 1 };
+    return {
+      billingCycle: cycle,
+      startType: "ON_PURCHASE",
+      endType: "CYCLES_COMPLETED",
+      cyclesCompletedDetails: { billingCycleCount: 1 },
+    };
+  }
+  // recurring
+  const cycle = plan.billingCycle || { period: "MONTH", count: 1 };
+  return { billingCycle: cycle, startType: "ON_PURCHASE", endType: "UNTIL_CANCELLED" };
+}
+
+// One pricingVariant with one pricingStrategy (schema allows ≤20 but is "currently limited
+// to 1"). Amounts are decimal STRINGS ("20.00"); the variant id is a REQUIRED
+// client-supplied GUID — omitting it returns 400.
+function buildPricingVariant(plan) {
+  const free = (plan.type || "recurring") === "free";
+  const amount = free ? "0" : String(plan.price);
+  return {
+    id: randomUUID(),
+    name: plan.variantName || "Standard",
+    billingTerms: buildBillingTerms(plan),
+    pricingStrategies: [{ flatRate: { amount } }],
+  };
+}
+
+// plain plan -> Plans V3 create body. status:"ACTIVE" is REQUIRED (omitting → 400
+// "status value is required"); currency is NOT sent (read-only, site-derived); perks are
+// display-only bullets, each with a REQUIRED client-supplied GUID.
+function buildPlan(plan) {
+  const free = (plan.type || "recurring") === "free";
+  return {
+    name: plan.name,
+    description: plan.description,
+    status: "ACTIVE",
+    visibility: plan.visibility || "PUBLIC",
+    buyable: plan.buyable ?? true,
+    buyerCanCancel: plan.buyerCanCancel ?? true,
+    ...(plan.termsAndConditions ? { termsAndConditions: plan.termsAndConditions } : {}),
+    pricingVariants: [buildPricingVariant(plan)],
+    perks: (plan.perks ?? []).map((p) => ({
+      id: randomUUID(),
+      description: typeof p === "string" ? p : p.description,
+    })),
+    // free: cap lifetime reuse. Array + maxCount per the SDK schema (PurchaseLimit[]); the
+    // recipe's older `{ type, count }` object form predates it.
+    ...(free ? { purchaseLimits: [{ type: "PER_MEMBER_LIFETIME", maxCount: 1 }] } : {}),
+  };
+}
+
+// ---- operations ----------------------------------------------------------------------------------
+
+export async function installPricingPlansApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: PRICING_PLANS_APP_ID, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+// Create the plan(s) — Plans V3 has NO bulk-create: one POST per plan. Keep plan.id: the
+// frontend orders by it AND it is the coverage externalId.
+export async function createPlans(ctx, plans) {
+  const out = [];
+  for (const plan of plans) {
+    const r = await req(ctx, "/pricing-plans/v3/plans", { body: { plan: buildPlan(plan) } });
+    out.push({
+      id: r.plan?.id,
+      slug: r.plan?.slug,
+      name: plan.name,
+      coveredServiceIds: plan.coveredServiceIds,
+    });
+  }
+  return out;
+}
+
+// ---- bookings coverage via Benefit Programs (SKIP when no bookings in the run) -------------------
+// Strictly ordered: plan.id -> programDefinition.id -> itemSetId -> items. Do NOT parallelize.
+
+// 2a: READ the auto-created program definition (the Plans app creates it; you never create
+// it). Provisioning is ~immediate but async — retry ONCE after a short backoff, don't loop.
+export async function getProgramDefinition(ctx, planId) {
+  const path = `/benefit-programs/v1/program-definitions/by-namespace-and-external-id?externalId=${planId}&namespace=${encodeURIComponent(PP_NAMESPACE)}`;
+  try {
+    const r = await req(ctx, path, { method: "GET" });
+    if (r.programDefinition?.id) return r.programDefinition.id;
+  } catch {
+    /* fall through to the single insurance retry */
+  }
+  await sleep(1000);
+  const r = await req(ctx, path, { method: "GET" });
+  return r.programDefinition?.id;
+}
+
+// 2b: create ONE pool definition with EXACTLY ONE benefit naming Bookings as the provider.
+// price "0" = unlimited (default; no creditConfiguration). Limited pack: pass creditAmount →
+// price "1" + details.creditConfiguration (a SIBLING of benefits[], NOT inside a benefit —
+// nesting it 400s with "Price should be 0 when credit pool is not set up").
+export async function createPoolDefinition(ctx, programDefinitionId, { creditAmount } = {}) {
+  const limited = creditAmount != null;
+  const details = {
+    ...(limited ? { creditConfiguration: { amount: String(creditAmount) } } : {}),
+    benefits: [
+      {
+        benefitKey: randomUUID(),
+        displayName: "Bookings sessions",
+        providerAppId: BOOKINGS_APP_ID,
+        price: limited ? "1" : "0",
+      },
+    ],
+  };
+  const r = await req(ctx, "/benefit-programs/v1/pool-definitions", {
+    body: {
+      poolDefinition: {
+        namespace: PP_NAMESPACE,
+        displayName: "Bookings benefit",
+        programDefinitionIds: [programDefinitionId],
+        details,
+      },
+      cascade: "IMMEDIATELY",
+    },
+  });
+  // itemSetId lives at poolDefinition.details.benefits[i].itemSetId — one benefit here, so [0].
+  return r.poolDefinition?.details?.benefits?.[0]?.itemSetId;
+}
+
+// 2c: bulk-create the benefit items — ONE item per covered service (externalId = bookings
+// service id). Up to 100 per call; category is an empty string; namespace/providerAppId
+// repeat 2b's values.
+export async function createBenefitItems(ctx, itemSetId, serviceIds) {
+  return req(ctx, "/benefit-programs/v1/bulk/items/create", {
+    body: {
+      items: serviceIds.map((externalId) => ({
+        namespace: PP_NAMESPACE,
+        category: "",
+        providerAppId: BOOKINGS_APP_ID,
+        itemSetId,
+        externalId,
+      })),
+      returnEntity: true,
+    },
+  });
+}
+
+/**
+ * Wire a plan to COVER bookings services (per plan). Runs 2a → 2b → 2c in order.
+ * serviceIds come from the BOOKINGS seed — seed bookings first.
+ */
+export async function attachBookingsCoverage(ctx, planId, serviceIds, { creditAmount } = {}) {
+  const programDefinitionId = await getProgramDefinition(ctx, planId);
+  if (!programDefinitionId) throw new Error(`No program definition for plan ${planId} — is the Pricing Plans app installed?`);
+  const itemSetId = await createPoolDefinition(ctx, programDefinitionId, { creditAmount });
+  await createBenefitItems(ctx, itemSetId, serviceIds);
+  return { itemSetId, serviceIds };
+}
+
+/**
+ * ONE-CALL seed: install → create plans (ids kept in memory) → per covering plan, wire
+ * bookings coverage (2a → 2b → 2c, strictly ordered). The default path.
+ */
+export async function setupPricingPlans(ctx, { plans = [] } = {}) {
+  await installPricingPlansApp(ctx);
+  const created = await createPlans(ctx, plans);
+  const coverageAttached = [];
+  for (let i = 0; i < created.length; i++) {
+    const cov = plans[i].bookingsCoverage || {};
+    const serviceIds = cov.serviceIds || created[i].coveredServiceIds;
+    if (!serviceIds?.length) continue; // plans-only plan — coverage skipped
+    const r = await attachBookingsCoverage(ctx, created[i].id, serviceIds, { creditAmount: cov.creditAmount });
+    coverageAttached.push({ planId: created[i].id, ...r });
+  }
+  return {
+    plans: created,
+    coverageAttached,
+    benefitsCreated: coverageAttached.reduce((n, c) => n + c.serviceIds.length, 0),
+  };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-pricing-plans.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupPricingPlans(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/restaurants/INSTRUCTIONS.md
@@ -1,0 +1,165 @@
+# Restaurants — playbook
+
+The restaurant machinery ships as files — the assembled menu tree (menus → sections → items
+with variants, modifiers, labels), the dish-ordering cart on the eCom current cart with the
+exact restaurant `catalogReference`, the hosted checkout, and the table-reservation
+hold → reserve flow, typed end-to-end. **The presentation is yours**: you design and
+implement the dish card, the menu surface, the order-cart chrome, and the reservations
+surface on the shipped hooks/DTOs, plus the home page and the brand. You never write
+ordering or reservation logic; you never skip designing.
+
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source only on a real fallback (runtime error / uncovered field),
+or to read a reference component's pattern.
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` · `wix/media.ts` · `wix/money.ts` | shared auth seam + helpers (deploy configures; nothing to set) |
+| `wix/restaurants/types.ts` | the DTOs (`MenuData`, `MenuSection`, `MenuItem`, `OrderCart`, `ReservationSlot`, …) — contracts below |
+| `wix/restaurants/menu.ts` | `fetchMenus` — the whole display-ordered menu tree, one call |
+| `wix/restaurants/ordering.ts` · `order-store.ts` | dish add-to-cart (Orders-app catalogReference) + eCom Cart V2 + shared cart state (module store — spans Astro islands) |
+| `wix/restaurants/reservations.ts` | locations, AVAILABLE slots, `holdReservation`, `completeReservation` — the exact hold→reserve sequence lives here |
+| `hooks/restaurants/useMenus.ts` | menu browsing + menu switching — contract below |
+| `hooks/restaurants/useOrderCart.ts` | order-cart state + actions — contract below |
+| `hooks/restaurants/useReservation.ts` | the whole reservation state machine — contract below |
+| `components/restaurants/MenuView.tsx` (+ `MenuItemCard`) · `OrderCartButton.tsx` · `OrderCartDrawer.tsx` · `ReservationView.tsx` | **REFERENCE implementations** — correct, plain; build your own instead of shipping them |
+| `styles/global.css` | the design system: Tailwind v4 + the `@theme` token block (shared across verticals) |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | site chrome — **yours to brand** (keep the `seo-tags` slot, global.css import, and one OrderCartButton + one OrderCartDrawer, both `client:only`). If another vertical is also deployed, its layout won — merge the Menu/Reservations links + cart mounts there |
+| `pages/menu.astro` | SSR menu — **keep the frontmatter**, swap the island import to YOUR component |
+| `pages/reservations.astro` | reservations — the island stays `client:only="react"` (availability is timezone-specific); swap the import to YOUR component |
+
+## What you build — the design job
+
+1. **The dish card + menu surface** — your card (photo treatment, price/variants, labels,
+   sold-out state, add-to-order) and your menu layout (menu tabs when >1, section navigation,
+   section rhythm), with skeletons while loading and an honest empty state — on `useMenus` +
+   `useOrderCart`.
+2. **The order-cart chrome** — your header order button (live count) and your cart panel
+   (lines, quantity stepper, remove, subtotal, checkout CTA) — on `useOrderCart`, which owns
+   ALL cart logic; you own how it looks.
+3. **The reservations surface** — party/date/time query, slot pills, the 10-minute-hold
+   details form (first name + phone required), and the confirmed vs pending-approval states —
+   on `useReservation`.
+4. **The home page** — hero, a featured-dishes strip (fetch `fetchMenus()` in frontmatter →
+   your cards; `item.featured` marks highlights), hours/location story, reserve CTA.
+
+Plus the **theme** (`@theme` block, one edit) and the **chrome** (`SiteLayout`, one pass).
+Style everything with Tailwind utilities on the tokens.
+
+### The contracts your components consume
+
+```ts
+// MenuData → sections → items, all display-ordered:
+// MenuItem = { id, name, description, price /* display string; null when variant-priced */,
+//   marketPrice /* true → "Market price", not orderable */,
+//   variants: [{ variantId, name, price }], imageUrl, labels: [{ id, name, iconUrl }],
+//   modifierGroups: [{ id, name, required, minSelections, maxSelections,
+//                      modifiers: [{ id, name, preSelected, additionalCharge, inStock }] }],
+//   inStock, featured }
+// ⚠ MENU prices carry NO currency symbol unless the platform formatted them — render as
+//   given; if plain decimals, prefix the brand's currency yourself. Order-cart prices ARE
+//   formatted. Modifier groups are DISPLAY-ONLY (selections aren't sent on the cart line).
+
+// useMenus({ initialMenus? }) →
+// { menus: MenuData[]|null /* null = loading → skeletons */,
+//   activeMenuId, setActiveMenuId(id), activeMenu: MenuData|null, error }
+
+// useOrderCart() →
+// { cart: { lines, itemCount, subtotal, currency }|null,
+//   ordering: boolean|null,                 // false → show "ordering unavailable"; null = resolving
+//   busy, error, open,
+//   addToOrder(itemId, { menuId, sectionId }, qty?),  // ids from the render context — see hard rules
+//   updateQuantity(lineItemId, qty), removeLine(lineItemId),
+//   checkout(),                             // browser redirects to the Wix-hosted checkout
+//   openCart(), closeCart(), refresh() }
+// OrderLine = { lineItemId, itemName, quantity, unitPrice, linePrice, imageUrl,
+//               descriptionLines, status /* not "IN_STOCK" → can't check out */ }
+
+// useReservation() →
+// { locations: [{ id, partySizeMin, partySizeMax, approvalMode, onlineReservationsEnabled }]|null,
+//   location, setLocationId(id),            // picker only when locations.length > 1
+//   date, setDate("YYYY-MM-DD"), time, setTime("HH:mm"), partySize, setPartySize(n),
+//   slots: ReservationSlot[]|null, findSlots(),   // AVAILABLE only; null until findSlots ran
+//   held, holdSlot(slot),                    // 10-minute hold → render the details form
+//   reservee, setReserveeField(field, value), // firstName + phone (E.164) required
+//   canConfirm, confirm(),                    // gate the CTA on canConfirm
+//   confirmed: { reservationId, status: "RESERVED"|"REQUESTED" }|null,
+//   reset(), loading, error }
+```
+
+### Wiring — Astro (default)
+
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass — merge into the
+   winning layout instead if another vertical is also deployed).
+2. Write your components under `src/components/restaurants/` (new names — don't overwrite the
+   references), swap the island imports in `pages/menu.astro` and `pages/reservations.astro`.
+   Menu island: `client:load` with the SSR props; reservations island and the cart chrome:
+   `client:only="react"`. **Author your surfaces in as few messages as possible** — batch
+   multiple Writes per message.
+3. Write `pages/index.astro` (home) — it exists from the scaffold; Read it before overwriting.
+
+### Wiring — React SPA (Vite etc.)
+
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+plugins — deploy added the dep). Routes: `/menu` → your menu surface (`useMenus()` fetches
+client-side when no `initialMenus`); `/reservations` → your reservation surface. Mount your
+order button in the header and your drawer once.
+
+## Hard rules
+
+- **Ordering logic only through the shipped exports** — `useOrderCart`/`addToOrder` own the
+  restaurant `catalogReference` (the Orders app id + `operationId`/`menuId`/`sectionId` — all
+  three, no `variantId`), the line-refusal checks, and the checkout redirect. Never re-derive
+  any of it, never hand-build a checkout URL.
+- **Thread `menuId` + `sectionId` from the render context** — each dish is rendered inside a
+  known section of a known menu (the `fetchMenus` tree); pass those ids to `addToOrder`.
+  Never look them up again.
+- **Modifier groups are display-only** — show them on the dish (diners read them; staff sees
+  choices at the counter), but don't invent a way to send selections: that cart-line shape
+  isn't documented. Send quantity only, as shipped.
+- **Reservations only through `useReservation`** — AVAILABLE-only slots, the hold's
+  `revision`, the firstName+phone requirement, and the RESERVED/REQUESTED split all live in
+  the data layer. Gate the CTA on `canConfirm`, surface `error` (holds expire in 10 minutes —
+  the hook already restarts the flow).
+- **The confirmed state must reflect REAL success**: render it only from `confirmed`, and
+  render `REQUESTED` as "pending the restaurant's approval", never as confirmed. A visitor
+  returning from the hosted checkout is NOT an order-success signal.
+- **Honest unavailability**: `ordering === false` → an "ordering unavailable" state on the
+  add button; `onlineReservationsEnabled === false` → a "call us to book" notice (the toggle
+  is premium-gated). Never mock menus, dishes, prices, slots, or availability.
+- Theme via the `@theme` tokens; no parallel theme files, no hardcoded palettes.
+
+## Point the user to their dashboard
+
+Give the owner the dashboard link (`https://manage.wix.com/dashboard/<siteId>`) plus:
+`…/wix-restaurants-menus-new` (edit the menu), `…/wix-restaurants-orders-new/settings`
+(fulfillment: pickup/delivery hours, fees), `…/wix-table-reservations/table-reservations`
+(tables, availability). Real paid orders need a premium plan + a connected payment method,
+and the online-reservations toggle itself is premium — mention both.
+
+## Seeding
+
+Per `seed/SEED.md` — plain-data `plan.json` into `seed-restaurants.mjs` from the project
+root. Seed a menu that exercises the UI (a few sections, an image per dish) and turn on the
+ordering + reservations add-ons when the restaurant takes orders/bookings.
+
+## Verify (before declaring done)
+
+- [ ] `/menu` renders the live menu SSR (view-source shows dish names) through YOUR
+      components, sections in seeded order; an empty backend shows your honest empty state.
+- [ ] Add to order works (drawer opens, count badge is live); quantity ± / remove work; the
+      order survives a reload (same visitor token); checkout redirects to the Wix-hosted
+      checkout — or, with no ordering operation, your "ordering unavailable" state shows.
+- [ ] `/reservations`: only AVAILABLE times offered; hold → details form → confirm produces
+      your RESERVED or REQUESTED state; a non-premium site shows your honest
+      "reservations aren't open yet" notice instead of a broken form.
+- [ ] Dish card / menu / cart chrome / reservations / home are YOUR designs on the tokens;
+      data-layer/hook files unedited.
+- [ ] Dashboard links handed to the owner, with the premium notes.

--- a/skills/wix-headless-fast/references/restaurants/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/restaurants/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,47 @@
+---
+// The site chrome for every restaurant page — THIS file (header/footer/nav) plus the @theme
+// token block in src/styles/global.css are what you brand. Keep the <slot name="seo-tags" />
+// in <head>, the global.css import, and one OrderCartButton in the header + one
+// OrderCartDrawer per page (both client:only — they read browser cart state and must not
+// server-render). (If another vertical is also deployed, its SiteLayout may have won; merge
+// the Menu/Reservations nav links and the order-cart mounts there instead.)
+import OrderCartButton from "../components/restaurants/OrderCartButton";
+import OrderCartDrawer from "../components/restaurants/OrderCartDrawer";
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+  </head>
+  <body>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <a href="/" class="text-base font-bold tracking-tight text-foreground no-underline">Brand Name</a>
+        <nav class="flex items-center gap-6 text-sm">
+          <a href="/menu" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Menu</a>
+          <a href="/reservations" class="text-foreground no-underline transition-colors hover:text-muted-foreground">Reservations</a>
+          <OrderCartButton client:only="react" />
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-6xl px-6 pb-24 pt-10">
+      <slot />
+    </main>
+    <footer class="border-t border-border px-6 py-10 text-center text-sm text-muted-foreground">
+      © Brand Name
+    </footer>
+    <OrderCartDrawer client:only="react" />
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/restaurants/app-astro/pages/menu.astro
+++ b/skills/wix-headless-fast/references/restaurants/app-astro/pages/menu.astro
@@ -1,0 +1,22 @@
+---
+// Menu page — the full menu tree fetched SERVER-SIDE (SEO: dish names in view-source) and
+// handed to the island as DTO props. Keep this frontmatter; swap the island import to YOUR
+// menu component. The island is client:load — add-to-order needs the browser.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import MenuView from "../components/restaurants/MenuView";
+import { fetchMenus } from "../wix/restaurants/menu";
+import type { MenuData } from "../wix/restaurants/types";
+
+let menus: MenuData[] = [];
+try {
+  menus = await fetchMenus();
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // empty state instead.
+}
+---
+
+<SiteLayout title="Menu">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Menu</h1>
+  <MenuView client:load initialMenus={menus} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/restaurants/app-astro/pages/reservations.astro
+++ b/skills/wix-headless-fast/references/restaurants/app-astro/pages/reservations.astro
@@ -1,0 +1,12 @@
+---
+// Reservations page. The surface is client:only — availability is timezone- and
+// party-specific, so nothing useful can server-render. Swap the island import to YOUR
+// reservation component.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import ReservationView from "../components/restaurants/ReservationView";
+---
+
+<SiteLayout title="Reservations" description="Reserve a table">
+  <h1 class="mb-8 text-2xl font-semibold tracking-tight">Reserve a table</h1>
+  <ReservationView client:only="react" />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/restaurants/app/components/restaurants/MenuView.tsx
+++ b/skills/wix-headless-fast/references/restaurants/app/components/restaurants/MenuView.tsx
@@ -1,0 +1,142 @@
+// REFERENCE menu surface: menu tabs (when >1), section nav, and the dish card, on the
+// @theme tokens. Correct and complete; per the skill's model you design and build your own
+// on useMenus + useOrderCart. Note the load-bearing wiring: each card threads its menuId +
+// sectionId from the render context into addToOrder — never re-derive them.
+import { useState } from "react";
+import { useMenus } from "../../hooks/restaurants/useMenus";
+import { useOrderCart } from "../../hooks/restaurants/useOrderCart";
+import type { MenuData, MenuItem } from "../../wix/restaurants/types";
+
+export interface MenuItemCardProps {
+  item: MenuItem;
+  menuId: string;
+  sectionId: string;
+}
+
+export function MenuItemCard({ item, menuId, sectionId }: MenuItemCardProps) {
+  const { addToOrder, ordering, busy } = useOrderCart();
+  const [error, setError] = useState<string | null>(null);
+  const canAdd = ordering === true && item.inStock && !item.marketPrice && !busy;
+
+  return (
+    <div className="flex gap-4 rounded-lg border border-border p-4">
+      {item.imageUrl && (
+        <img
+          src={item.imageUrl}
+          alt={item.name}
+          loading="lazy"
+          className="h-24 w-24 flex-shrink-0 rounded-md bg-secondary object-cover"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-sm font-semibold">{item.name}</p>
+          <p className="whitespace-nowrap text-sm text-foreground">
+            {item.marketPrice ? "Market price" : (item.price ?? "")}
+          </p>
+        </div>
+        {item.labels.length > 0 && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{item.labels.map((l) => l.name).join(" · ")}</p>
+        )}
+        {item.description && (
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{item.description}</p>
+        )}
+        {item.variants.length > 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {item.variants.map((v) => `${v.name} ${v.price}`).join(" · ")}
+          </p>
+        )}
+        {item.modifierGroups.length > 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {/* Modifier groups are DISPLAY-ONLY — selections aren't sent on the cart line. */}
+            Options: {item.modifierGroups.map((g) => g.name).join(", ")}
+          </p>
+        )}
+        <div className="mt-2 flex items-center gap-3">
+          {ordering !== null && !item.marketPrice && (
+            <button
+              type="button"
+              disabled={!canAdd}
+              onClick={() =>
+                addToOrder(item.id, { menuId, sectionId }).catch((e: unknown) =>
+                  setError(e instanceof Error ? e.message : String(e)),
+                )
+              }
+              className="rounded-full bg-primary px-4 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              {!item.inStock ? "Sold out" : ordering === false ? "Ordering unavailable" : "Add to order"}
+            </button>
+          )}
+          {error && <p className="text-xs text-red-600">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export interface MenuViewProps {
+  initialMenus?: MenuData[];
+  emptyMessage?: string;
+}
+
+const tab = (active: boolean) =>
+  `rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+    active
+      ? "border-primary bg-primary text-primary-foreground"
+      : "border-border text-foreground hover:bg-secondary"
+  }`;
+
+export default function MenuView({
+  initialMenus,
+  emptyMessage = "The menu is being written — check back soon.",
+}: MenuViewProps) {
+  const { menus, activeMenuId, setActiveMenuId, activeMenu, error } = useMenus({ initialMenus });
+
+  if (menus === null) {
+    return (
+      <div aria-busy="true">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="mb-4 h-24 animate-pulse rounded-lg bg-secondary" />
+        ))}
+      </div>
+    );
+  }
+  if (menus.length === 0) {
+    return <p className="py-16 text-center text-muted-foreground">{error ?? emptyMessage}</p>;
+  }
+
+  return (
+    <div>
+      {menus.length > 1 && (
+        <div className="mb-8 flex flex-wrap gap-2" role="group" aria-label="Menus">
+          {menus.map((m) => (
+            <button key={m.id} type="button" className={tab(m.id === activeMenuId)} onClick={() => setActiveMenuId(m.id)}>
+              {m.name}
+            </button>
+          ))}
+        </div>
+      )}
+      {activeMenu && activeMenu.sections.length > 1 && (
+        <nav className="mb-8 flex flex-wrap gap-x-5 gap-y-1 text-sm" aria-label="Sections">
+          {activeMenu.sections.map((s) => (
+            <a key={s.id} href={`#section-${s.id}`} className="text-muted-foreground no-underline transition-colors hover:text-foreground">
+              {s.name}
+            </a>
+          ))}
+        </nav>
+      )}
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+      {activeMenu?.sections.map((section) => (
+        <section key={section.id} id={`section-${section.id}`} className="mb-12">
+          <h2 className="text-lg font-semibold tracking-tight">{section.name}</h2>
+          {section.description && <p className="mt-1 text-sm text-muted-foreground">{section.description}</p>}
+          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+            {section.items.map((item) => (
+              <MenuItemCard key={item.id} item={item} menuId={activeMenu.id} sectionId={section.id} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/restaurants/app/components/restaurants/OrderCartButton.tsx
+++ b/skills/wix-headless-fast/references/restaurants/app/components/restaurants/OrderCartButton.tsx
@@ -1,0 +1,26 @@
+// REFERENCE header order button with a live count badge — opens the OrderCartDrawer.
+// Correct and complete; per the skill's model you design your own chrome on useOrderCart.
+import { useOrderCart } from "../../hooks/restaurants/useOrderCart";
+
+export default function OrderCartButton() {
+  const { itemCount, openCart } = useOrderCart();
+  return (
+    <button
+      type="button"
+      aria-label={`Order, ${itemCount} items`}
+      onClick={openCart}
+      className="relative inline-flex items-center p-1.5 text-foreground transition-opacity hover:opacity-70"
+    >
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <path d="M16 10a4 4 0 01-8 0" />
+      </svg>
+      {itemCount > 0 && (
+        <span className="absolute -right-1 -top-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-primary-foreground">
+          {itemCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/skills/wix-headless-fast/references/restaurants/app/components/restaurants/OrderCartDrawer.tsx
+++ b/skills/wix-headless-fast/references/restaurants/app/components/restaurants/OrderCartDrawer.tsx
@@ -1,0 +1,121 @@
+// REFERENCE slide-over order cart with quantity stepper, remove, live subtotal, and the
+// Wix-hosted checkout. Mount ONCE per page; opens via useOrderCart().openCart(). Correct and
+// complete; per the skill's model you design your own chrome on useOrderCart.
+import { useOrderCart } from "../../hooks/restaurants/useOrderCart";
+
+export default function OrderCartDrawer() {
+  const { cart, open, closeCart, busy, error, updateQuantity, removeLine, checkout } = useOrderCart();
+  if (!open) return null;
+  const lines = cart?.lines ?? [];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-foreground/40 backdrop-blur-[2px]"
+      onClick={closeCart}
+    >
+      <aside
+        role="dialog"
+        aria-label="Your order"
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-full w-full max-w-md flex-col bg-background text-foreground shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-border px-6 py-5">
+          <span className="text-base font-semibold">
+            Your order{cart && cart.itemCount > 0 ? ` (${cart.itemCount})` : ""}
+          </span>
+          <button
+            type="button"
+            aria-label="Close order"
+            onClick={closeCart}
+            className="text-xl leading-none text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {lines.length === 0 && (
+            <p className="py-16 text-center text-sm text-muted-foreground">Your order is empty.</p>
+          )}
+          {lines.map((line) => (
+            <div className="mb-6 flex gap-4" key={line.lineItemId}>
+              {line.imageUrl ? (
+                <img
+                  src={line.imageUrl}
+                  alt=""
+                  loading="lazy"
+                  className="h-16 w-16 flex-shrink-0 rounded-md bg-secondary object-cover"
+                />
+              ) : (
+                <div aria-hidden="true" className="h-16 w-16 flex-shrink-0 rounded-md bg-secondary" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">{line.itemName}</p>
+                {line.descriptionLines.map((d) => (
+                  <p className="mt-0.5 text-xs text-muted-foreground" key={d}>
+                    {d}
+                  </p>
+                ))}
+                {line.status !== "IN_STOCK" && (
+                  <p className="mt-1 text-xs text-red-600">No longer available</p>
+                )}
+                <div className="mt-2 flex items-center">
+                  <div className="inline-flex items-center gap-3 rounded-full border border-border px-2 py-0.5">
+                    <button
+                      type="button"
+                      aria-label="Decrease quantity"
+                      disabled={busy || line.quantity <= 1}
+                      onClick={() => updateQuantity(line.lineItemId, line.quantity - 1).catch(() => {})}
+                      className="px-1 text-base disabled:opacity-40"
+                    >
+                      −
+                    </button>
+                    <span className="text-sm tabular-nums">{line.quantity}</span>
+                    <button
+                      type="button"
+                      aria-label="Increase quantity"
+                      disabled={busy}
+                      onClick={() => updateQuantity(line.lineItemId, line.quantity + 1).catch(() => {})}
+                      className="px-1 text-base disabled:opacity-40"
+                    >
+                      +
+                    </button>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => removeLine(line.lineItemId).catch(() => {})}
+                    className="ml-3 text-xs text-muted-foreground underline transition-colors hover:text-foreground disabled:opacity-40"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+              <p className="text-sm font-medium">{line.linePrice}</p>
+            </div>
+          ))}
+        </div>
+
+        {lines.length > 0 && (
+          <div className="border-t border-border px-6 py-5">
+            {cart?.subtotal && (
+              <div className="mb-4 flex justify-between text-sm">
+                <span className="text-muted-foreground">Subtotal</span>
+                <strong className="font-semibold">{cart.subtotal}</strong>
+              </div>
+            )}
+            {error && <p className="mb-3 text-xs text-red-600">{error}</p>}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => checkout().catch(() => {})}
+              className="w-full rounded-full bg-primary py-3.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? "One moment…" : "Checkout"}
+            </button>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/restaurants/app/components/restaurants/ReservationView.tsx
+++ b/skills/wix-headless-fast/references/restaurants/app/components/restaurants/ReservationView.tsx
@@ -1,0 +1,155 @@
+// REFERENCE reservations surface: party/date/time query → AVAILABLE slot pills → hold →
+// details form → confirmed, on the @theme tokens. Correct and complete; per the skill's
+// model you design and build your own on useReservation (which owns ALL booking logic).
+import { useReservation } from "../../hooks/restaurants/useReservation";
+
+const input =
+  "w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary";
+
+export default function ReservationView() {
+  const r = useReservation();
+
+  if (r.locations === null) {
+    return <div className="h-64 animate-pulse rounded-lg bg-secondary" aria-busy="true" />;
+  }
+  if (r.locations.length === 0 || !r.location) {
+    return (
+      <p className="py-16 text-center text-muted-foreground">
+        Table reservations aren't set up yet — call us to book.
+      </p>
+    );
+  }
+  if (!r.location.onlineReservationsEnabled) {
+    // Premium-gated toggle is off — slots/booking would fail; be honest, don't fake a form.
+    return (
+      <p className="py-16 text-center text-muted-foreground">
+        Online reservations aren't open yet — call us to book a table.
+      </p>
+    );
+  }
+
+  if (r.confirmed) {
+    return (
+      <div className="mx-auto max-w-md rounded-lg border border-border p-8 text-center">
+        <p className="text-lg font-semibold">
+          {r.confirmed.status === "RESERVED" ? "Table reserved" : "Request sent"}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {r.confirmed.status === "RESERVED"
+            ? "See you soon — a confirmation is on its way."
+            : "The restaurant will confirm your reservation shortly."}
+        </p>
+        <button
+          type="button"
+          onClick={r.reset}
+          className="mt-6 rounded-full border border-border px-5 py-2 text-sm font-medium hover:bg-secondary"
+        >
+          Make another reservation
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Guests</span>
+          <input
+            type="number"
+            min={r.location.partySizeMin}
+            max={r.location.partySizeMax}
+            value={r.partySize}
+            onChange={(e) => r.setPartySize(Number(e.target.value))}
+            className={`mt-1 ${input}`}
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Date</span>
+          <input type="date" value={r.date} onChange={(e) => r.setDate(e.target.value)} className={`mt-1 ${input}`} />
+        </label>
+        <label className="block text-sm">
+          <span className="text-muted-foreground">Around</span>
+          <input type="time" value={r.time} onChange={(e) => r.setTime(e.target.value)} className={`mt-1 ${input}`} />
+        </label>
+      </div>
+      <button
+        type="button"
+        disabled={r.loading}
+        onClick={() => void r.findSlots()}
+        className="mt-4 w-full rounded-full bg-primary py-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        {r.loading && r.slots === null ? "Finding times…" : "Find a table"}
+      </button>
+
+      {r.error && <p className="mt-4 text-sm text-red-600">{r.error}</p>}
+
+      {r.slots !== null && r.slots.length === 0 && !r.error && (
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          No tables around that time — try another time or party size.
+        </p>
+      )}
+
+      {r.slots !== null && r.slots.length > 0 && !r.held && (
+        <div className="mt-6 flex flex-wrap gap-2" role="group" aria-label="Available times">
+          {r.slots.map((slot) => (
+            <button
+              key={slot.startIso}
+              type="button"
+              disabled={r.loading}
+              onClick={() => void r.holdSlot(slot)}
+              className="rounded-full border border-border px-4 py-1.5 text-sm font-medium transition-colors hover:bg-secondary disabled:opacity-40"
+            >
+              {slot.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {r.held && (
+        <div className="mt-6 rounded-lg border border-border p-5">
+          <p className="text-sm font-medium">
+            Holding {new Date(r.held.startIso).toLocaleString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}{" "}
+            for {r.held.partySize} — complete within 10 minutes.
+          </p>
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <input
+              placeholder="First name *"
+              value={r.reservee.firstName}
+              onChange={(e) => r.setReserveeField("firstName", e.target.value)}
+              className={input}
+            />
+            <input
+              placeholder="Last name"
+              value={r.reservee.lastName ?? ""}
+              onChange={(e) => r.setReserveeField("lastName", e.target.value)}
+              className={input}
+            />
+            <input
+              placeholder="Phone (+15551234567) *"
+              type="tel"
+              value={r.reservee.phone}
+              onChange={(e) => r.setReserveeField("phone", e.target.value)}
+              className={input}
+            />
+            <input
+              placeholder="Email"
+              type="email"
+              value={r.reservee.email ?? ""}
+              onChange={(e) => r.setReserveeField("email", e.target.value)}
+              className={input}
+            />
+          </div>
+          <button
+            type="button"
+            disabled={!r.canConfirm}
+            onClick={() => void r.confirm()}
+            className="mt-4 w-full rounded-full bg-primary py-3 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {r.loading ? "Reserving…" : "Complete reservation"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useMenus.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useMenus.ts
@@ -1,0 +1,55 @@
+// Menu browsing. SSR-friendly: pass server-fetched menus as `initialMenus` (Astro
+// frontmatter) and no client fetch happens; a SPA passes nothing. Menu switching is
+// client-side (the whole tree is fetched once).
+import { useEffect, useMemo, useState } from "react";
+import { fetchMenus } from "../../wix/restaurants/menu";
+import type { MenuData } from "../../wix/restaurants/types";
+
+export interface UseMenusOptions {
+  initialMenus?: MenuData[];
+}
+
+export interface UseMenus {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  menus: MenuData[] | null;
+  /** Defaults to the first menu once loaded. */
+  activeMenuId: string | null;
+  setActiveMenuId: (id: string) => void;
+  /** The menu to render (its sections/items are display-ordered). */
+  activeMenu: MenuData | null;
+  error: string | null;
+}
+
+export function useMenus({ initialMenus }: UseMenusOptions = {}): UseMenus {
+  const [menus, setMenus] = useState<MenuData[] | null>(initialMenus ?? null);
+  const [activeMenuId, setActiveMenuId] = useState<string | null>(initialMenus?.[0]?.id ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!initialMenus) {
+      fetchMenus()
+        .then((m) => {
+          if (!alive) return;
+          setMenus(m);
+          setActiveMenuId((id) => id ?? m[0]?.id ?? null);
+        })
+        .catch((e) => {
+          if (!alive) return;
+          setMenus([]);
+          setError(e instanceof Error ? e.message : String(e));
+        });
+    }
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const activeMenu = useMemo(() => {
+    if (!menus) return null;
+    return menus.find((m) => m.id === activeMenuId) ?? menus[0] ?? null;
+  }, [menus, activeMenuId]);
+
+  return { menus, activeMenuId: activeMenu?.id ?? null, setActiveMenuId, activeMenu, error };
+}

--- a/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useOrderCart.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useOrderCart.ts
@@ -1,0 +1,43 @@
+// React binding for the order-cart store. Works in any React root — Astro islands (several
+// on one page share the same store) and SPAs alike.
+import { useSyncExternalStore } from "react";
+import {
+  addOrderLine,
+  getOrderCartState,
+  goToOrderCheckout,
+  refreshOrderCart,
+  removeLineFromOrder,
+  setOrderCartOpen,
+  subscribeOrderCart,
+  updateOrderLineQuantity,
+  type OrderCartState,
+} from "../../wix/restaurants/order-store";
+
+const SERVER_STATE = getOrderCartState();
+
+export interface UseOrderCart extends OrderCartState {
+  itemCount: number;
+  /** menuId/sectionId come from the render context (the fetchMenus tree) — pass both. */
+  addToOrder: (itemId: string, context: { menuId: string; sectionId: string }, quantity?: number) => Promise<void>;
+  updateQuantity: (lineItemId: string, quantity: number) => Promise<void>;
+  removeLine: (lineItemId: string) => Promise<void>;
+  checkout: () => Promise<void>;
+  openCart: () => void;
+  closeCart: () => void;
+  refresh: () => Promise<void>;
+}
+
+export function useOrderCart(): UseOrderCart {
+  const state = useSyncExternalStore(subscribeOrderCart, getOrderCartState, () => SERVER_STATE);
+  return {
+    ...state,
+    itemCount: state.cart?.itemCount ?? 0,
+    addToOrder: addOrderLine,
+    updateQuantity: updateOrderLineQuantity,
+    removeLine: removeLineFromOrder,
+    checkout: goToOrderCheckout,
+    openCart: () => setOrderCartOpen(true),
+    closeCart: () => setOrderCartOpen(false),
+    refresh: refreshOrderCart,
+  };
+}

--- a/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useReservation.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/hooks/restaurants/useReservation.ts
@@ -1,0 +1,177 @@
+// The whole table-reservation state machine: location, date + party size, AVAILABLE slots,
+// the 10-minute hold, the details form, and confirm. All correctness (AVAILABLE-only slots,
+// hold → reserve with the revision, firstName + E.164 phone, RESERVED vs REQUESTED) lives in
+// the data layer — this hook orchestrates; you own how it looks. Client-only: availability
+// is timezone-specific, so render the surface with client:only="react" in Astro.
+import { useEffect, useState } from "react";
+import {
+  completeReservation,
+  fetchReservationLocations,
+  fetchReservationSlots,
+  holdReservation,
+} from "../../wix/restaurants/reservations";
+import type {
+  ReservationConfirmation,
+  ReservationHold,
+  ReservationLocationInfo,
+  ReservationReservee,
+  ReservationSlot,
+} from "../../wix/restaurants/types";
+
+const todayKey = (): string => {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+export interface UseReservation {
+  /** null while loading; [] when Table Reservations isn't set up (honest empty state). */
+  locations: ReservationLocationInfo[] | null;
+  /** The active location (default first). Render a picker only when locations.length > 1. */
+  location: ReservationLocationInfo | null;
+  setLocationId: (id: string) => void;
+  /** "YYYY-MM-DD" for a date input. */
+  date: string;
+  setDate: (date: string) => void;
+  /** "HH:mm" anchor for the slot fan-out. */
+  time: string;
+  setTime: (time: string) => void;
+  /** Clamped to the location's partySizeMin/Max. */
+  partySize: number;
+  setPartySize: (size: number) => void;
+  /** AVAILABLE slots for the current query; null until findSlots ran. */
+  slots: ReservationSlot[] | null;
+  findSlots: () => Promise<void>;
+  /** Set after holdSlot — the visitor has 10 minutes to confirm. */
+  held: ReservationHold | null;
+  holdSlot: (slot: ReservationSlot) => Promise<void>;
+  reservee: ReservationReservee;
+  setReserveeField: (field: keyof ReservationReservee, value: string) => void;
+  /** True when a slot is held and firstName + phone are filled — gate the confirm CTA. */
+  canConfirm: boolean;
+  confirm: () => Promise<void>;
+  /** Set on success. REQUESTED → tell the visitor approval is pending, not confirmed. */
+  confirmed: ReservationConfirmation | null;
+  /** Back to slot picking (keeps date/party). */
+  reset: () => void;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useReservation(): UseReservation {
+  const [locations, setLocations] = useState<ReservationLocationInfo[] | null>(null);
+  const [locationId, setLocationId] = useState<string | null>(null);
+  const [date, setDate] = useState<string>(todayKey());
+  const [time, setTime] = useState<string>("19:00");
+  const [partySize, setPartySizeRaw] = useState<number>(2);
+  const [slots, setSlots] = useState<ReservationSlot[] | null>(null);
+  const [held, setHeld] = useState<ReservationHold | null>(null);
+  const [reservee, setReservee] = useState<ReservationReservee>({ firstName: "", phone: "" });
+  const [confirmed, setConfirmed] = useState<ReservationConfirmation | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchReservationLocations()
+      .then((locs) => {
+        if (!alive) return;
+        setLocations(locs);
+        setLocationId((id) => id ?? locs[0]?.id ?? null);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setLocations([]);
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const location = locations?.find((l) => l.id === locationId) ?? locations?.[0] ?? null;
+
+  const setPartySize = (size: number) => {
+    const min = location?.partySizeMin ?? 1;
+    const max = location?.partySizeMax ?? 20;
+    setPartySizeRaw(Math.min(Math.max(size, min), max));
+  };
+
+  async function findSlots(): Promise<void> {
+    if (!location) return;
+    setError(null);
+    setSlots(null);
+    setHeld(null);
+    setConfirmed(null);
+    setLoading(true);
+    try {
+      const aroundIso = new Date(`${date}T${time}:00`).toISOString();
+      setSlots(await fetchReservationSlots(location.id, aroundIso, partySize));
+    } catch (e) {
+      setSlots([]);
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function holdSlot(slot: ReservationSlot): Promise<void> {
+    if (!location) return;
+    setError(null);
+    setLoading(true);
+    try {
+      setHeld(await holdReservation(location.id, slot.startIso, partySize));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const canConfirm =
+    !!held && reservee.firstName.trim().length > 0 && reservee.phone.trim().length > 0 && !loading;
+
+  async function confirm(): Promise<void> {
+    if (!held) return;
+    setError(null);
+    setLoading(true);
+    try {
+      setConfirmed(await completeReservation(held, reservee));
+    } catch (e) {
+      // An expired hold can't be reserved — send the visitor back to slot picking.
+      setError(e instanceof Error ? e.message : String(e));
+      setHeld(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return {
+    locations,
+    location,
+    setLocationId,
+    date,
+    setDate,
+    time,
+    setTime,
+    partySize,
+    setPartySize,
+    slots,
+    findSlots,
+    held,
+    holdSlot,
+    reservee,
+    setReserveeField: (field, value) => setReservee((r) => ({ ...r, [field]: value })),
+    canConfirm,
+    confirm,
+    confirmed,
+    reset: () => {
+      setHeld(null);
+      setConfirmed(null);
+      setSlots(null);
+      setError(null);
+    },
+    loading,
+    error,
+  };
+}

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/menu.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/menu.ts
@@ -1,0 +1,158 @@
+// Menu reads (Wix Restaurants Menus V1) — the only file that touches raw menu entities.
+// Everything it returns is a plain DTO from ./types. Copy as-is; extend by adding functions,
+// not by editing these.
+//
+// The hierarchy is Menu → Sections → Items wired by ID ARRAYS: display structure and order
+// live in menu.sectionIds / section.itemIds, NOT in the list* response order — fetchMenus
+// stitches in id-array order and drops dangling ids. Entity ids are `_id` (never `id`).
+import {
+  menus as menusModule,
+  sections as sectionsModule,
+  items as itemsModule,
+  itemVariants,
+  itemModifierGroups,
+  itemModifiers,
+  itemLabels,
+} from "@wix/restaurants";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type {
+  MenuData,
+  MenuItem,
+  MenuItemLabel,
+  MenuItemVariant,
+  MenuModifier,
+  MenuModifierGroup,
+  MenuSection,
+} from "./types";
+
+const menusApi = wixModule(menusModule);
+const sectionsApi = wixModule(sectionsModule);
+const itemsApi = wixModule(itemsModule);
+const variantsApi = wixModule(itemVariants);
+const groupsApi = wixModule(itemModifierGroups);
+const modifiersApi = wixModule(itemModifiers);
+const labelsApi = wixModule(itemLabels);
+
+type Raw = Record<string, any>;
+
+// Menu prices are decimal strings in the site currency with NO symbol; the response may
+// carry a platform-formatted twin (formattedPrice) — prefer it, never invent a symbol.
+function displayPrice(priceInfo: Raw | undefined): string | null {
+  if (!priceInfo) return null;
+  return priceInfo.formattedPrice ?? priceInfo.price ?? null;
+}
+
+function toItem(
+  raw: Raw,
+  lookups: { variantById: Map<string, Raw>; groupById: Map<string, Raw>; modifierById: Map<string, Raw>; labelById: Map<string, Raw> },
+): MenuItem {
+  const variants: MenuItemVariant[] = (raw.priceVariants?.variants ?? [])
+    .map((v: Raw): MenuItemVariant => ({
+      variantId: v.variantId ?? "",
+      name: lookups.variantById.get(v.variantId)?.name ?? "",
+      price: displayPrice(v.priceInfo) ?? v.price ?? "",
+    }))
+    .filter((v: MenuItemVariant) => v.variantId);
+  const modifierGroups: MenuModifierGroup[] = (raw.modifierGroups ?? [])
+    .map((ref: Raw) => lookups.groupById.get(ref._id))
+    .filter(Boolean)
+    .map((g: Raw): MenuModifierGroup => ({
+      id: g._id ?? "",
+      name: g.name ?? "",
+      required: g.rule?.required === true,
+      minSelections: g.rule?.minSelections ?? 0,
+      maxSelections: g.rule?.maxSelections ?? null,
+      modifiers: (g.modifiers ?? []).map((m: Raw): MenuModifier => ({
+        id: m._id ?? "",
+        name: lookups.modifierById.get(m._id)?.name ?? "",
+        preSelected: m.preSelected === true,
+        additionalCharge: m.additionalChargeInfo?.additionalCharge ?? "0",
+        inStock: lookups.modifierById.get(m._id)?.inStock !== false,
+      })),
+    }));
+  const labels: MenuItemLabel[] = (raw.labels ?? [])
+    .map((ref: Raw) => lookups.labelById.get(ref._id))
+    .filter(Boolean)
+    .map((l: Raw): MenuItemLabel => ({ id: l._id ?? "", name: l.name ?? "", iconUrl: imgSrc(l.icon, 48, 48) }));
+  const price = displayPrice(raw.priceInfo);
+  return {
+    id: raw._id ?? "",
+    name: raw.name ?? "",
+    description: raw.description ?? "",
+    price,
+    marketPrice: price === null && variants.length === 0,
+    variants,
+    imageUrl: imgSrc(raw.image, 800, 800),
+    labels,
+    modifierGroups,
+    inStock: raw.orderSettings?.inStock !== false,
+    featured: raw.featured === true,
+  };
+}
+
+/**
+ * The site's full menu tree, assembled and display-ordered: visible menus → their sections →
+ * their items, each item enriched with resolved price variants, modifier groups, and labels.
+ * The one entry point for every menu surface. [] when no menus exist (honest empty state).
+ * Caps at the APIs' 500-per-list limit — plenty for a restaurant.
+ */
+export async function fetchMenus(): Promise<MenuData[]> {
+  const [menusRes, sectionsRes, itemsRes]: Raw[] = await Promise.all([
+    menusApi.listMenus({ onlyVisible: true }),
+    sectionsApi.listSections({ onlyVisible: true }),
+    itemsApi.listItems({ onlyVisible: true }),
+  ]);
+  const menus: Raw[] = menusRes.menus ?? [];
+  if (!menus.length) return [];
+  const sections: Raw[] = sectionsRes.sections ?? [];
+  const items: Raw[] = itemsRes.items ?? [];
+
+  const variantIds: string[] = [
+    ...new Set(items.flatMap((i: Raw) => (i.priceVariants?.variants ?? []).map((v: Raw) => v.variantId)).filter(Boolean)),
+  ] as string[];
+  const groupIds: string[] = [
+    ...new Set(items.flatMap((i: Raw) => (i.modifierGroups ?? []).map((g: Raw) => g._id)).filter(Boolean)),
+  ] as string[];
+  const hasLabels = items.some((i: Raw) => (i.labels ?? []).length > 0);
+
+  const [variantsRes, groupsRes, labelsRes]: Raw[] = await Promise.all([
+    variantIds.length ? variantsApi.listVariants({ variantIds }) : Promise.resolve({ variants: [] }),
+    groupIds.length ? groupsApi.listModifierGroups({ modifierGroupIds: groupIds }) : Promise.resolve({ modifierGroups: [] }),
+    hasLabels ? labelsApi.listLabels() : Promise.resolve({ labels: [] }),
+  ]);
+  const groups: Raw[] = groupsRes.modifierGroups ?? [];
+  const modifierIds: string[] = [
+    ...new Set(groups.flatMap((g: Raw) => (g.modifiers ?? []).map((m: Raw) => m._id)).filter(Boolean)),
+  ] as string[];
+  const modifiersRes: Raw = modifierIds.length
+    ? await modifiersApi.listModifiers({ modifierIds })
+    : { modifiers: [] };
+
+  const byId = (arr: Raw[]) => new Map<string, Raw>(arr.map((e: Raw) => [e._id, e]));
+  const lookups = {
+    variantById: byId(variantsRes.variants ?? []),
+    groupById: byId(groups),
+    modifierById: byId(modifiersRes.modifiers ?? []),
+    labelById: byId(labelsRes.labels ?? []),
+  };
+  const sectionById = byId(sections);
+  const itemById = new Map<string, MenuItem>(items.map((i: Raw) => [i._id, toItem(i, lookups)]));
+
+  return menus.map((m: Raw): MenuData => ({
+    id: m._id ?? "",
+    name: m.name ?? "",
+    description: m.description ?? "",
+    slug: m.urlQueryParam ?? "",
+    sections: (m.sectionIds ?? [])
+      .map((sid: string) => sectionById.get(sid))
+      .filter(Boolean)
+      .map((s: Raw): MenuSection => ({
+        id: s._id ?? "",
+        name: s.name ?? "",
+        description: s.description ?? "",
+        imageUrl: imgSrc(s.image, 800, 800),
+        items: (s.itemIds ?? []).map((iid: string) => itemById.get(iid)).filter(Boolean) as MenuItem[],
+      })),
+  }));
+}

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/order-store.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/order-store.ts
@@ -1,0 +1,103 @@
+// Client-side order-cart state — a module-scope store, deliberately NOT a React context.
+// A context can't span Astro islands (each island is its own React root); a module singleton
+// is shared by every island in the page bundle, and works identically in a single-root SPA.
+// Consume it through useOrderCart() (hooks/), or subscribe directly.
+import type { OrderCart } from "./types";
+import {
+  addToOrder as apiAdd,
+  fetchOrderCart,
+  orderCheckoutUrl,
+  removeOrderLine as apiRemove,
+  resolveOperationId,
+  updateOrderQuantity as apiUpdate,
+} from "./ordering";
+
+export interface OrderCartState {
+  cart: OrderCart | null;
+  /** null while resolving; false → no ordering operation configured (show "unavailable"). */
+  ordering: boolean | null;
+  /** True while any cart operation is in flight. */
+  busy: boolean;
+  /** Last failed operation's message — render it; a new operation clears it. */
+  error: string | null;
+  /** Order drawer visibility (OrderCartButton opens it, OrderCartDrawer renders by it). */
+  open: boolean;
+}
+
+const EMPTY: OrderCartState = { cart: null, ordering: null, busy: false, error: null, open: false };
+
+let state: OrderCartState = EMPTY;
+const listeners = new Set<() => void>();
+let loaded = false;
+
+function setState(patch: Partial<OrderCartState>): void {
+  state = { ...state, ...patch };
+  for (const l of listeners) l();
+}
+
+export function getOrderCartState(): OrderCartState {
+  return state;
+}
+
+export function subscribeOrderCart(listener: () => void): () => void {
+  listeners.add(listener);
+  // First subscriber triggers the initial load (browser only — SSR renders the empty state).
+  if (!loaded && typeof window !== "undefined") {
+    loaded = true;
+    void refreshOrderCart();
+    void resolveOperationId().then((id) => setState({ ordering: id !== null }));
+  }
+  return () => listeners.delete(listener);
+}
+
+async function run(op: () => Promise<OrderCart>): Promise<void> {
+  setState({ busy: true, error: null });
+  try {
+    setState({ cart: await op(), busy: false });
+  } catch (e) {
+    setState({ busy: false, error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+export async function refreshOrderCart(): Promise<void> {
+  try {
+    setState({ cart: await fetchOrderCart() });
+  } catch {
+    /* no cart yet — leave the empty state */
+  }
+}
+
+/** Add a menu item to the order and open the drawer. Throws (and sets .error) on refusal. */
+export async function addOrderLine(
+  itemId: string,
+  context: { menuId: string; sectionId: string },
+  quantity = 1,
+): Promise<void> {
+  await run(() => apiAdd(itemId, context, quantity));
+  setState({ open: true });
+}
+
+export async function updateOrderLineQuantity(lineItemId: string, quantity: number): Promise<void> {
+  await run(() => apiUpdate(lineItemId, quantity));
+}
+
+export async function removeLineFromOrder(lineItemId: string): Promise<void> {
+  await run(() => apiRemove(lineItemId));
+}
+
+/** Navigate to the Wix-hosted checkout. Never hand-build a checkout URL. */
+export async function goToOrderCheckout(): Promise<void> {
+  setState({ busy: true, error: null });
+  try {
+    const url = await orderCheckoutUrl();
+    window.location.href = url;
+  } catch (e) {
+    setState({ busy: false, error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+export function setOrderCartOpen(open: boolean): void {
+  setState({ open });
+}

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/ordering.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/ordering.ts
@@ -1,0 +1,247 @@
+// Online ordering (Restaurants Orders + Wix eCom Cart V2) — the only file that touches the
+// raw cart and operation entities. Copy as-is; extend by calling these exports, never by
+// editing them. The request shapes are exact and rewriting them is how carts break:
+//   - the catalogReference appId is the ORDERS app (9a5d83fd-…), never the Stores id;
+//   - options MUST carry operationId + menuId + sectionId (all three) — the restaurant
+//     analog of the store's variantId; there is NO variantId here;
+//   - modifier/variant selections on the cart line are NOT sent — that options shape isn't
+//     documented for client add-to-cart (display modifiers; send quantity only).
+// Failures are loud: throws on a missing ordering operation, unavailable lines, and an empty
+// cart at checkout — surface the message, don't swallow it.
+import { operations as operationsModule, fulfillmentMethods as fulfillmentModule, items as itemsModule } from "@wix/restaurants";
+import { currentCartV2 } from "@wix/ecom";
+import { redirects as redirectsModule } from "@wix/redirects";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import { formatMoney } from "../money";
+import type { FulfillmentMethodInfo, OrderCart, OrderLine } from "./types";
+
+const operationsApi = wixModule(operationsModule);
+const fulfillmentApi = wixModule(fulfillmentModule);
+const itemsApi = wixModule(itemsModule);
+const cartApi = wixModule(currentCartV2);
+const redirects = wixModule(redirectsModule);
+
+/** The Restaurants Orders app id — every restaurant cart line's catalogReference.appId. */
+export const RESTAURANTS_ORDERS_APP_ID = "9a5d83fd-8570-482e-81ab-cfa88942ee60";
+
+type Raw = Record<string, any>;
+
+// The ordering operation is site config — resolve once, reuse for every add.
+let operationIdPromise: Promise<string | null> | null = null;
+
+/**
+ * The id of the operation to order through (ENABLED, else default, else first) — null when
+ * the site has no online ordering configured (show an "ordering unavailable" state).
+ */
+export function resolveOperationId(): Promise<string | null> {
+  operationIdPromise ??= operationsApi
+    .listOperations()
+    .then((res: Raw) => {
+      const ops: Raw[] = res.operations ?? [];
+      const op =
+        ops.find((o: Raw) => o.onlineOrderingStatus === "ENABLED") ?? ops.find((o: Raw) => o.default) ?? ops[0];
+      return op?._id ?? null;
+    })
+    .catch(() => {
+      operationIdPromise = null; // transient failure — allow a retry on the next call
+      return null;
+    });
+  return operationIdPromise;
+}
+
+/** Enabled pickup/delivery methods, for display — the buyer picks one on the hosted checkout. */
+export async function fetchFulfillmentMethods(): Promise<FulfillmentMethodInfo[]> {
+  try {
+    const res: Raw = await fulfillmentApi.listFulfillmentMethods();
+    return (res.fulfillmentMethods ?? [])
+      .filter((m: Raw) => m.enabled === true)
+      .map((m: Raw): FulfillmentMethodInfo => ({
+        id: m._id ?? "",
+        type: m.type === "DELIVERY" ? "DELIVERY" : "PICKUP",
+        name: m.name ?? "",
+        fee: m.fee ?? "0",
+        minOrderPrice: m.minOrderPrice ?? "0",
+      }))
+      .filter((m: FulfillmentMethodInfo) => m.id);
+  } catch {
+    return []; // display nicety — ordering still works without the list
+  }
+}
+
+// The V2 cart doesn't reliably return line-item images — join them from the menu items by
+// the line's catalogItemId and cache for the session.
+const lineImageCache = new Map<string, string>();
+
+async function fillLineImages(lines: OrderLine[], raws: Raw[]): Promise<void> {
+  const wanted = new Map<string, number[]>(); // itemId -> line indexes
+  raws.forEach((raw: Raw, i: number) => {
+    if (lines[i].imageUrl) return;
+    const itemId = raw.source?.catalogReference?.catalogItemId;
+    if (!itemId) return;
+    const cached = lineImageCache.get(itemId);
+    if (cached !== undefined) {
+      lines[i].imageUrl = cached;
+      return;
+    }
+    wanted.set(itemId, [...(wanted.get(itemId) ?? []), i]);
+  });
+  if (!wanted.size) return;
+  try {
+    const res: Raw = await itemsApi.listItems({ itemIds: [...wanted.keys()] });
+    for (const item of (res.items ?? []) as Raw[]) {
+      const url = imgSrc(item.image, 300, 300);
+      lineImageCache.set(item._id, url);
+      for (const i of wanted.get(item._id) ?? []) lines[i].imageUrl = url;
+    }
+  } catch {
+    /* images are a nicety — the cart stays correct without them */
+  }
+}
+
+function cartCurrency(raw: Raw | null): string {
+  return raw?.customerInfo?.currencyCode ?? raw?.businessInfo?.currencyCode ?? "";
+}
+
+function toLine(raw: Raw, currency: string): OrderLine {
+  const descriptionLines: string[] = (raw.attributes?.descriptionLines ?? [])
+    .map((d: Raw) => {
+      const label = d.name?.original ?? "";
+      const value = d.plainText?.original ?? d.colorInfo?.original ?? "";
+      return label && value ? `${label}: ${value}` : value || label;
+    })
+    .filter(Boolean);
+  return {
+    lineItemId: raw._id ?? "",
+    itemName: raw.name?.original ?? "",
+    quantity: raw.quantityInfo?.confirmedQuantity ?? 0,
+    unitPrice: formatMoney(raw.pricing?.unitPrice, currency),
+    linePrice: formatMoney(raw.pricing?.totalPrice, currency),
+    imageUrl: imgSrc(raw.attributes?.image, 300, 300),
+    descriptionLines,
+    status: raw.status ?? "IN_STOCK",
+  };
+}
+
+function toCart(raw: Raw | null, subtotal: string): OrderCart {
+  const currency = cartCurrency(raw);
+  const lines = (raw?.lineItems ?? []).map((l: Raw) => toLine(l, currency));
+  return {
+    lines,
+    itemCount: lines.reduce((sum: number, l: OrderLine) => sum + l.quantity, 0),
+    subtotal,
+    currency,
+  };
+}
+
+async function readCartWithSubtotal(raw: Raw | null): Promise<OrderCart> {
+  if (!raw?.lineItems?.length) return toCart(raw, "");
+  // The authoritative after-discount subtotal comes from the cart estimate, never from
+  // hand-summing line items (fees, tax, and delivery resolve at checkout).
+  let subtotal = "";
+  try {
+    const estimate: Raw = await cartApi.estimateCurrentCart();
+    subtotal = formatMoney(estimate?.summary?.priceSummary?.subtotal, cartCurrency(raw));
+  } catch {
+    /* estimate is a display nicety — the cart itself is still valid */
+  }
+  const cart = toCart(raw, subtotal);
+  await fillLineImages(cart.lines, raw.lineItems as Raw[]);
+  return cart;
+}
+
+/** Read the visitor's current order cart. An empty cart (not an error) when none exists yet. */
+export async function fetchOrderCart(): Promise<OrderCart> {
+  try {
+    const { cart } = await cartApi.getCurrentCart();
+    return readCartWithSubtotal(cart as Raw);
+  } catch {
+    return toCart(null, "");
+  }
+}
+
+/**
+ * Add a menu item to the current order. `menuId` and `sectionId` are the ids of the menu and
+ * section the item is RENDERED UNDER — thread them from the render context (the fetchMenus
+ * tree), never re-derive them. Throws when ordering isn't configured or the line is refused.
+ */
+export async function addToOrder(
+  itemId: string,
+  { menuId, sectionId }: { menuId: string; sectionId: string },
+  quantity = 1,
+): Promise<OrderCart> {
+  const operationId = await resolveOperationId();
+  if (!operationId) throw new Error("Online ordering isn't available right now.");
+  if (!itemId || !menuId || !sectionId) throw new Error("addToOrder needs the item, menu, and section ids.");
+
+  const { cart } = await cartApi.addLineItemsToCurrentCart({
+    catalogItems: [
+      {
+        quantity,
+        catalogReference: {
+          catalogItemId: itemId,
+          appId: RESTAURANTS_ORDERS_APP_ID,
+          options: { operationId, menuId, sectionId },
+        },
+      },
+    ],
+  });
+
+  // V2 nests the reference under `source` — a top-level lineItem.catalogReference no longer exists.
+  const line = ((cart as Raw)?.lineItems ?? []).find(
+    (l: Raw) => l.source?.catalogReference?.catalogItemId === itemId,
+  );
+  if (line?.status && line.status !== "IN_STOCK") {
+    throw new Error(`This dish isn't available right now (${line.status.toLowerCase().replace(/_/g, " ")}).`);
+  }
+  if (!line || line.quantityInfo?.confirmedQuantity === 0) {
+    throw new Error("The dish couldn't be added to the order — please try again.");
+  }
+  return readCartWithSubtotal(cart as Raw);
+}
+
+/** Change a line's quantity. `lineItemId` is OrderLine.lineItemId, never the menu item id. */
+export async function updateOrderQuantity(lineItemId: string, quantity: number): Promise<OrderCart> {
+  const { cart } = await cartApi.updateLineItemsInCurrentCart({
+    lineItems: [{ lineItemId, quantity: { newQuantity: quantity } }],
+  });
+  return readCartWithSubtotal(cart as Raw);
+}
+
+/** Remove a line from the order by OrderLine.lineItemId. */
+export async function removeOrderLine(lineItemId: string): Promise<OrderCart> {
+  const { cart } = await cartApi.removeLineItemsFromCurrentCart([lineItemId]);
+  return readCartWithSubtotal(cart as Raw);
+}
+
+/**
+ * Start the Wix-hosted checkout for the current order and return the URL to navigate to.
+ * The cart's id IS the checkout id — no separate checkout-creation call. Fulfillment
+ * (pickup/delivery + time) and payment are collected on the hosted page. Call from the
+ * browser: the return origin must be window.location.origin (https), never a server-derived
+ * request origin (http behind the proxy → the return redirect 403s).
+ */
+export async function orderCheckoutUrl(): Promise<string> {
+  const { cart } = await cartApi.getCurrentCart();
+  const raw = cart as Raw;
+  const lines: Raw[] = raw?.lineItems ?? [];
+  if (!lines.length) throw new Error("Your order is empty.");
+  const unavailable = lines.filter((l) => l.status && l.status !== "IN_STOCK");
+  if (unavailable.length) {
+    const names = unavailable.map((l) => l.name?.original).filter(Boolean).join(", ");
+    throw new Error(`Some dishes are no longer available: ${names}.`);
+  }
+  if (!raw?._id) throw new Error("Checkout couldn't start: the order has no id.");
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const session = await redirects.createRedirectSession({
+    ecomCheckout: { checkoutId: raw._id },
+    callbacks: {
+      postFlowUrl: origin ? `${origin}/` : undefined,
+      thankYouPageUrl: origin ? `${origin}/` : undefined,
+    },
+  });
+  const url = session?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Checkout couldn't start: no redirect URL returned.");
+  return url;
+}

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/reservations.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/reservations.ts
@@ -1,0 +1,142 @@
+// Table reservations (@wix/table-reservations) — the only file that touches raw reservation
+// entities. Copy as-is; extend by calling these exports, never by editing them.
+//
+// The flow is location → AVAILABLE slots → hold (10-minute temporary reservation) → reserve
+// with the visitor's details. A reservation is a hold, not a purchase — no cart, no checkout.
+// getTimeSlots takes POSITIONAL args and a Date (not an ISO string); reserveReservation takes
+// THREE positional args (id, reservee, revision) and the only exit from HELD is reserve.
+// Failures are loud — surface the message, don't swallow it.
+import { reservationLocations, timeSlots, reservations as reservationsModule } from "@wix/table-reservations";
+import { wixModule } from "../sdk";
+import type {
+  ReservationConfirmation,
+  ReservationHold,
+  ReservationLocationInfo,
+  ReservationReservee,
+  ReservationSlot,
+} from "./types";
+
+const locationsApi = wixModule(reservationLocations);
+const timeSlotsApi = wixModule(timeSlots);
+const reservationsApi = wixModule(reservationsModule);
+
+type Raw = Record<string, any>;
+
+/**
+ * Active (non-archived) reservation locations, default first. [] when Table Reservations
+ * isn't set up. `onlineReservationsEnabled: false` means the premium-gated toggle is off —
+ * slots and booking won't work; render an honest "reservations aren't open yet" state.
+ */
+export async function fetchReservationLocations(): Promise<ReservationLocationInfo[]> {
+  const res: Raw = await locationsApi.listReservationLocations();
+  return (res.reservationLocations ?? [])
+    .filter((l: Raw) => l.archived !== true)
+    .map((l: Raw): ReservationLocationInfo => {
+      const online = l.configuration?.onlineReservations ?? {};
+      return {
+        id: l._id ?? "",
+        default: l.default === true,
+        partySizeMin: online.partySize?.min ?? 1,
+        partySizeMax: online.partySize?.max ?? 20,
+        approvalMode: online.approval?.mode ?? "AUTOMATIC",
+        onlineReservationsEnabled: online.onlineReservationsEnabled === true,
+      };
+    })
+    .filter((l: ReservationLocationInfo) => l.id)
+    .sort((a: ReservationLocationInfo, b: ReservationLocationInfo) => Number(b.default) - Number(a.default));
+}
+
+function toSlot(raw: Raw): ReservationSlot {
+  const start: Date = raw.startDate instanceof Date ? raw.startDate : new Date(raw.startDate);
+  let label = "";
+  let dayKey = "";
+  try {
+    label = start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+    const pad = (n: number) => String(n).padStart(2, "0");
+    dayKey = `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())}`;
+  } catch {
+    /* label/dayKey stay "" — startIso still books */
+  }
+  return {
+    startIso: start.toISOString(),
+    label,
+    dayKey,
+    durationMinutes: raw.duration ?? 0,
+    manualApproval: raw.manualApproval === true,
+  };
+}
+
+/**
+ * AVAILABLE reservation slots around a moment for a party size — UNAVAILABLE and
+ * NON_WORKING_HOURS slots are already filtered out (offering them makes the hold fail).
+ * `aroundIso` anchors the fan-out: slotsBefore/slotsAfter extra slots on each side.
+ */
+export async function fetchReservationSlots(
+  locationId: string,
+  aroundIso: string,
+  partySize: number,
+  { slotsBefore = 6, slotsAfter = 6 }: { slotsBefore?: number; slotsAfter?: number } = {},
+): Promise<ReservationSlot[]> {
+  // The date param is a Date — the SDK types it as Date, not the ISO string the docs show.
+  const res: Raw = await timeSlotsApi.getTimeSlots(locationId, new Date(aroundIso), partySize, {
+    slotsBefore,
+    slotsAfter,
+  });
+  return (res.timeSlots ?? [])
+    .filter((s: Raw) => s.status === "AVAILABLE")
+    .map((s: Raw) => toSlot(s));
+}
+
+/**
+ * Hold a slot for 10 minutes while the visitor enters their details. The returned hold
+ * carries the { reservationId, revision } that completeReservation NEEDS — keep both.
+ */
+export async function holdReservation(
+  locationId: string,
+  startIso: string,
+  partySize: number,
+): Promise<ReservationHold> {
+  const res: Raw = await reservationsApi.createHeldReservation({
+    reservationLocationId: locationId,
+    startDate: new Date(startIso),
+    partySize,
+  });
+  const reservationId = res.reservation?._id;
+  const revision = res.reservation?.revision;
+  if (!reservationId || !revision) {
+    throw new Error("That time couldn't be held — it may have just been taken. Pick another slot.");
+  }
+  return { reservationId, revision, startIso, partySize };
+}
+
+/**
+ * Complete a held reservation with the visitor's details. firstName and phone (E.164, e.g.
+ * "+15551234567") are REQUIRED. A hold expires after 10 minutes — on failure, start a fresh
+ * hold; never try to update a HELD reservation by other means.
+ */
+export async function completeReservation(
+  hold: Pick<ReservationHold, "reservationId" | "revision">,
+  reservee: ReservationReservee,
+): Promise<ReservationConfirmation> {
+  if (!reservee.firstName?.trim() || !reservee.phone?.trim()) {
+    throw new Error("First name and phone number are required.");
+  }
+  const res: Raw = await reservationsApi.reserveReservation(
+    hold.reservationId,
+    {
+      firstName: reservee.firstName.trim(),
+      phone: reservee.phone.trim(),
+      ...(reservee.lastName?.trim() ? { lastName: reservee.lastName.trim() } : {}),
+      ...(reservee.email?.trim() ? { email: reservee.email.trim() } : {}),
+    },
+    hold.revision,
+  );
+  const reservation = res.reservation;
+  if (!reservation?._id) {
+    throw new Error("The reservation couldn't be completed — the hold may have expired. Start over.");
+  }
+  return {
+    reservationId: reservation._id,
+    status: reservation.status === "REQUESTED" ? "REQUESTED" : "RESERVED",
+  };
+}

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/types.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/types.ts
@@ -1,0 +1,168 @@
+// Restaurants DTOs — the serializable shapes every hook, component, and page consumes.
+// Plain JSON: safe as Astro island props or across server/client boundaries. Images are
+// resolved https URLs. MENU prices come from the Menus API as decimal strings in the site
+// currency with NO symbol ("12.50") — the DTO carries the platform's formatted string when
+// the response includes one, else the plain decimal (prefix your brand's currency in the UI).
+// Order-cart prices (eCom) ARE fully formatted strings.
+
+/** A dietary/style label on a menu item (e.g. "Vegan", "Spicy"). */
+export interface MenuItemLabel {
+  id: string;
+  name: string;
+  /** Resolved https URL ("" when the label has no icon). */
+  iconUrl: string;
+}
+
+/** One price variant of an item ("Glass" / "Bottle"). An item has price OR variants. */
+export interface MenuItemVariant {
+  variantId: string;
+  name: string;
+  /** Display price — formatted when the API provides it, else the decimal amount. */
+  price: string;
+}
+
+/** One choice inside a modifier group ("Extra cheese"). */
+export interface MenuModifier {
+  id: string;
+  name: string;
+  preSelected: boolean;
+  /** Decimal up-charge amount ("0" = free), site currency, no symbol. */
+  additionalCharge: string;
+  inStock: boolean;
+}
+
+/** A modifier group on an item ("Toppings", choose 0–3). DISPLAY-ONLY: modifier
+ * selections are not sent on the cart line (the API doesn't document that shape). */
+export interface MenuModifierGroup {
+  id: string;
+  name: string;
+  required: boolean;
+  minSelections: number;
+  maxSelections: number | null;
+  modifiers: MenuModifier[];
+}
+
+/** A dish/drink as the menu page needs it. */
+export interface MenuItem {
+  id: string;
+  name: string;
+  description: string;
+  /** Display price; null when the item is variant-priced or market-priced. */
+  price: string | null;
+  /** True → show "Market price"; the item can't be ordered online. */
+  marketPrice: boolean;
+  /** Non-empty exactly when price is null and not marketPrice. */
+  variants: MenuItemVariant[];
+  /** Resolved https URL ("" when the item has no image). */
+  imageUrl: string;
+  labels: MenuItemLabel[];
+  modifierGroups: MenuModifierGroup[];
+  /** False → render "Sold out" and disable add-to-order. */
+  inStock: boolean;
+  featured: boolean;
+}
+
+/** A section of a menu ("Appetizers"), items already in display order. */
+export interface MenuSection {
+  id: string;
+  name: string;
+  description: string;
+  /** Resolved https URL ("" when none). */
+  imageUrl: string;
+  items: MenuItem[];
+}
+
+/** A whole menu ("Dinner"), sections already in display order. */
+export interface MenuData {
+  id: string;
+  name: string;
+  description: string;
+  /** URL fragment (urlQueryParam), e.g. "dinner". */
+  slug: string;
+  sections: MenuSection[];
+}
+
+/** A pickup/delivery method to display (the buyer picks one on the hosted checkout). */
+export interface FulfillmentMethodInfo {
+  id: string;
+  type: "PICKUP" | "DELIVERY";
+  name: string;
+  /** Decimal amounts, site currency, no symbol ("0", "5"). */
+  fee: string;
+  minOrderPrice: string;
+}
+
+export interface OrderLine {
+  /** The cart line id — what update/remove take (NOT the menu item id). */
+  lineItemId: string;
+  itemName: string;
+  quantity: number;
+  /** Per-unit price, formatted. */
+  unitPrice: string;
+  /** Line total, formatted. */
+  linePrice: string;
+  /** Resolved https URL ("" when none). */
+  imageUrl: string;
+  /** Human-readable selection labels the platform attached (may be empty). */
+  descriptionLines: string[];
+  /** Not IN_STOCK → the line can't be checked out as-is. */
+  status: string;
+}
+
+export interface OrderCart {
+  lines: OrderLine[];
+  /** Sum of line quantities. */
+  itemCount: number;
+  /** Formatted subtotal (after discounts) — from the cart estimate, not hand-summed. */
+  subtotal: string;
+  currency: string;
+}
+
+/** A reservation location as the booking form needs it. */
+export interface ReservationLocationInfo {
+  id: string;
+  default: boolean;
+  /** Bound the party-size input to [partySizeMin, partySizeMax]. */
+  partySizeMin: number;
+  partySizeMax: number;
+  /** "AUTOMATIC" confirms instantly; "MANUAL"/"MANUAL_FOR_LARGE_PARTIES" may end REQUESTED. */
+  approvalMode: "AUTOMATIC" | "MANUAL" | "MANUAL_FOR_LARGE_PARTIES";
+  /** False (premium-gated toggle off) → slots/booking won't work; show an honest notice. */
+  onlineReservationsEnabled: boolean;
+}
+
+/** One AVAILABLE reservation time slot. */
+export interface ReservationSlot {
+  /** ISO datetime — pass to holdSlot as-is. */
+  startIso: string;
+  /** Display label, e.g. "7:00 PM". */
+  label: string;
+  /** "YYYY-MM-DD" in the visitor's timezone — for grouping/labeling. */
+  dayKey: string;
+  durationMinutes: number;
+  /** This slot needs staff approval → the reservation will end REQUESTED, not RESERVED. */
+  manualApproval: boolean;
+}
+
+/** A 10-minute hold on a slot; completeReservation needs BOTH ids. */
+export interface ReservationHold {
+  reservationId: string;
+  revision: string;
+  startIso: string;
+  partySize: number;
+}
+
+/** The visitor's details. firstName + phone (E.164, e.g. "+15551234567") are REQUIRED. */
+export interface ReservationReservee {
+  firstName: string;
+  phone: string;
+  lastName?: string;
+  email?: string;
+}
+
+/** The outcome of completing a reservation. */
+export interface ReservationConfirmation {
+  reservationId: string;
+  /** RESERVED = confirmed; REQUESTED = pending the restaurant's approval — tell the visitor. */
+  status: "RESERVED" | "REQUESTED";
+}

--- a/skills/wix-headless-fast/references/restaurants/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/restaurants/lock/astro/package-lock.json
@@ -1,0 +1,12560 @@
+{
+ "name": "wix-headless-fast-restaurants",
+ "version": "0.0.0",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-headless-fast-restaurants",
+   "version": "0.0.0",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/ecom": "^1.0.2454",
+    "@wix/redirects": "^1.0.125",
+    "@wix/restaurants": "^1.0.525",
+    "@wix/sdk": "^1.21.5",
+    "@wix/table-reservations": "^1.0.397",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT"
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT"
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT"
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-checkbox": {
+   "version": "1.3.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+   "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-icons": {
+   "version": "1.3.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+   "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-radio-group": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.7.tgz",
+   "integrity": "sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-tabs": {
+   "version": "1.1.21",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+   "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT"
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/atlas": {
+   "version": "1.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/atlas/-/@wix/atlas-1.0.41.tgz",
+   "integrity": "sha512-DC7EbCMrXKHjh9tG3dwIY4yXZxZv+dB8I1EqifqA65N035vJaTHep3Pqam82TuJ4ykq1Fy+GAnvewF0oXukAjQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_atlas_autocomplete": "1.0.16",
+    "@wix/auto_sdk_atlas_location": "1.0.16",
+    "@wix/auto_sdk_atlas_places": "1.0.16"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_atlas_autocomplete": {
+   "version": "1.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_autocomplete/-/@wix/auto_sdk_atlas_autocomplete-1.0.16.tgz",
+   "integrity": "sha512-h0mtI9WxJzhyvEbgD0Cjj4iWaVuOcr6byHGPTQrLUoFVC5Sgj/YIP4+g1qPydnkzyJhR33PQP5ew56fFKu8nHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_atlas_location": {
+   "version": "1.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_location/-/@wix/auto_sdk_atlas_location-1.0.16.tgz",
+   "integrity": "sha512-KhxUJ/7V5AU+w3rqeFoI6Y6Fjpc01HPW5r1oX0iq/fgWU3pglbXHilzzBruEawsPqrzhTnLryfYqzwjo5eITcg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_atlas_places": {
+   "version": "1.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_places/-/@wix/auto_sdk_atlas_places-1.0.16.tgz",
+   "integrity": "sha512-0ZqxQpoUfl4UOD8QMQ+B3g1SQWbTRRdGS5u8iG2NkZtVbA+sQuvOH3iLNlcOKzKVUyjh4XtbEnBlmCx66cpibg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_abandoned-checkouts": {
+   "version": "1.0.83",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_abandoned-checkouts/-/@wix/auto_sdk_ecom_abandoned-checkouts-1.0.83.tgz",
+   "integrity": "sha512-k7mo7MuxcFgwyq6aUrBEaVjsDOkSceXb0jDSKYRFMsysivlQ3H5Io+ZOvFJ2NlBJT4Kq3OStXj4hyvIEFuJNzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_additional-fees": {
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_additional-fees/-/@wix/auto_sdk_ecom_additional-fees-1.0.49.tgz",
+   "integrity": "sha512-ouF6gC/hZQXIiQM3HN/88Svf/TUEmHpDRyEGCSGNiG+DDb7WMQ5lgo+elnrZ5xsrK8nh3ir9wCcZf4Et511wuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_back-in-stock-notifications": {
+   "version": "1.0.63",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-notifications/-/@wix/auto_sdk_ecom_back-in-stock-notifications-1.0.63.tgz",
+   "integrity": "sha512-9enqO6pwJU114uhnaa4v0f2qj8VWYexYHUutP86qxmadNVi0ekEQUrif5VonByPRgIgGTFlGwIPP5BD4L0BeoA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_back-in-stock-settings": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-settings/-/@wix/auto_sdk_ecom_back-in-stock-settings-1.0.42.tgz",
+   "integrity": "sha512-YKRGIjbKqhtXnfSrGjqPSwqLDCjt2Se9q11ro0vI+9zoyyfWmsRIR4oYt1quZ/m7w8Qz79auLt1z80WRFJehOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_cart": {
+   "version": "1.0.174",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart/-/@wix/auto_sdk_ecom_cart-1.0.174.tgz",
+   "integrity": "sha512-bng9lfcWQ0XJ1Nr0SKe2v7yen9SprlZRHRuQ+iXe27VJWjmFhGcUGj7xqCtbLj9zTQ91DBU916eYIo9YBM5WRw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
+   "version": "1.0.192",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/@wix/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
+   "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_catalog": {
+   "version": "1.0.64",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_catalog/-/@wix/auto_sdk_ecom_catalog-1.0.64.tgz",
+   "integrity": "sha512-fKmFDucjlRKPCiLiTseBSTVGTQQyvn6Hap9gLzkF/+IFsKCg515Z+pSs2ds8os8D3V4DZCUkOfYJenzleJw01Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout": {
+   "version": "1.0.168",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-content": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-content/-/@wix/auto_sdk_ecom_checkout-content-1.0.37.tgz",
+   "integrity": "sha512-RrG3rzJBFGTCQR1hG9RX9/p9z07dfqNHjDtZs9DZUbHlsgqZlo8mJ6H28Th2tUlc7LaFBJ90l+3/qlJwSCzL/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-settings": {
+   "version": "1.0.73",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-settings/-/@wix/auto_sdk_ecom_checkout-settings-1.0.73.tgz",
+   "integrity": "sha512-2j8Z3dbhox4Hs0n0VmUUcEyreOX02OYkPyRk9MTGI51L6i4Bd5rWWxaqn74boDURcgQjF9JTxAlXXQvfvDC0eA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-templates": {
+   "version": "1.0.150",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-templates/-/@wix/auto_sdk_ecom_checkout-templates-1.0.150.tgz",
+   "integrity": "sha512-jomZhO1xhmmHX/FYaijYI8+g8b05rSn+X2bGIpVFGsjynZCj0lXyxcMKJxANk+t6D11pxf4oIoF8o45EpzkVBg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_contact-tax-details": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_contact-tax-details/-/@wix/auto_sdk_ecom_contact-tax-details-1.0.3.tgz",
+   "integrity": "sha512-kx7Q+0QWzc0TCqPINuhLjXuFacrkxl1Vc3hmF/ZtqiTpHZ4xoegAaHOhiQ20l7mNXbgAWajn1bVVNS/ZNHxD1g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_currencies": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_currencies/-/@wix/auto_sdk_ecom_currencies-1.0.35.tgz",
+   "integrity": "sha512-gfCYsiJ4zsDbm9PGxhi/paZEW8lJZdUnIEAPneRU9lfvGK+6QbM5TRJd74Fwcgsp8K82O15DPfzlZ0tH9Y02kQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart": {
+   "version": "1.0.184",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart-v-2": {
+   "version": "1.0.193",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart-v-2/-/@wix/auto_sdk_ecom_current-cart-v-2-1.0.193.tgz",
+   "integrity": "sha512-H9v8Jsmm+TXPSZ/WlQD9Gz/lLJIKzZIQHW/FOB/VfOBC20yufghAhZl9g05YgBWoBydtmNePS/wOQGzVwJ1nVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_custom-triggers": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_custom-triggers/-/@wix/auto_sdk_ecom_custom-triggers-1.0.40.tgz",
+   "integrity": "sha512-4pbt7WOMuMSQIEre/Do0LmcF3RdSVvE6Z3538pTg9jCvg6R+uBb/mycBNu/Za3iJNrcsYmv62Zq6p8y+BuHdbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_delivery-profile": {
+   "version": "1.0.440",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-profile/-/@wix/auto_sdk_ecom_delivery-profile-1.0.440.tgz",
+   "integrity": "sha512-KZA+tN85AR65oUvmsVr0WTOBLkwYq18piO+8QE5ug5XxLSLLnwC7WUBqGDbm5N6GWxW1L2cJu8eIIqBzPxPY+A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_delivery-solutions": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-solutions/-/@wix/auto_sdk_ecom_delivery-solutions-1.0.62.tgz",
+   "integrity": "sha512-YuLWOYsSSrfhZ/RpKa/67Qel8O9Ft1Qz8VebclOuAB1JrAV25zsMVh3Ks8yJeBPdOfawlcL4ECGbMi4t6v9b4A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discount-rules": {
+   "version": "1.0.115",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discount-rules/-/@wix/auto_sdk_ecom_discount-rules-1.0.115.tgz",
+   "integrity": "sha512-K0TMVir6a7o5pSvetPebJELwuVrhMiPwhyC6dtnTmdHNYwmMVpGZlkloJowNcra9kCiPm1iGKRSrvSu4SxtjmQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discounts": {
+   "version": "1.0.34",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts/-/@wix/auto_sdk_ecom_discounts-1.0.34.tgz",
+   "integrity": "sha512-UBSaqNnZrivhDAhrDYmGceibwe0sYCd+RQEbAOPn/8ZlXKnS9R6VCVjxvmgMqrnQ9Cpyht8WGS/df61g2ID8Sg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discounts-custom-trigger": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts-custom-trigger/-/@wix/auto_sdk_ecom_discounts-custom-trigger-1.0.45.tgz",
+   "integrity": "sha512-ykH8JVbiXukiHCtikksv5NjrjLec+8I9M6kf8RrwGekgD1NXX73hvij4XV8tJp8Pxm14OTPocGmTl/vPA00/gA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_draft-orders": {
+   "version": "1.0.171",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-orders/-/@wix/auto_sdk_ecom_draft-orders-1.0.171.tgz",
+   "integrity": "sha512-DZkSx3spJDmXsDxf0EhQg30EjNJoEuaixlJGPcXJn43mQTtFeb0pI4s3hlikS1ZsXsJPdyefhYcPn6d8/jq9Eg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_draft-subscription-contracts": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-subscription-contracts/-/@wix/auto_sdk_ecom_draft-subscription-contracts-1.0.7.tgz",
+   "integrity": "sha512-IqP/MoK8T0YlDvcmrH9OkZrvaUMKnPyky1/+aXZ4qM4IQH1AiVi6S34vU/BwOlwMC37EMaJWVnaZ82j986xS/Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_ecommerce-settings": {
+   "version": "1.0.33",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_ecommerce-settings/-/@wix/auto_sdk_ecom_ecommerce-settings-1.0.33.tgz",
+   "integrity": "sha512-2Wy6YrZV488ENvXmy9lIUYW65qSJ7KkgLYVZeH211EESGXqpKYHjSeMafopBpN+ycz3huzwYtyhoTqVQ577uwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_gift-vouchers": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers/-/@wix/auto_sdk_ecom_gift-vouchers-1.0.45.tgz",
+   "integrity": "sha512-z+n1zAZ/EHFP1fKjRNXNDNbUsx/G/sy5KFJES2+l/Ipzgsu/m/9smBzjtJlKndf0MMCxeSQk6sU2pa92pEt0fQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_gift-vouchers-provider": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers-provider/-/@wix/auto_sdk_ecom_gift-vouchers-provider-1.0.35.tgz",
+   "integrity": "sha512-57/A3DK88Awz8fgmfkEc51tPEsCfJgzkQCYrCUsgaHPyJZ2froVF+UfDvBDPqlFCJhbmI4ZAtYWhXUXzsxezfg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_inventory": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_inventory/-/@wix/auto_sdk_ecom_inventory-1.0.24.tgz",
+   "integrity": "sha512-gvhjYT5NtAcsfSuvth7Y3JNsKajAPJswdot7Vtvojx+tOAQLgdCtvBdS+CY27Ms1HRcVUjqGSUg1czu4IKaZUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_local-delivery-options": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_local-delivery-options/-/@wix/auto_sdk_ecom_local-delivery-options-1.0.53.tgz",
+   "integrity": "sha512-9Bw2w1MNgMaQNNmNNegDWn4YHuycjJMzBH3CObEZuSrpGk0pBz/oHJyUAGFLcfrNu3QHSMfqqHUk78T1wXi7bg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_manual-tax-mappings": {
+   "version": "1.0.43",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_manual-tax-mappings/-/@wix/auto_sdk_ecom_manual-tax-mappings-1.0.43.tgz",
+   "integrity": "sha512-5lOIYwVHFoiHMTumdGO/Hz8EBMUUHaolJ2cBhopfQE4KM0g4iWQad8tmQxNAo229azQB3LySnFm3O0dQSA/fSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_memberships": {
+   "version": "1.0.66",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_memberships/-/@wix/auto_sdk_ecom_memberships-1.0.66.tgz",
+   "integrity": "sha512-oSjsAhJOk/a7v5+Pfd3AYLx43sdU6knnc8kiGRuZdeZg4Mu1mhqLXsmhfdLo/dvILqbgf/bEkLwLQ6Gg/yxmOQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-billing": {
+   "version": "1.0.104",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-billing/-/@wix/auto_sdk_ecom_order-billing-1.0.104.tgz",
+   "integrity": "sha512-mhC2hVZb65oPwc0/y4gthsSgnWqiaanNrog9qAFj7NxS9Gz3QC1hw0GbXzog814paZlB/QETm5jKu1FxzXweMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-fulfillments": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-fulfillments/-/@wix/auto_sdk_ecom_order-fulfillments-1.0.62.tgz",
+   "integrity": "sha512-Rsjbrq6aeXlQXQD42HH4es5a+1R9hePBca0I3sb+/XsPnszB+GvaCyUwsX8a/UpimHciqN+aQ07p1yMKN8M+rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-invoices": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-invoices/-/@wix/auto_sdk_ecom_order-invoices-1.0.52.tgz",
+   "integrity": "sha512-htA5vi/lACC20BF4dfnxZ8GaY9viaemZi4oQQqf8FOIHuItlMzoscwF21viybu/XKzghXfZqi/vX+jJBWXdTZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-payment-requests": {
+   "version": "1.0.67",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-payment-requests/-/@wix/auto_sdk_ecom_order-payment-requests-1.0.67.tgz",
+   "integrity": "sha512-zqVQlZztMspEG2TguG+hmw8yFVqsipjdyxudraOwxqTcpHTA71ay+35EDHRGsH36WvORHNGM1DHj8D6PyojKJQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-transactions": {
+   "version": "1.0.104",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-transactions/-/@wix/auto_sdk_ecom_order-transactions-1.0.104.tgz",
+   "integrity": "sha512-vZwoWGPWgG273L4omJLBTItvqBWiqCqUQgPOpIKaU6PnbA5R8xib5VdjQ853zqjnAZFlrkPztWNLiFn7AnqlXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_orders": {
+   "version": "1.0.286",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders/-/@wix/auto_sdk_ecom_orders-1.0.286.tgz",
+   "integrity": "sha512-YJVe5RjcF+heHig9Bai64O/SbhaRVeO5qc6K2trN8dQDD7RMJiZndRNgDzo0+sGxggDsnd3jLpH4a0AZcVmkgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_orders-settings": {
+   "version": "1.0.55",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders-settings/-/@wix/auto_sdk_ecom_orders-settings-1.0.55.tgz",
+   "integrity": "sha512-RY+rDh307GkVr8aEnHri+N3EgW0wzKc4gKRJw2/RcjAGDX8QY9JDb7C8ep2vhgm/FcMXA3csxddV/TyPeZ0LGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_payment-settings": {
+   "version": "1.0.143",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_payment-settings/-/@wix/auto_sdk_ecom_payment-settings-1.0.143.tgz",
+   "integrity": "sha512-9LOI5E1p5aZZ5sC2k4q6T+uZ4Ylp2bYuVeOdj/4quXfT45OqPotAH+66ET5vhzPhaRSY3VfuAC5EnwHrdDH0PA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_pickup-locations": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_pickup-locations/-/@wix/auto_sdk_ecom_pickup-locations-1.0.52.tgz",
+   "integrity": "sha512-E4+UEDHHNU4jV7KsyoJR++tTw9cqcROOBltG8CNJCAhQCnDbqxK3gfOdK9gYvgPrAWNoJ1Jzq2bCmTaK7Ru/QA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_recommendations": {
+   "version": "1.0.47",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations/-/@wix/auto_sdk_ecom_recommendations-1.0.47.tgz",
+   "integrity": "sha512-kIX4fnm/IYDMdV7BJMK8eUx05lP0hm/0v8PvviCKlhG/0LtLQ9SrusRZn8pZOEyG2Lp+7RAYkS3F/t4SRBAdTg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_recommendations-provider": {
+   "version": "1.0.33",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations-provider/-/@wix/auto_sdk_ecom_recommendations-provider-1.0.33.tgz",
+   "integrity": "sha512-x00UHSPpdXDt/bKwRx9fhspPKbOWH74cHuzSJRj7+7rp5hAAySBepNvbY+V4YKtq1W2wZ3au+b0fSBQ2BDdOPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shipping-options": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-options/-/@wix/auto_sdk_ecom_shipping-options-1.0.230.tgz",
+   "integrity": "sha512-PqlZiJqSKHde7yZbom0KhndP6Pe+UsdzUx0C2EH2XBszXSv1FKymBNVEw2+PaI0JxDfZ2E4WpWWaGHuIm9E2dA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shipping-rates": {
+   "version": "1.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-rates/-/@wix/auto_sdk_ecom_shipping-rates-1.0.39.tgz",
+   "integrity": "sha512-WzM3aB28G/XeaBjaXWYAAEXP5niKQprw2Cchpd4jHOPC1atWy91lox8Vvi080WZQUdOWuw9eUfGpci9D+/jTLw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shippo-configurations": {
+   "version": "1.0.71",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shippo-configurations/-/@wix/auto_sdk_ecom_shippo-configurations-1.0.71.tgz",
+   "integrity": "sha512-h7kJJpsPYQTMQKelbeECsEDLZM6VLEb37FBE//Nmiap1ff+PUcFFZ0DsHuXktsWkoa3oQp4JBuCWbqojvy6dOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_subscription-contracts": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_subscription-contracts/-/@wix/auto_sdk_ecom_subscription-contracts-1.0.125.tgz",
+   "integrity": "sha512-elR3LIlzu/dM1eBBc8Jbklni/lD3QL4eeEuHp470g4QF9TXq/a1e4cJ9qzqC1EUm8L+y5VsWZXI1G8Q8rwuI3w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-calculation": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation/-/@wix/auto_sdk_ecom_tax-calculation-1.0.54.tgz",
+   "integrity": "sha512-wkXEshZoXgBm8LtxX/38iJ9tdnzRTpBKtY0PpvMmhp/AHt4z8nFSKPhLJHo35U3XJSLxBnt7meiVWnZY+0v9Fw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-calculation-provider": {
+   "version": "1.0.31",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation-provider/-/@wix/auto_sdk_ecom_tax-calculation-provider-1.0.31.tgz",
+   "integrity": "sha512-X8WgM60a+qMqKOHwH3kdvJMEB+mCnrnFRZbVSLjigAqwL5YcVYBltAovI8viR05LLQd6s0MOqntjew/pDPzZeQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-exempt-groups": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-exempt-groups/-/@wix/auto_sdk_ecom_tax-exempt-groups-1.0.4.tgz",
+   "integrity": "sha512-yk7U1z5enPiVxeNVFH05lr7UtCM5xn0IAXDW7pswkknrdAOk0axrjc279CY5jTHaZTmEgqyEv0/39ZZTycDCkA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-groups": {
+   "version": "1.0.64",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-groups/-/@wix/auto_sdk_ecom_tax-groups-1.0.64.tgz",
+   "integrity": "sha512-df8Zise8uEfHFgj7tDvTTcT7DRn+771j6eI4tWqL6fPIQGPN0rURY7kGQehBi3jnDHLOohI5ksg7hlKKsjCQzw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-regions": {
+   "version": "1.0.61",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-regions/-/@wix/auto_sdk_ecom_tax-regions-1.0.61.tgz",
+   "integrity": "sha512-o2Gmc89SlO5pQuOngj+l8y+vm7HQJ0qxuEJzqdJwx0siRIwRqb8hkmT0+HXn+zM1e0Ntc9kMxHHabYf2OtqCmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-settings": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-settings/-/@wix/auto_sdk_ecom_tax-settings-1.0.2.tgz",
+   "integrity": "sha512-8+566igMSdW6dOK9RHRmoatin7w6U+H10ren7YqlNixf3qJBazSyv2CdMwFvf1MFSFSY319u3VgkW64OPWrQKg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tip-settings": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tip-settings/-/@wix/auto_sdk_ecom_tip-settings-1.0.54.tgz",
+   "integrity": "sha512-4N1l/X0KTIXOzkbCVO/oYuDnApCpz/MToDg0IEbfjeEnm1SX/gk1DkXnSjuGv6ttOEusekyL1WdOXwL5qKvQmw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tippable-staff": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tippable-staff/-/@wix/auto_sdk_ecom_tippable-staff-1.0.40.tgz",
+   "integrity": "sha512-FvIEtLdx3qbMSvQcr5czVDjzP7BvV9c69FquHuvrBOVotq6xjEiqs9+durHHHcqNpWgs/DjVIeT+GZ2rwWrozw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tips": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tips/-/@wix/auto_sdk_ecom_tips-1.0.62.tgz",
+   "integrity": "sha512-zPUDIRSXEdghPH7G049nzNsyB+5JYeiOLtwUelQasibHwln1sb/rG7R5xP9ifIVuy6u7kzwN7Oisuk8NDrNyCg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_totals-calculator": {
+   "version": "1.0.115",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_totals-calculator/-/@wix/auto_sdk_ecom_totals-calculator-1.0.115.tgz",
+   "integrity": "sha512-N1rp4LtZSfTooN3J/3OmfMpcbrWIIHkskSm7NYo74TmnJFLpE5sAUyAMGbCwamZjYFXKVWdCJnWMjn8PgQq3Pg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_validations": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_validations/-/@wix/auto_sdk_ecom_validations-1.0.56.tgz",
+   "integrity": "sha512-UUbTbVI5qTYkJYg+DBtJN2dAGJqYuZ1FyFlTEI5sgqxRHeFlalKxWppAGG0stlk5E2Tweb52/OLb3UvMQ7zLVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_wishlists": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_wishlists/-/@wix/auto_sdk_ecom_wishlists-1.0.2.tgz",
+   "integrity": "sha512-W1VkbP9U40aHpk1eu27Z9PoFFgWO1FuTUhpm346jlHBK//9kL8Zktwbag9P6Taxp3/CeILsqsriAvJtb1LkE9Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.97",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_availability-exceptions": {
+   "version": "1.0.61",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_availability-exceptions/-/@wix/auto_sdk_restaurants_availability-exceptions-1.0.61.tgz",
+   "integrity": "sha512-eT6NclNAglX1v0hUYglLO6p20Fq98wqm49nm2lblEG7kC7KVjUlSpfkH8DuaUYCfdCRUIjPpzRytWx3ylIKuig==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_catalogs": {
+   "version": "1.0.72",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_catalogs/-/@wix/auto_sdk_restaurants_catalogs-1.0.72.tgz",
+   "integrity": "sha512-5KDutDFj7YM7iWCcG8eyRLBeMU4NPnGczoSTWiZKPfwvMAPz2ngO1cNAc+9HDK9tA1Kd74neVef8YR2OSBQYEw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_discount": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_discount/-/@wix/auto_sdk_restaurants_discount-1.0.54.tgz",
+   "integrity": "sha512-Yh4puzATO43U2JKTAkmbWY1XMuLFIBg0imeX4tpaIP+EOIb3+eta7TsKRMmQQxFLbryPvyvCnFCez6GDi+j0cw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_fulfillemt-methods": {
+   "version": "1.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillemt-methods/-/@wix/auto_sdk_restaurants_fulfillemt-methods-1.0.39.tgz",
+   "integrity": "sha512-jihrWRvfUanmXIE6LfIwG//1qtRcCm3mti7sLzfGtVUhbW9wHW3IZikiF7s6Fu0ARGNihf6lxwf4b0tQtqZOMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_fulfillment-methods": {
+   "version": "1.0.71",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillment-methods/-/@wix/auto_sdk_restaurants_fulfillment-methods-1.0.71.tgz",
+   "integrity": "sha512-Tww45umJfU8KcE0BdwjAH5biUPXLVMDLinMul4fcLx/JWfXwBUjkFUmMuo4WDqtaprni/VixyYvit8xvL6ZJ+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_item-labels": {
+   "version": "1.0.68",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-labels/-/@wix/auto_sdk_restaurants_item-labels-1.0.68.tgz",
+   "integrity": "sha512-ph+ogTlky/QEmNgrt3gcyC7qO/XSFwOW8I5WnA9YD/efakmQYt+q1fy08sK843f074zRwYPuU9VxEzjdAzYqOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_item-modifier-groups": {
+   "version": "1.0.73",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifier-groups/-/@wix/auto_sdk_restaurants_item-modifier-groups-1.0.73.tgz",
+   "integrity": "sha512-im6r2hnejsnWUTodqfoNOp4/fm767h049qDGGeO5QTVF0aNIToCU/s2IP6ptUtaw+hLFDb/Zm9eg7i/+6JBVbw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_item-modifiers": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifiers/-/@wix/auto_sdk_restaurants_item-modifiers-1.0.69.tgz",
+   "integrity": "sha512-h6i1zUlm6nn+qfgEAMYV2TEO1QJS/+ZvzwUcmwcFFYNW3TjclimnpDgFBBCsMwfFbit03g6wEq+c+xQJW8HjfA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_item-variants": {
+   "version": "1.0.65",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-variants/-/@wix/auto_sdk_restaurants_item-variants-1.0.65.tgz",
+   "integrity": "sha512-EwqZ+uR9zGZa1EmvsvZTFKYdzrXHOrCYzTMHUOgWfzADK0n4AXizPLGkTvdokgVuwtszIA236+F5NN2TiuD8YQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_items": {
+   "version": "1.0.87",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_items/-/@wix/auto_sdk_restaurants_items-1.0.87.tgz",
+   "integrity": "sha512-KzJoNlz6ES3CY1SrVet6E/sejDhvLRnz8gTtrDYnozFooEy/VWxYVzrl0i4B9JRwfijHTOQler0Q6ML69tr6RQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_local-delivery-spi": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_local-delivery-spi/-/@wix/auto_sdk_restaurants_local-delivery-spi-1.0.45.tgz",
+   "integrity": "sha512-8iCNDrnr6GeHCdrfQaPcRx4B9XwB+PAIciMgXZcU9Iw7OxRBsBNMDolJG6zhYzqV94ryfXj40vrKN3m/5UempQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_menu-ordering-settings": {
+   "version": "1.0.60",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menu-ordering-settings/-/@wix/auto_sdk_restaurants_menu-ordering-settings-1.0.60.tgz",
+   "integrity": "sha512-sPdXRoIsFvZwjbgA40hGPDrcH7dawh0XTqdX0JwhmeYB4mLbwJvP5wgDXj32WoXU9GzacMjBNC2FLvWfHioxTw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_menus": {
+   "version": "1.0.80",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menus/-/@wix/auto_sdk_restaurants_menus-1.0.80.tgz",
+   "integrity": "sha512-7VcoQ9+VfrAE0Q2+6OZzRX38RCFwSLSAXEltUooDhdwlfSitZDJJe4IzkJZL8Rxg7/puRyeBnaHaLVzFe+6mhw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_operation-groups": {
+   "version": "1.0.64",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operation-groups/-/@wix/auto_sdk_restaurants_operation-groups-1.0.64.tgz",
+   "integrity": "sha512-jKr7QGGsaFmqr4W/kNzNynzU5n8Iwusp4yZj2JHyybnASZZYWoQyBZSzQ7CAsNXuNhSA2NTmacs3Hy4R0LR4jg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_operations": {
+   "version": "1.0.98",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operations/-/@wix/auto_sdk_restaurants_operations-1.0.98.tgz",
+   "integrity": "sha512-VjuegEKmzAg0tqneLWS2YHfcEhl2BG4nPeeIAe74gfUslvymOyMg2CuMeIROjeBAfGND9bsXiC9s+21FgV5ahg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_order-pacing-order": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-order/-/@wix/auto_sdk_restaurants_order-pacing-order-1.0.37.tgz",
+   "integrity": "sha512-90shXv/haozmcJVB6CN22p8ZEZ8jQclmjoy3X6KS5eyiziWt+EXtXs+r6zCkcZRLCeZ9jO3+CGSu8+c+wpVx3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_order-pacing-policy": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-policy/-/@wix/auto_sdk_restaurants_order-pacing-policy-1.0.46.tgz",
+   "integrity": "sha512-T1dvsf3+/Od+//mBrV2FxUyyq9Nw9EgPbSEikvy1j/rVDBztPf5LL76JyNQR355vkjnNtlIwCa4UksXZo2S12A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_order-settings": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-settings/-/@wix/auto_sdk_restaurants_order-settings-1.0.37.tgz",
+   "integrity": "sha512-eLkWv81SyCoQhx2+JozpZXNirrhGm+LiRFw3H6Fyz2QCbcfz561K2iwLCmGAnnH+CJkp9kuRtXK7oDNKADeCQA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_orders": {
+   "version": "1.0.58",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_orders/-/@wix/auto_sdk_restaurants_orders-1.0.58.tgz",
+   "integrity": "sha512-c934r6LuARhyWsoPvgjaJXcjv9S1iG935DknMhGmqyUsvIUUrFjNhPDAIr/GkWqM3zogwmBMKV/rbUvtGbHIwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_pos-tpa": {
+   "version": "1.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_pos-tpa/-/@wix/auto_sdk_restaurants_pos-tpa-1.0.41.tgz",
+   "integrity": "sha512-H46gCch4IWlqBuPuSCfBqMtITh1WWdyu55WLK8tnIp5aJ8HaP0J4POJkUwQ4i9HoUc1xCTSL+mEgVF0wGhI95g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_recipients": {
+   "version": "1.0.31",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_recipients/-/@wix/auto_sdk_restaurants_recipients-1.0.31.tgz",
+   "integrity": "sha512-rbipvHfR75VTiHnQ1pteKGRh0JKNJpenPmsp5zeGMlfjQZf7B0bEQX2tujKLETefd8h37Khe/nX5zis/Zi904A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_restaurant-locations": {
+   "version": "1.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_restaurant-locations/-/@wix/auto_sdk_restaurants_restaurant-locations-1.0.39.tgz",
+   "integrity": "sha512-iYXRZdBjTbXmUhm9wZhujW7ZHWAJCmUnLgI3WQWsd1NiNePnOZKG5vsTMlP5yrC99jnoFzSttKTTR0RU61J6cQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_sections": {
+   "version": "1.0.72",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_sections/-/@wix/auto_sdk_restaurants_sections-1.0.72.tgz",
+   "integrity": "sha512-JZtyIAsuXroWQB3BgdRL83bajDvd+u8I8MqAQ3AujIMAxRMSCacNFgNRWaLA1fF7PLGqGpF8IwkrB7s8uU23dg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_restaurants_service-fees": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_service-fees/-/@wix/auto_sdk_restaurants_service-fees-1.0.56.tgz",
+   "integrity": "sha512-6VXLQdw+vSIX4+KwLj5ozaG0ZPAjBAO4ji/poDBSBwEahVfy7rc8xGsK0ve8m+IZevlJJF5E39kfBiCRkXyu0Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_table-reservations_experiences": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_experiences/-/@wix/auto_sdk_table-reservations_experiences-1.0.56.tgz",
+   "integrity": "sha512-pssKfV7OPsmBw6VMosnO3fxfmDTDsIdgAvtNM3rGuiKRJw8bu3bA5qhYyxTNZKTd8RauxWRwGXV0Y2+2U6qw0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_table-reservations_reservation-locations": {
+   "version": "1.0.101",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservation-locations/-/@wix/auto_sdk_table-reservations_reservation-locations-1.0.101.tgz",
+   "integrity": "sha512-b078MnHxosuT/coJu9C60InI/vO+oIBuaCftWA3NZBY8o7lY81pHSz7vYAvsMAVLAczpwdeTxvcexYIMAJK/4Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_table-reservations_reservations": {
+   "version": "1.0.76",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservations/-/@wix/auto_sdk_table-reservations_reservations-1.0.76.tgz",
+   "integrity": "sha512-ss2WDMyCiZpUC1j0mKStAyZsnp8+Z8Dy0dSGGjfLgvutl3QeqtZBN8EPsjx0FmiVzcijipbptFuLszOyWvjEvA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_table-reservations_time-slots": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_time-slots/-/@wix/auto_sdk_table-reservations_time-slots-1.0.48.tgz",
+   "integrity": "sha512-41i83EI2tdPD1vBZ3uIOSMNv9WAAfMNdlHYhcQxjSF1WfF6tIZIuRx64UIPqMYtY4D9waDHCwyrlD+kmPJ0iJQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/ecom": {
+   "version": "1.0.2454",
+   "resolved": "https://registry.npmjs.org/@wix/ecom/-/@wix/ecom-1.0.2454.tgz",
+   "integrity": "sha512-fjkJZf+utwGk6db2W7/WUo/UiAiYzODeaJOkqSDoGVL4rt6j6u1YQRRtWoCSc1nixIZengHYs1amJp7+SZnEww==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_ecom_abandoned-checkouts": "1.0.83",
+    "@wix/auto_sdk_ecom_additional-fees": "1.0.49",
+    "@wix/auto_sdk_ecom_back-in-stock-notifications": "1.0.63",
+    "@wix/auto_sdk_ecom_back-in-stock-settings": "1.0.42",
+    "@wix/auto_sdk_ecom_cart": "1.0.174",
+    "@wix/auto_sdk_ecom_cart-v-2": "1.0.192",
+    "@wix/auto_sdk_ecom_catalog": "1.0.64",
+    "@wix/auto_sdk_ecom_checkout": "1.0.168",
+    "@wix/auto_sdk_ecom_checkout-content": "1.0.37",
+    "@wix/auto_sdk_ecom_checkout-settings": "1.0.73",
+    "@wix/auto_sdk_ecom_checkout-templates": "1.0.150",
+    "@wix/auto_sdk_ecom_contact-tax-details": "1.0.3",
+    "@wix/auto_sdk_ecom_currencies": "1.0.35",
+    "@wix/auto_sdk_ecom_current-cart": "1.0.184",
+    "@wix/auto_sdk_ecom_current-cart-v-2": "1.0.193",
+    "@wix/auto_sdk_ecom_custom-triggers": "1.0.40",
+    "@wix/auto_sdk_ecom_delivery-profile": "1.0.440",
+    "@wix/auto_sdk_ecom_delivery-solutions": "1.0.62",
+    "@wix/auto_sdk_ecom_discount-rules": "1.0.115",
+    "@wix/auto_sdk_ecom_discounts": "1.0.34",
+    "@wix/auto_sdk_ecom_discounts-custom-trigger": "1.0.45",
+    "@wix/auto_sdk_ecom_draft-orders": "1.0.171",
+    "@wix/auto_sdk_ecom_draft-subscription-contracts": "1.0.7",
+    "@wix/auto_sdk_ecom_ecommerce-settings": "1.0.33",
+    "@wix/auto_sdk_ecom_gift-vouchers": "1.0.45",
+    "@wix/auto_sdk_ecom_gift-vouchers-provider": "1.0.35",
+    "@wix/auto_sdk_ecom_inventory": "1.0.24",
+    "@wix/auto_sdk_ecom_local-delivery-options": "1.0.53",
+    "@wix/auto_sdk_ecom_manual-tax-mappings": "1.0.43",
+    "@wix/auto_sdk_ecom_memberships": "1.0.66",
+    "@wix/auto_sdk_ecom_order-billing": "1.0.104",
+    "@wix/auto_sdk_ecom_order-fulfillments": "1.0.62",
+    "@wix/auto_sdk_ecom_order-invoices": "1.0.52",
+    "@wix/auto_sdk_ecom_order-payment-requests": "1.0.67",
+    "@wix/auto_sdk_ecom_order-transactions": "1.0.104",
+    "@wix/auto_sdk_ecom_orders": "1.0.286",
+    "@wix/auto_sdk_ecom_orders-settings": "1.0.55",
+    "@wix/auto_sdk_ecom_payment-settings": "1.0.143",
+    "@wix/auto_sdk_ecom_pickup-locations": "1.0.52",
+    "@wix/auto_sdk_ecom_recommendations": "1.0.47",
+    "@wix/auto_sdk_ecom_recommendations-provider": "1.0.33",
+    "@wix/auto_sdk_ecom_shipping-options": "1.0.230",
+    "@wix/auto_sdk_ecom_shipping-rates": "1.0.39",
+    "@wix/auto_sdk_ecom_shippo-configurations": "1.0.71",
+    "@wix/auto_sdk_ecom_subscription-contracts": "1.0.125",
+    "@wix/auto_sdk_ecom_tax-calculation": "1.0.54",
+    "@wix/auto_sdk_ecom_tax-calculation-provider": "1.0.31",
+    "@wix/auto_sdk_ecom_tax-exempt-groups": "1.0.4",
+    "@wix/auto_sdk_ecom_tax-groups": "1.0.64",
+    "@wix/auto_sdk_ecom_tax-regions": "1.0.61",
+    "@wix/auto_sdk_ecom_tax-settings": "1.0.2",
+    "@wix/auto_sdk_ecom_tip-settings": "1.0.54",
+    "@wix/auto_sdk_ecom_tippable-staff": "1.0.40",
+    "@wix/auto_sdk_ecom_tips": "1.0.62",
+    "@wix/auto_sdk_ecom_totals-calculator": "1.0.115",
+    "@wix/auto_sdk_ecom_validations": "1.0.56",
+    "@wix/auto_sdk_ecom_wishlists": "1.0.2",
+    "@wix/ecom_app-extensions": "1.0.107",
+    "@wix/headless-ecom": "0.0.41"
+   }
+  },
+  "node_modules/@wix/ecom_app-extensions": {
+   "version": "1.0.107",
+   "resolved": "https://registry.npmjs.org/@wix/ecom_app-extensions/-/@wix/ecom_app-extensions-1.0.107.tgz",
+   "integrity": "sha512-oAUv1VGGFCth/G7YxkMlvJCv1RjPJ02QgcMWGJFwuorfgCZHEinoA3F8QKaQ97FaF+k7Nup00OMLYJl/TBpCwA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.786.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-environment-api": "1.162.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.474.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.162.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.474.0",
+    "@wix/editor-platform-contexts": "1.161.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.395.0",
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-ecom": {
+   "version": "0.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.41.tgz",
+   "integrity": "sha512-YYZZtCLvY+2vcS0FxSJuuro8aWF8jnINHQRafxYwkZXQNvPMbewKpx1MF97/UiSaGyeSCJyZZoOTdSldEo7Vtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/auto_sdk_ecom_checkout": "^1.0.61",
+    "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
+    "@wix/headless-media": "0.0.21",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.21.tgz",
+   "integrity": "sha512-7o9ctPfQsQwfLwLCjs4RDO9Ns900Hv+BNVc301tShulKeitxgMKTrFqUxCsCuSQqqgQYaOhm5hDB+994LtBozg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-menus": {
+   "version": "0.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-menus/-/@wix/headless-restaurants-menus-0.0.24.tgz",
+   "integrity": "sha512-dCL/fZiIz8A7b8xUDriPvYJLMvnr8Om9BgSlLjtqM1u9iBZutvBXz0gfwY0QboZL8BeW0JcSl4g48mwYoBU4AA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.3",
+    "@wix/headless-media": "0.0.20",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/redirects": "^1.0.0",
+    "@wix/restaurants": "^1.0.396",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-menus/node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-menus/node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-olo": {
+   "version": "0.0.50",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-olo/-/@wix/headless-restaurants-olo-0.0.50.tgz",
+   "integrity": "sha512-Qq/rqgayRIAjohkDl+quHo8mOqQxyD3WZaGEfQT3KaqT6zP9jt5yHS2fliL+YvzIwJg9DPDhksHO8T8MFqcOlA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-radio-group": "^1.1.3",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/atlas": "^1.0.33",
+    "@wix/auto_sdk_restaurants_items": "^1.0.48",
+    "@wix/ecom": "^1.0.1560",
+    "@wix/essentials": "^1.0.0",
+    "@wix/headless-components": "0.0.36",
+    "@wix/headless-media": "0.0.20",
+    "@wix/headless-restaurants-menus": "0.0.24",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/redirects": "^1.0.0",
+    "@wix/restaurants": "^1.0.459",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-components": {
+   "version": "0.0.36",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/@wix/headless-components-0.0.36.tgz",
+   "integrity": "sha512-PKq1vsXKdSUf/sIpPkQHgfqATkO/e67PgkKtcS3p4MZYQo7IRatY0KE3JaYzy92XStptJtOWEP/iBpXCYQOtNw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/essentials": "^1.0.0",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/l10n": "^1.198.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-media": {
+   "version": "0.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-table-reservations": {
+   "version": "0.0.19",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-table-reservations/-/@wix/headless-restaurants-table-reservations-0.0.19.tgz",
+   "integrity": "sha512-WZO49sd2Bd9FBq3FDTdFSTZkGMalvyDBZi7dPOJLiXA56dBDuALqBd5w/J6IglnjO9E0qeeoGCCTlB4vF3c9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "@wix/essentials": "^0.1.24",
+    "@wix/headless-utils": "0.0.8",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "@wix/table-reservations": "^1.0.281",
+    "@wix/table-reservations-lib": "^1.293.0",
+    "date-fns": "^4.1.0",
+    "react-phone-number-input": "^3.4.13"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/headless-utils": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/l10n": {
+   "version": "1.207.0",
+   "resolved": "https://registry.npmjs.org/@wix/l10n/-/@wix/l10n-1.207.0.tgz",
+   "integrity": "sha512-af9QAcXDixaj3dRnYy2bA1NU09RV5uBd8uUf746DpZJhAoPlTzK7XDmgHo/PG6X8x7y2HwdN43h2NGrLPBIxtw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.272",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.97",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/media/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.395.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.104.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.104.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.133",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/restaurants": {
+   "version": "1.0.525",
+   "resolved": "https://registry.npmjs.org/@wix/restaurants/-/@wix/restaurants-1.0.525.tgz",
+   "integrity": "sha512-1VT3mJRBrFTD2eqBRz2TIfd7WiF7aCc3bBdj5xiCIopCBaQUXR2fXmT3f3vLwbFH3f7VHEcARSuG6PXTiJArbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_restaurants_availability-exceptions": "1.0.61",
+    "@wix/auto_sdk_restaurants_catalogs": "1.0.72",
+    "@wix/auto_sdk_restaurants_discount": "1.0.54",
+    "@wix/auto_sdk_restaurants_fulfillemt-methods": "1.0.39",
+    "@wix/auto_sdk_restaurants_fulfillment-methods": "1.0.71",
+    "@wix/auto_sdk_restaurants_item-labels": "1.0.68",
+    "@wix/auto_sdk_restaurants_item-modifier-groups": "1.0.73",
+    "@wix/auto_sdk_restaurants_item-modifiers": "1.0.69",
+    "@wix/auto_sdk_restaurants_item-variants": "1.0.65",
+    "@wix/auto_sdk_restaurants_items": "1.0.87",
+    "@wix/auto_sdk_restaurants_local-delivery-spi": "1.0.45",
+    "@wix/auto_sdk_restaurants_menu-ordering-settings": "1.0.60",
+    "@wix/auto_sdk_restaurants_menus": "1.0.80",
+    "@wix/auto_sdk_restaurants_operation-groups": "1.0.64",
+    "@wix/auto_sdk_restaurants_operations": "1.0.98",
+    "@wix/auto_sdk_restaurants_order-pacing-order": "1.0.37",
+    "@wix/auto_sdk_restaurants_order-pacing-policy": "1.0.46",
+    "@wix/auto_sdk_restaurants_order-settings": "1.0.37",
+    "@wix/auto_sdk_restaurants_orders": "1.0.58",
+    "@wix/auto_sdk_restaurants_pos-tpa": "1.0.41",
+    "@wix/auto_sdk_restaurants_recipients": "1.0.31",
+    "@wix/auto_sdk_restaurants_restaurant-locations": "1.0.39",
+    "@wix/auto_sdk_restaurants_sections": "1.0.72",
+    "@wix/auto_sdk_restaurants_service-fees": "1.0.56",
+    "@wix/headless-restaurants-menus": "^0.0.24",
+    "@wix/headless-restaurants-olo": "^0.0.50",
+    "@wix/restaurants_app-extensions": "1.0.43"
+   }
+  },
+  "node_modules/@wix/restaurants_app-extensions": {
+   "version": "1.0.43",
+   "resolved": "https://registry.npmjs.org/@wix/restaurants_app-extensions/-/@wix/restaurants_app-extensions-1.0.43.tgz",
+   "integrity": "sha512-rYMxXAJYppaW6Gy4TUSQmxUfon0V+ztkvEq50qGUZ5y8y29+UE8QKO44Jgi0NWjPqpOONBjiXBAq1zQZHGRTrw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/table-reservations": {
+   "version": "1.0.397",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations/-/@wix/table-reservations-1.0.397.tgz",
+   "integrity": "sha512-BPZpU6mlWYZOxrtT7CBOaxCkFRDiAnGT48em2AWWZMWg5r6b9bQG2SnAUhMCGRiP/yfb2m/sWFWA/nSc5Ly//Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_table-reservations_experiences": "1.0.56",
+    "@wix/auto_sdk_table-reservations_reservation-locations": "1.0.101",
+    "@wix/auto_sdk_table-reservations_reservations": "1.0.76",
+    "@wix/auto_sdk_table-reservations_time-slots": "1.0.48",
+    "@wix/headless-restaurants-table-reservations": "^0.0.19",
+    "@wix/table-reservations_app-extensions": "1.0.38"
+   }
+  },
+  "node_modules/@wix/table-reservations_app-extensions": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations_app-extensions/-/@wix/table-reservations_app-extensions-1.0.38.tgz",
+   "integrity": "sha512-ImYorQmqy4jyLcNnWPTEYkVHN2C1rBPbMQ0AAW9bSMJtq+B7GODpcIil2fQL2J/vQBmkZ7ebKCLt/8FC8ALTmQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/table-reservations-lib": {
+   "version": "1.304.0",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations-lib/-/@wix/table-reservations-lib-1.304.0.tgz",
+   "integrity": "sha512-NA877KvFrdx0F6/IaklkkAYWC0VyFbvP1kQwnyz1uUf1PuC+sQvhlB2foQKnALjjr8CiFHYAVC7bXsNiW1yVDQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "assert-never": "^1.4.0",
+    "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.2.0",
+    "dayjs": "^1.11.19",
+    "lodash": "^4.17.21",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/table-reservations-lib/node_modules/date-fns": {
+   "version": "3.6.0",
+   "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+   "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/kossnocorp"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/assert-never": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+   "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+   "license": "MIT"
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.14",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+   "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/classnames": {
+   "version": "2.5.1",
+   "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+   "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+   "license": "MIT"
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/country-flag-icons": {
+   "version": "1.6.20",
+   "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.20.tgz",
+   "integrity": "sha512-py8JiEKzjhYw6HPJ0L7SxLgCYim36UPRTZX43/kqGueUCZLSvnrqAiwW8HtQibur7mdkFQUkjOgdK+o/9FBtaw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/date-fns": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+   "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/kossnocorp"
+   }
+  },
+  "node_modules/date-fns-tz": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+   "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "date-fns": "^3.0.0 || ^4.0.0"
+   }
+  },
+  "node_modules/dayjs": {
+   "version": "1.11.21",
+   "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+   "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT"
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/input-format": {
+   "version": "0.3.14",
+   "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.14.tgz",
+   "integrity": "sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==",
+   "license": "MIT",
+   "dependencies": {
+    "prop-types": "^15.8.1"
+   },
+   "peerDependencies": {
+    "react": ">=18.1.0",
+    "react-dom": ">=18.1.0"
+   },
+   "peerDependenciesMeta": {
+    "react": {
+     "optional": true
+    },
+    "react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/libphonenumber-js": {
+   "version": "1.13.10",
+   "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.10.tgz",
+   "integrity": "sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==",
+   "license": "MIT"
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/object-assign": {
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+   "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/prop-types": {
+   "version": "15.8.1",
+   "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+   "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.4.0",
+    "object-assign": "^4.1.1",
+    "react-is": "^16.13.1"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-is": {
+   "version": "16.13.1",
+   "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+   "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+   "license": "MIT"
+  },
+  "node_modules/react-phone-number-input": {
+   "version": "3.4.17",
+   "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.4.17.tgz",
+   "integrity": "sha512-1wcjhBAWHgEBAGLi5/XbeZI7Q3aEHNb2z/dHY6R2Gz70TQvu0ZoOT28NTdwtZf4lyRKXWufnTzVhLPBUD8LfmQ==",
+   "license": "MIT",
+   "dependencies": {
+    "classnames": "^2.5.1",
+    "country-flag-icons": "^1.6.14",
+    "input-format": "^0.3.14",
+    "libphonenumber-js": "^1.13.4",
+    "prop-types": "^15.8.1"
+   },
+   "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  }
+ }
+}

--- a/skills/wix-headless-fast/references/restaurants/seed/SEED.md
+++ b/skills/wix-headless-fast/references/restaurants/seed/SEED.md
@@ -1,0 +1,76 @@
+# Restaurants — seeding
+
+Seed by **running `seed-restaurants.mjs` with a plan file** — don't hand-write the REST calls.
+The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
+required), installs the Restaurants apps, builds each menu bottom-up (items → sections →
+menu, all visible), imports+attaches images, and configures ordering/reservations.
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief. **Default to one menu with ~3 sections
+of 2–3 items each** (the seed shows the shape; the owner adds the rest in the dashboard),
+every item with a verified `imageUrl` (a menu without photos looks broken), and both add-ons
+on for a restaurant that takes orders and reservations:
+
+```json
+{
+  "menus": [
+    { "name": "Dinner", "description": "Evening menu", "sections": [
+      { "name": "Antipasti", "description": "To start", "items": [
+        { "name": "Bruschetta al Pomodoro", "description": "Grilled sourdough, San Marzano tomatoes, basil.",
+          "price": 9.5, "imageUrl": "https://…" },
+        { "name": "Burrata", "description": "Creamy burrata, heirloom tomatoes, olive oil.",
+          "price": 14, "imageUrl": "https://…" }
+      ] },
+      { "name": "Mains", "items": [
+        { "name": "Tagliatelle al Ragù", "description": "Slow-braised beef ragù, parmigiano.",
+          "price": 22, "imageUrl": "https://…" },
+        { "name": "Branzino", "description": "Whole roasted sea bass, lemon, herbs.",
+          "price": 28, "imageUrl": "https://…" }
+      ] },
+      { "name": "Dolci", "items": [
+        { "name": "Tiramisù", "description": "Espresso-soaked ladyfingers, mascarpone.",
+          "price": 10, "imageUrl": "https://…" }
+      ] }
+    ] }
+  ],
+  "ordering": { "address": {
+    "name": "Trattoria Lumina", "timeZone": "America/New_York",
+    "address": { "country": "US", "subdivision": "US-NY", "city": "New York", "postalCode": "10012",
+      "streetAddress": { "number": "18", "name": "Prince Street" },
+      "formattedAddress": "18 Prince Street, New York, NY 10012" } } },
+  "reservations": { "partySize": { "min": 1, "max": 10 } }
+}
+```
+
+- `price` — a number; stored as a decimal string in the **site currency** (never send one).
+- `ordering` — installs the Orders app, which **auto-provisions** a working setup (ENABLED
+  operation, Pickup + Delivery methods, every menu orderable); the seed verifies it. The
+  `address` is **required for real ordering** — without one, ordering is "testing only" and
+  checkout breaks. If the brief names no address, pass `"ordering": true` and the result
+  carries a note to flag the owner. Completing a **paid** order additionally needs a premium
+  plan + a connected payment method (dashboard) — mention it, don't treat it as a failure.
+- `reservations` — installs Table Reservations, which auto-provisions a default reservation
+  location; `partySize` (or a full `configuration`) is a partial PATCH. The final
+  **enable-online-reservations toggle is premium-only**: on a free site the result carries
+  `reservations.premiumRequired: true` — expected, tell the owner, don't retry.
+- Fresh Menus installs ship a sample "Dinner Menu"; when THIS run installs the app the seed
+  removes that sample (`sampleMenuRemoved: true`). On a site that already had the app,
+  **seeding is strictly additive — never delete or overwrite existing content**; ask first
+  if a cleanup seems needed.
+
+## Escape hatch — individual functions
+`setupRestaurants` composes exported steps — `installMenusApp`, `installOrdersApp`,
+`installTableReservationsApp`, `removeSampleMenu`, `createMenu`, `importImage`,
+`attachItemImages`, `setBusinessLocation`, `listOperationsWithRetry`, `enableOperation`,
+`queryMenuOrderingSettings`, `updateMenuOrderingSettings`, `listReservationLocationsWithRetry`,
+`updateReservationLocation`, `enableOnlineReservations`, plus `makeCtx()` — import them only
+for a partial re-seed.
+
+## Reference
+Unexpected shape or an uncovered operation → read the live Wix API reference; the
+authoritative source recipes are `wix-headless/references/inline-recipes/setup-restaurants.md`,
+`setup-restaurant-orders.md`, and `setup-restaurant-reservations.md`.

--- a/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
+++ b/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
@@ -1,0 +1,455 @@
+// Restaurants seed — a BUILD-TIME script, never shipped in the app. Run from the project
+// root (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
+//
+// It mints its own site token via the Wix CLI, installs the Wix Restaurants Menus app (plus
+// Orders / Table Reservations when the plan asks), builds each menu BOTTOM-UP (bulk items →
+// bulk sections → menu — every child exists before its parent, visible:true at every level),
+// imports+attaches item images, and configures the add-ons. Prints a JSON result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "menus": [{ "name", "description"?, "sections": [{ "name", "description"?,
+//                 "items": [{ "name", "description"?, "price", "imageUrl"? }] }] }],
+//     "ordering"?: true | { "address"? },        // menu-first add-on; address is STEP 0
+//     "reservations"?: true | { "partySize"? { "min","max" }, "address"? } }
+//
+// Seeding is ADDITIVE — with ONE recipe-sanctioned exception: when THIS run installs the
+// Menus app onto a site that didn't have it, the install's own sample "Dinner Menu" is
+// removed (it's provably not owner content). Nothing else is ever deleted. Unexpected
+// shapes → read the live API reference; authoritative source recipes:
+// wix-headless/references/inline-recipes/setup-restaurants.md, setup-restaurant-orders.md,
+// setup-restaurant-reservations.md.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const MENUS_APP_ID = "b278a256-2757-4f19-9313-c05c783bec92";
+const ORDERS_APP_ID = "9a5d83fd-8570-482e-81ab-cfa88942ee60";
+const TABLE_RESERVATIONS_APP_ID = "f9c07de2-5341-40c6-b096-8eb39de391fb";
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- app installs --------------------------------------------------------------------------------
+
+async function installApp(ctx, appDefId) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId, enabled: true },
+    } });
+  } catch {
+    /* already installed is fine */
+  }
+}
+export async function installMenusApp(ctx) { return installApp(ctx, MENUS_APP_ID); }
+export async function installOrdersApp(ctx) { return installApp(ctx, ORDERS_APP_ID); }
+export async function installTableReservationsApp(ctx) { return installApp(ctx, TABLE_RESERVATIONS_APP_ID); }
+
+/** True when the Menus API answers — i.e. the app is already on the site. */
+export async function menusAppPresent(ctx) {
+  try {
+    await req(ctx, "/restaurants/menus/v1/menus", { method: "GET" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---- menu (setup-restaurants.md) -----------------------------------------------------------------
+// Everything is Restaurants Menus V1 on /restaurants/menus/v1/... . REST flattens the
+// protobuf wrappers: plain values ("visible": true), never {"value": …}.
+
+/**
+ * Recipe STEP 0 — a FRESH Menus-app install ships a populated sample "Dinner Menu"
+ * (~4 sections, ~21 items) that would render next to the seeded menu. Call ONLY when this
+ * run installed the app onto a site that didn't have it (menusAppPresent was false) — then
+ * everything present is provably the install's own sample. Polls briefly (the sample
+ * provisions async), then deletes children before parents. No-op when nothing appears.
+ */
+export async function removeSampleMenu(ctx, { tries = 8, delayMs = 2000 } = {}) {
+  let menus = [];
+  for (let i = 0; i < tries; i++) {
+    const r = await req(ctx, "/restaurants/menus/v1/menus", { method: "GET" });
+    menus = r.menus ?? [];
+    if (menus.length) break;
+    if (i < tries - 1) await sleep(delayMs);
+  }
+  if (!menus.length) return { removed: false };
+
+  const itemsRes = await req(ctx, "/restaurants/menus/v1/items", { method: "GET" });
+  const sectionsRes = await req(ctx, "/restaurants/menus/v1/sections", { method: "GET" });
+  const itemIds = (itemsRes.items ?? []).map((it) => it.id).filter(Boolean);
+  const sectionIds = (sectionsRes.sections ?? []).map((s) => s.id).filter(Boolean);
+  if (itemIds.length) {
+    await req(ctx, "/restaurants/menus/v1/bulk/items/delete", { method: "DELETE", body: { ids: itemIds } });
+  }
+  if (sectionIds.length) {
+    await req(ctx, "/restaurants/menus/v1/bulk/sections/delete", { method: "DELETE", body: { ids: sectionIds } });
+  }
+  for (const m of menus) {
+    await req(ctx, `/restaurants/menus/v1/menus/${m.id}`, { method: "DELETE" }); // no bulk delete for menus
+  }
+  return { removed: true, menus: menus.map((m) => m.name) };
+}
+
+/**
+ * Build ONE menu BOTTOM-UP (items → sections → menu) in three bulk phases.
+ * price -> priceInfo.price as a decimal STRING; currency is the site's (send none).
+ * visible:true is baked in at every level — required to render on the live site.
+ * Returns { menuId, name, sectionIds, itemIds, items: [{ id, revision, price }] } — the
+ * per-item revision/price feed the image pass (Update Item is a full replace).
+ */
+export async function createMenu(ctx, menu) {
+  // STEP 1 — bulk-create every item across all sections in ONE request.
+  const flat = [];
+  menu.sections.forEach((sec, si) => (sec.items || []).forEach((it) => flat.push({ ...it, _section: si })));
+  const itemRes = await req(ctx, "/restaurants/menus/v1/bulk/items/create", {
+    body: {
+      items: flat.map((it) => ({
+        name: it.name,
+        ...(it.description ? { description: it.description } : {}),
+        priceInfo: { price: String(it.price) },
+        visible: true,
+      })),
+      returnEntity: true,
+    },
+  });
+  // created items are under results[].item (results[].itemMetadata.success is the per-item flag)
+  const createdItems = (itemRes.results ?? []).map((r) => r.item);
+  const itemIdsBySection = menu.sections.map(() => []);
+  flat.forEach((it, i) => {
+    const id = createdItems[i]?.id;
+    if (id) itemIdsBySection[it._section].push(id);
+  });
+
+  // STEP 2 — bulk-create sections, each carrying the itemIds of its items in display order.
+  const secRes = await req(ctx, "/restaurants/menus/v1/bulk/sections/create", {
+    body: {
+      sections: menu.sections.map((sec, si) => ({
+        name: sec.name,
+        ...(sec.description ? { description: sec.description } : {}),
+        visible: true,
+        itemIds: itemIdsBySection[si],
+      })),
+      returnEntity: true,
+    },
+  });
+  const sectionIds = (secRes.results ?? []).map((r) => r.item?.id);
+
+  // STEP 3 — create the menu (single create wraps in `menu`), carrying its sectionIds.
+  // businessLocationId omitted -> binds to the site's default (main) location.
+  const menuRes = await req(ctx, "/restaurants/menus/v1/menus", {
+    body: {
+      menu: {
+        name: menu.name,
+        ...(menu.description ? { description: menu.description } : {}),
+        visible: true,
+        sectionIds,
+      },
+    },
+  });
+  return {
+    menuId: menuRes.menu?.id,
+    name: menu.name,
+    sectionIds,
+    itemIds: createdItems.map((it) => it?.id),
+    items: createdItems.map((it, i) => ({ id: it?.id, revision: it?.revision, price: flat[i]?.price })),
+  };
+}
+
+// Restaurants binds an item image by Wix Media file ID — an external url must be imported first.
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+// Image pass. Update Item is a FULL-ENTITY REPLACE with NO field mask — each entry MUST echo
+// the item's current `revision` AND `priceInfo`, or it fails 428 MISSING_ITEM_PRICING and the
+// image does NOT apply. `image` is an OBJECT { id, url, height, width } (never a bare string);
+// the binding field is the Wix Media file `id`.
+// items: [{ id, revision, price, image: { id, url, height, width } }]
+export async function attachItemImages(ctx, items) {
+  return req(ctx, "/restaurants/menus/v1/bulk/items/update", {
+    body: {
+      items: items.map((it) => ({
+        item: {
+          id: it.id,
+          revision: it.revision,
+          priceInfo: { price: String(it.price) },
+          image: it.image,
+        },
+      })),
+    },
+  });
+}
+
+// ---- business location (shared STEP 0 for ordering + reservations) ------------------------------
+// Update Location is a FULL OVERRIDE — send the WHOLE `location` object (omitted fields are
+// wiped), echo `default:true` (omitting it 400s CHANGE_DEFAULT_FORBIDDEN) and the current
+// `revision`. address.country is a 2-letter ISO code. Without a real address, ordering is
+// "testing only" and checkout breaks — a placeholder must be flagged to the owner.
+// location: { name, timeZone, email?, phone?, address: { country, subdivision, city,
+//             postalCode, streetAddress: { number, name }, formattedAddress } }
+export async function setBusinessLocation(ctx, location) {
+  const list = await req(ctx, "/locations/v1/locations", { method: "GET" });
+  const def = (list.locations ?? []).find((l) => l.default);
+  if (!def) {
+    // No default location at all (a bare site can have none) -> CREATE one; operations
+    // auto-bind on first-location-add.
+    const r = await req(ctx, "/locations/v1/locations", { body: { location: { ...location, default: true } } });
+    return r.location;
+  }
+  const r = await req(ctx, `/locations/v1/locations/${def.id}`, {
+    method: "PUT",
+    body: { location: { ...location, id: def.id, revision: def.revision, default: true } },
+  });
+  return r.location;
+}
+
+// ---- online ordering (setup-restaurant-orders.md) ------------------------------------------------
+// The Orders-app install AUTO-provisions a working setup (an ENABLED operation with Pickup +
+// Delivery attached, every menu ordering-enabled) — these helpers VERIFY it; they never POST
+// an operation. Each micro-service is on its OWN host prefix — do not normalize.
+
+export async function listOperations(ctx) {
+  const r = await req(ctx, "/restaurants-operations/v1/operations", { method: "GET" });
+  return r.operations ?? [];
+}
+
+// A fresh install provisions the operation ASYNC — poll until it lands.
+export async function listOperationsWithRetry(ctx, { tries = 15, delayMs = 2000 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const ops = await listOperations(ctx).catch(() => []);
+    if (ops.length) return ops;
+    if (i < tries - 1) await sleep(delayMs);
+  }
+  return [];
+}
+
+// Normally already ENABLED — only PATCH when DISABLED/PAUSED_UNTIL. revision mandatory + current.
+export async function enableOperation(ctx, operationId, revision) {
+  return req(ctx, `/restaurants-operations/v1/operations/${operationId}`, {
+    method: "PATCH",
+    body: { operation: { revision, onlineOrderingStatus: "ENABLED" } },
+  });
+}
+
+export async function queryMenuOrderingSettings(ctx) {
+  const r = await req(ctx, "/menu-ordering-settings/v1/menu-ordering-settings/query", { body: { query: {} } });
+  return r.menuOrderingSettings ?? [];
+}
+
+// Only when an entry shows onlineOrderingEnabled:false / operationId:"none".
+export async function updateMenuOrderingSettings(ctx, settingsId, patch) {
+  return req(ctx, `/menu-ordering-settings/v1/menu-ordering-settings/${settingsId}`, {
+    method: "PATCH",
+    body: { menuOrderingSettings: patch },
+  });
+}
+
+// ---- table reservations (setup-restaurant-reservations.md) ---------------------------------------
+// The install AUTO-provisions one default reservation location with a complete config; the
+// one thing OFF is onlineReservationsEnabled (premium-gated). A reservation location cannot
+// be created via this API — discover, configure, enable. Post-Jan-2026 field names:
+// partySize (not partiesSize), approval (not manualApproval).
+
+export async function listReservationLocations(ctx) {
+  const r = await req(ctx, "/table-reservations/reservation-locations/v1/reservation-locations", { method: "GET" });
+  return r.reservationLocations ?? [];
+}
+
+export async function listReservationLocationsWithRetry(ctx, { tries = 15, delayMs = 2000 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const locs = await listReservationLocations(ctx).catch(() => []);
+    if (locs.length) return locs;
+    if (i < tries - 1) await sleep(delayMs);
+  }
+  return [];
+}
+
+// Partial PATCH; revision mandatory; works on a non-premium site. The `location` object
+// (address/name) is IMMUTABLE here — only touch `configuration`.
+export async function updateReservationLocation(ctx, reservationLocationId, revision, configuration) {
+  return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
+    method: "PATCH",
+    body: { reservationLocation: { id: reservationLocationId, revision, configuration } },
+  });
+}
+
+// PREMIUM-ONLY: on a non-premium site this THROWS `428 PREMIUM_ONLY` — expected and
+// non-fatal; the caller records it and continues (never retry-spiral, never fail the seed).
+export async function enableOnlineReservations(ctx, reservationLocationId, revision) {
+  return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
+    method: "PATCH",
+    body: {
+      reservationLocation: {
+        id: reservationLocationId,
+        revision,
+        configuration: { onlineReservations: { onlineReservationsEnabled: true } },
+      },
+    },
+  });
+}
+
+/**
+ * ONE-CALL seed: Menus install (+ sample cleanup when fresh) → menus bottom-up → images →
+ * ordering add-on → reservations add-on, ids threaded in memory. The default path.
+ */
+export async function setupRestaurants(ctx, plan) {
+  const menusPlan = plan.menus ?? [];
+  const wasPresent = await menusAppPresent(ctx);
+  await installMenusApp(ctx);
+  let sampleMenuRemoved = false;
+  if (!wasPresent) {
+    const r = await removeSampleMenu(ctx).catch(() => ({ removed: false }));
+    sampleMenuRemoved = r.removed === true;
+  }
+
+  const createdMenus = [];
+  for (const m of menusPlan) createdMenus.push(await createMenu(ctx, m));
+
+  // image pass — import each item's url to Wix Media (restaurants binds by file id), then
+  // bulk full-replace with revision + priceInfo echoed. Never block on image failure.
+  let imagesAttached = 0;
+  const imageItems = [];
+  menusPlan.forEach((m, mi) => {
+    const flat = m.sections.flatMap((s) => s.items || []);
+    flat.forEach((it, i) => {
+      const created = createdMenus[mi]?.items?.[i];
+      if (it.imageUrl && created?.id) imageItems.push({ ...created, imageUrl: it.imageUrl, name: it.name });
+    });
+  });
+  const toAttach = [];
+  for (const it of imageItems) {
+    try {
+      const file = await importImage(ctx, it.imageUrl, `${it.name || "item"}.png`);
+      toAttach.push({ id: it.id, revision: it.revision ?? "1", price: it.price,
+        image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
+    } catch {
+      /* skip this item's image */
+    }
+  }
+  if (toAttach.length) {
+    try {
+      await attachItemImages(ctx, toAttach);
+      imagesAttached = toAttach.length;
+    } catch {
+      /* the items stay text-only */
+    }
+  }
+
+  // shared STEP 0 address — set once across both add-ons.
+  let locationSet = false;
+  const ensureLocation = async (address) => {
+    if (address && !locationSet) {
+      await setBusinessLocation(ctx, address);
+      locationSet = true;
+    }
+  };
+
+  const ordering = { enabled: false, addressSet: false };
+  if (plan.ordering) {
+    const cfg = typeof plan.ordering === "object" ? plan.ordering : {};
+    await installOrdersApp(ctx); // auto-provisions operation + methods + per-menu settings
+    await ensureLocation(cfg.address);
+    ordering.addressSet = locationSet;
+    const ops = await listOperationsWithRetry(ctx);
+    const op = ops.find((o) => o.default) ?? ops[0];
+    if (!op) throw new Error("No ordering operation appeared — the Orders app install may not have completed; re-run the seed.");
+    if (op.onlineOrderingStatus !== "ENABLED") await enableOperation(ctx, op.id, op.revision);
+    // confirm each menu is orderable (auto-created + auto-enabled per menu; PATCH only when off)
+    const settings = await queryMenuOrderingSettings(ctx);
+    for (const s of settings) {
+      if (s.onlineOrderingEnabled === false || s.operationId === "none") {
+        await updateMenuOrderingSettings(ctx, s.id, {
+          revision: s.revision,
+          operationId: op.id,
+          onlineOrderingEnabled: true,
+          availability: { type: "ALWAYS_AVAILABLE", timeZone: cfg.address?.timeZone ?? "America/New_York" },
+        }).catch(() => {});
+      }
+    }
+    ordering.enabled = true;
+    ordering.operationId = op.id;
+    if (!ordering.addressSet) ordering.note = "No address in the plan — ordering is 'testing only' until the owner sets the real business address.";
+  }
+
+  const reservations = { enabled: false };
+  if (plan.reservations) {
+    const cfg = typeof plan.reservations === "object" ? plan.reservations : {};
+    await installTableReservationsApp(ctx); // auto-provisions the default reservation location
+    await ensureLocation(cfg.address);
+    let [loc] = await listReservationLocationsWithRetry(ctx);
+    if (!loc) throw new Error("No reservation location appeared — the Table Reservations install may not have completed; re-run the seed.");
+    const configuration = cfg.configuration ?? (cfg.partySize ? { onlineReservations: { partySize: cfg.partySize } } : null);
+    if (configuration) {
+      await updateReservationLocation(ctx, loc.id, loc.revision, configuration);
+      [loc] = await listReservationLocations(ctx); // re-read for the bumped revision
+    }
+    reservations.reservationLocationId = loc.id;
+    try {
+      await enableOnlineReservations(ctx, loc.id, loc.revision);
+      reservations.enabled = true;
+    } catch {
+      // 428 PREMIUM_ONLY on a free site — expected; record, don't fail.
+      reservations.premiumRequired = true;
+    }
+  }
+
+  return {
+    menus: createdMenus.map(({ items, ...m }) => m),
+    imagesAttached,
+    sampleMenuRemoved,
+    ordering,
+    reservations,
+  };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-restaurants.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupRestaurants(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}

--- a/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
@@ -13,7 +13,7 @@
 // tokens persist to localStorage — never re-minted per load (a fresh anonymous mint is a NEW
 // visitor and silently empties the cart).
 import { createClient, OAuthStrategy, EMPTY_TOKENS } from "@wix/sdk";
-import type { TokenStorage, Tokens } from "@wix/sdk";
+import type { IOAuthStrategy, TokenStorage, Tokens } from "@wix/sdk";
 import { WIX_CLIENT_ID } from "./config";
 
 const STORAGE_KEY = `wix-session-${WIX_CLIENT_ID ?? "ambient"}`;
@@ -55,4 +55,13 @@ const client = WIX_CLIENT_ID
 export function wixModule<T>(module: T): T {
   // The cast bridges the SDK's internal Descriptors constraint; the in/out type is identical.
   return client ? (client.use(module as unknown as Record<string, unknown>) as unknown as T) : module;
+}
+
+/**
+ * The manual-mode auth strategy (member-login handshake, loggedIn()), or null under ambient
+ * auth, where `@wix/astro` owns the session end-to-end. Only wix/members/auth.ts branches on
+ * this — app code reads the session through the members hooks instead.
+ */
+export function wixAuth(): IOAuthStrategy | null {
+  return client ? client.auth : null;
 }


### PR DESCRIPTION
Fills in the structure contract with every remaining wix-vibe-headless vertical: **blog, cms, events, members, portfolio, pricing-plans, restaurants** — each a full package (typed DTO data layer → SSR-friendly hooks → reference components on the shared `@theme` tokens → Astro overlay → ESM seed + SEED.md + INSTRUCTIONS.md with inlined contracts), built from the vibe reference + the classic recipes, with **every SDK call verified against the installed `.d.ts` before it was written**.

Scope notes:
- **members** ships the investigated reduced v1: hosted login/logout (ambient `/api/auth/*` on managed Astro; PKCE handshake on manual OAuth), current-member store, gating, account page — one stack-branched `auth.ts` over a new additive `wixAuth()` in shared `sdk.ts`. Custom login forms + social login documented out of scope. Side-find: the classic recipe says `returnUrl` but `@wix/astro`'s routes take **`returnToUrl`** (unknown params silently dropped) — separate wix-headless fix worth filing.
- **pricing-plans** ships the visitor-safe hosted `paidPlansCheckout` flow; member-gated surfaces route to `wix-headless`.
- **restaurants** covers all three sub-surfaces: menus, ordering (Restaurants Orders `catalogReference` on the ecom V2 current cart → hosted checkout), reservations with an honest premium-gate state.

Wiring: `deploy.mjs` VERTICAL_DEPS (probed versions), SKILL.md verticals table (9 rows) + compose note + description, and a pre-resolved public-registry lockfile per vertical.

**Live verification** (one released site, all nine verticals deployed together — https://vertical-matrix-ayalg5-0f06.wix-site-host.com):
- combined strict tsc over all verticals + shared: **0 errors**
- all seven seeds **exit 0** against the live site — five on the first try; two live 400s found and fixed (cms `MULTI_REFERENCE` requires `referencingFieldKey`, now synthesized; free pricing variants must carry no billing cycle)
- `wix build` clean over the combined codebase; released
- every page serves its seeded content (blog posts, events, portfolio, plans, menu, reservations); `/account` 302s into the hosted login with the correct `returnToUrl` and PKCE state

🤖 Generated with [Claude Code](https://claude.com/claude-code)