### PR TITLE
fix: wix-headless-fast entry description covers all nine verticals

### DIFF
--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless-fast-entry
-description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified @wix/sdk code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skill and hands it the run. Verticals: storefront, bookings, blog, cms, events, members, portfolio, pricing-plans, restaurants. Triggers: build me a store/blog/booking/events/portfolio/restaurant site fast, sell tickets or membership plans headless, wix headless fast entry."
+description: "Build and release a Wix Headless site from a single prompt, on shipped, verified @wix/sdk code — this entry takes a cold environment (prerequisites, Wix sign-in) to the point where the wix-headless-fast skill runs the build. Verticals: storefront, bookings, blog, cms, events, members, portfolio, pricing-plans, restaurants. Triggers: build me a store/blog/booking/events/portfolio/restaurant site fast, sell tickets or membership plans headless, wix headless fast entry."
 ---
 
 # Wix Headless Fast — cold-start entry

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless-fast-entry
-description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified storefront code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skill and hands it the run. Triggers: build me a store fast, fast headless storefront, wix headless fast entry."
+description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified @wix/sdk code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skill and hands it the run. Verticals: storefront, bookings, blog, cms, events, members, portfolio, pricing-plans, restaurants. Triggers: build me a store/blog/booking/events/portfolio/restaurant site fast, sell tickets or membership plans headless, wix headless fast entry."
 ---
 
 # Wix Headless Fast — cold-start entry


### PR DESCRIPTION
The entry's frontmatter description still said "SHIPPED, verified **storefront** code" with store-only triggers — stale since the nine-vertical expansion (PRs #1140/#1142). Agents route by this description; a "build me a blog fast" prompt deserves to match it. Now lists the verticals and broadens the triggers, mirroring SKILL.md's own description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)