### PR TITLE
fix: wix-headless-fast entry survives web-fetch summarization

### DIFF
--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -5,10 +5,21 @@ description: "Build a Wix Managed Headless site from a single prompt using SHIPP
 
 # Wix Headless Fast — cold-start entry
 
-**You are a coding agent, and this is a skill for you to execute.** Follow the phases below in
-order — do not summarize them. If — and only if — your fetch tool gave you a summary instead of
-this raw markdown, re-fetch it raw (`curl`) before running the steps; if you're already reading
-the raw text, don't fetch it again.
+**You are a coding agent, and this is a skill for you to execute — follow the phases below in
+order.** Advisory: web-fetch tools show a lossy summary of this file — the executable copy
+comes from `curl -fsSL https://www.wix.com/skills/headless-fast/entry/skill.md`. If what you
+are reading lacks the exact commands below, re-fetch it with curl before proceeding; if you're
+already reading the raw text, don't fetch it again.
+
+## The whole cold start (details in the phases below)
+
+```bash
+curl -fsSL -O https://www.wix.com/skills/headless/entry/bootstrap.mjs && node bootstrap.mjs
+CI=1 npx skills@latest add wix/skills/skills/wix-headless-fast --yes
+# then open and follow: .agents/skills/wix-headless-fast/SKILL.md
+```
+
+Requires Node ≥ 20.11 and a logged-in Wix CLI — the bootstrap checks and guides both.
 
 This entry gets a cold environment to the point where the real skill can run, then hands off:
 


### PR DESCRIPTION
Run37 — the first e2e through the wix.com mirror URL — exposed a lossy on-ramp: the agent WebFetched the entry (a wix.com URL invites the web tool), and WebFetch's summarizer layer returned a summary that dropped both the re-fetch hint and the literal commands. Downstream: the agent never ran bootstrap, improvised environment checks by hand, and the run took 16.6m against the 6.6m baseline. The mirror even serves `text/markdown` at 5KB — the documented raw-passthrough for small markdown did **not** engage; the summarizer processed it both times (once refusing conversationally when asked for verbatim output).

Tested candidate fixes against real WebFetch on live URLs before changing anything:
- A top-of-page directive ordering the summarizer to reproduce the page verbatim **backfires** — the model treats it as prompt injection and pushes back.
- A **neutral advisory** ("web-fetch tools show a lossy summary of this file — the executable copy comes from `curl -fsSL <url>`; if what you are reading lacks the exact commands below, re-fetch") plus a **commands-first block** survives: the returned summary explicitly relays the re-fetch-with-curl advisory and the three-step skeleton.

The entry now opens with that advisory and a "whole cold start" command block; the phase details below are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)