### PR TITLE
fix: wix-headless-fast lockfiles were broken outside Wix's network

### DIFF
--- a/skills/wix-headless-fast/references/blog/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/blog/lock/astro/package-lock.json
@@ -3941,18 +3941,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -3968,7 +3968,7 @@
   },
   "node_modules/@wix/aria-ai-avatar": {
    "version": "0.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/aria-ai-avatar/-/@wix/aria-ai-avatar-0.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/aria-ai-avatar/-/aria-ai-avatar-0.11.0.tgz",
    "integrity": "sha512-xAhC06GaYzr94OEtAQZB8kCfbY0+7VOuGIA1z6hUBVFkqDsMUIocJdiU4IVAUGd7nYHIm5XqwKdlrHWPtJMGQw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3981,7 +3981,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -4008,7 +4008,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -4016,7 +4016,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -4028,7 +4028,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -4037,7 +4037,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -4047,7 +4047,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -4058,7 +4058,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -4069,7 +4069,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -4080,7 +4080,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -4091,7 +4091,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -4102,7 +4102,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -4113,7 +4113,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -4124,7 +4124,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -4135,7 +4135,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -4146,7 +4146,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_blog-cache": {
    "version": "1.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_blog-cache/-/@wix/auto_sdk_blog_blog-cache-1.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_blog-cache/-/auto_sdk_blog_blog-cache-1.0.41.tgz",
    "integrity": "sha512-7ar6SmJZJvzL9LabVZ9Ky8E9QUgtwNIhGBXiNDRr8r1CMn52FrBaErieSMM7B4QhSUEk2z/da6SSw/6NGoDPZQ==",
    "license": "MIT",
    "dependencies": {
@@ -4157,7 +4157,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_categories": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_categories/-/@wix/auto_sdk_blog_categories-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_categories/-/auto_sdk_blog_categories-1.0.48.tgz",
    "integrity": "sha512-hj/C2DvEJdfCwUgQ0ktnebkHl4vbQErpxp2J1j5Fz0iv1Vg5Ciqr3377eyU9VZC4UdSeg001etRWZgWllE9zXg==",
    "license": "MIT",
    "dependencies": {
@@ -4168,7 +4168,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_draft-posts": {
    "version": "1.0.98",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_draft-posts/-/@wix/auto_sdk_blog_draft-posts-1.0.98.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_draft-posts/-/auto_sdk_blog_draft-posts-1.0.98.tgz",
    "integrity": "sha512-NAH0KBbF+GUdPF+T6TVLDUBhKukgE0v92ryV39LB4RDYm3nXvhyhikQ+saO0gjPtPJiSgADDWKMZA71odhyNBA==",
    "license": "MIT",
    "dependencies": {
@@ -4179,7 +4179,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_likes": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_likes/-/@wix/auto_sdk_blog_likes-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_likes/-/auto_sdk_blog_likes-1.0.24.tgz",
    "integrity": "sha512-iIjq4KDjTNp2pM96CErFedKciJhsI8prPKCwD6MK8p5os7a24q6Lsrh8pct0KGccRVJiPUk6AVgo8FrIvNINIw==",
    "license": "MIT",
    "dependencies": {
@@ -4190,7 +4190,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_posts": {
    "version": "1.0.177",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_posts/-/@wix/auto_sdk_blog_posts-1.0.177.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_posts/-/auto_sdk_blog_posts-1.0.177.tgz",
    "integrity": "sha512-tM2fRUl+oSsTcxLyBIifs5gyoxVrJVitbglzxCXCCbs26pWiCrzgTC8f3EWzN7VtmF4RpA6lbO394CzDQYCArg==",
    "license": "MIT",
    "dependencies": {
@@ -4201,7 +4201,7 @@
   },
   "node_modules/@wix/auto_sdk_blog_tags": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_tags/-/@wix/auto_sdk_blog_tags-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_blog_tags/-/auto_sdk_blog_tags-1.0.57.tgz",
    "integrity": "sha512-t5iBZg9sXPs3Qe9IOYGnvBovoX8zROZSby+FlaXE+UuiKwPcicVNbiRpk6+KMgxYd97fAOQUpjjHyFgU59rRbg==",
    "license": "MIT",
    "dependencies": {
@@ -4212,7 +4212,7 @@
   },
   "node_modules/@wix/auto_sdk_comments_categories": {
    "version": "1.0.61",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_categories/-/@wix/auto_sdk_comments_categories-1.0.61.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_categories/-/auto_sdk_comments_categories-1.0.61.tgz",
    "integrity": "sha512-16BeZ4SXWsL6xbT5l3WZZ1l0aNZi967N1QzQGx1Fo++FqV8C4IlRFZBtjnEo1ebZyBI22C3loNZwBvUqusm4pA==",
    "license": "MIT",
    "dependencies": {
@@ -4223,7 +4223,7 @@
   },
   "node_modules/@wix/auto_sdk_comments_comments": {
    "version": "1.0.69",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_comments/-/@wix/auto_sdk_comments_comments-1.0.69.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_comments/-/auto_sdk_comments_comments-1.0.69.tgz",
    "integrity": "sha512-m6CsJXlsyH2KRkPkRdrQEtm5CdoDVGlLG+MuErRAMV0/wrWlrRrVbTFuSwSw7S5nlvxswtblMFI/vxiznEhiKg==",
    "license": "MIT",
    "dependencies": {
@@ -4234,7 +4234,7 @@
   },
   "node_modules/@wix/auto_sdk_comments_ratings": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_ratings/-/@wix/auto_sdk_comments_ratings-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_ratings/-/auto_sdk_comments_ratings-1.0.5.tgz",
    "integrity": "sha512-5E/1yHQGOyviO+igJ84dW4UzUU6kUrWgTLRsnpNqh4RorxP97IzhN1wo1zDg4ESyZig/x04dRKY+kODUWnVnCQ==",
    "license": "MIT",
    "dependencies": {
@@ -4245,7 +4245,7 @@
   },
   "node_modules/@wix/auto_sdk_comments_widgets": {
    "version": "1.0.39",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_widgets/-/@wix/auto_sdk_comments_widgets-1.0.39.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_comments_widgets/-/auto_sdk_comments_widgets-1.0.39.tgz",
    "integrity": "sha512-yeuCKxB9y2/xj36Fl9ElN1RVi27h5uqdrZfEgXtyFLbdxDrQk0cXFEh9U8EgLF+IyBjR/KONWVIAYjs/dMuq7Q==",
    "license": "MIT",
    "dependencies": {
@@ -4256,7 +4256,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -4267,7 +4267,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -4278,7 +4278,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -4289,7 +4289,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -4300,7 +4300,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -4311,7 +4311,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -4322,7 +4322,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -4333,7 +4333,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -4344,7 +4344,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -4355,7 +4355,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -4366,7 +4366,7 @@
   },
   "node_modules/@wix/auto_sdk_members_authentication": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/@wix/auto_sdk_members_authentication-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/auto_sdk_members_authentication-1.0.45.tgz",
    "integrity": "sha512-rYbM07KLz3FQgjxb1tUO/7Ns+ZnI15XCdXQI13NZRmWLLU6NhxfVuy7EyHNxb+IgeEXzAyiqB1taGY4IriMx9g==",
    "license": "MIT",
    "dependencies": {
@@ -4377,7 +4377,7 @@
   },
   "node_modules/@wix/auto_sdk_members_authorization": {
    "version": "1.0.36",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/@wix/auto_sdk_members_authorization-1.0.36.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/auto_sdk_members_authorization-1.0.36.tgz",
    "integrity": "sha512-hpaTseJXSv9CpQWwFItXjmIPgq0NjNBBm98XX6We7m+lDMXkoDHvIgo645xS/jIMpWbwRS26/iY61W9A9Is02g==",
    "license": "MIT",
    "dependencies": {
@@ -4388,7 +4388,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badge-assignments": {
    "version": "1.0.30",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/@wix/auto_sdk_members_badge-assignments-1.0.30.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/auto_sdk_members_badge-assignments-1.0.30.tgz",
    "integrity": "sha512-0RggesluwvfP8lEpLTaJlKtz9LKEuuPzIKpxce+iGbSZin6CyvmaV9HIGEO+G64QSOdWCzXUY8JU+9/4ni1xPA==",
    "license": "MIT",
    "dependencies": {
@@ -4399,7 +4399,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badges": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/@wix/auto_sdk_members_badges-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/auto_sdk_members_badges-1.0.52.tgz",
    "integrity": "sha512-vJPXfwIKobCLFvW6EalpbP9mZe/fTL7WiZsdlZJUX7igr64udS65JAnnDb73Ge7l9SoiWtXUDLPcvbMMF+mw8w==",
    "license": "MIT",
    "dependencies": {
@@ -4410,7 +4410,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badges-v-2": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/@wix/auto_sdk_members_badges-v-2-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/auto_sdk_members_badges-v-2-1.0.37.tgz",
    "integrity": "sha512-KHy7ZizF1KW+icDRabv3swQtR0i+WQ43XcqQ3sFYVowpXsb73rg9XgpZ8/3gc+d5sEedIh9OuCOtYfzZi2htsg==",
    "license": "MIT",
    "dependencies": {
@@ -4421,7 +4421,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-field-applications": {
    "version": "1.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/@wix/auto_sdk_members_custom-field-applications-1.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/auto_sdk_members_custom-field-applications-1.0.41.tgz",
    "integrity": "sha512-GnCIAZ7ATgCr9gEqxuClE4y9VHEN1ayxq2nJrdHatIkxsoElvWp2E/Uw9e7O0TUdkNXLLlBvd3mjeKpdrUhUvQ==",
    "license": "MIT",
    "dependencies": {
@@ -4432,7 +4432,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-field-suggestions": {
    "version": "1.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/@wix/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
    "integrity": "sha512-2LCuljSdthAoIoiw4A+ZjSIOqCam4TnsJI1meZLmvOUBenQghzeflwvFvmIG13h+lkKWiLc0WmkhrmEo8Iosog==",
    "license": "MIT",
    "dependencies": {
@@ -4443,7 +4443,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-fields": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/@wix/auto_sdk_members_custom-fields-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/auto_sdk_members_custom-fields-1.0.59.tgz",
    "integrity": "sha512-e0Gj3mWXzv1VDGY95CMh1zVp6YQGbLuURD4TTDuxETvqEYMFzTtDXfTuGi90MbEWAwTk1aqYF8BR0gKL0ILV8Q==",
    "license": "MIT",
    "dependencies": {
@@ -4454,7 +4454,7 @@
   },
   "node_modules/@wix/auto_sdk_members_default-privacy": {
    "version": "1.0.34",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/@wix/auto_sdk_members_default-privacy-1.0.34.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/auto_sdk_members_default-privacy-1.0.34.tgz",
    "integrity": "sha512-pgAe1M898aSSnYKn0mIf8SdGNeA2lK8OI9vncLv9kV1wknP5ue6/eNr3GEBl5JawspoifxbyuD7C+c1R8WiLBw==",
    "license": "MIT",
    "dependencies": {
@@ -4465,7 +4465,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-followers": {
    "version": "1.0.44",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/@wix/auto_sdk_members_member-followers-1.0.44.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/auto_sdk_members_member-followers-1.0.44.tgz",
    "integrity": "sha512-LVxdoeXewsZul72frlyLY5PYU6Ycz6ddbvYkhZr09TCgP6sPvwCuI+br/r3sxGwJ3XlM3w9cFtwOc6cZf40+eA==",
    "license": "MIT",
    "dependencies": {
@@ -4476,7 +4476,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-privacy-settings": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/@wix/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
    "integrity": "sha512-JpcWY+fppyjBXfwcIX7ztlo34ZpA+b7Cbhh62oaH8fzQq7PpfVk9zc94FT2EEiwutaipgJOU4SyrLl3/JULwGA==",
    "license": "MIT",
    "dependencies": {
@@ -4487,7 +4487,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-report": {
    "version": "1.0.49",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/@wix/auto_sdk_members_member-report-1.0.49.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/auto_sdk_members_member-report-1.0.49.tgz",
    "integrity": "sha512-kx+netTOEhPS32d98pgko+fbwyR4HT87TlxdKqg1aBaJBrDEz2M533wc8wTJX1TArj9B41ew39k/fXdbfCEozA==",
    "license": "MIT",
    "dependencies": {
@@ -4498,7 +4498,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-role-definition": {
    "version": "1.0.47",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/@wix/auto_sdk_members_member-role-definition-1.0.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/auto_sdk_members_member-role-definition-1.0.47.tgz",
    "integrity": "sha512-PpGcfee/QCqtCU4U7KdGjqe8CB8ereXnMxLleisyapNWhwfWo1r1XBfq4EaVc0GF9uLdozWWx6Oums/bB42E6g==",
    "license": "MIT",
    "dependencies": {
@@ -4509,7 +4509,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-to-member-block": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/@wix/auto_sdk_members_member-to-member-block-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/auto_sdk_members_member-to-member-block-1.0.35.tgz",
    "integrity": "sha512-U5Z5l7KGpYztXtz0E3V7JNogdJGNCPmcR5yjeEZdT0u8yZTQKsnF7hNvMxxyv2RMGJwCNmdYLHbFYj/ic/Futw==",
    "license": "MIT",
    "dependencies": {
@@ -4520,7 +4520,7 @@
   },
   "node_modules/@wix/auto_sdk_members_members": {
    "version": "1.0.131",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/@wix/auto_sdk_members_members-1.0.131.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/auto_sdk_members_members-1.0.131.tgz",
    "integrity": "sha512-kgPFRm1faDjRsCv7kOcALlZiHpBJ9Ix5PZy8NJxzJEu2kKBdkdH6kVBTk+R13lRO6XkK5NRPytY9cinu2suP2g==",
    "license": "MIT",
    "dependencies": {
@@ -4531,7 +4531,7 @@
   },
   "node_modules/@wix/auto_sdk_members_members-about": {
    "version": "1.0.78",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/@wix/auto_sdk_members_members-about-1.0.78.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/auto_sdk_members_members-about-1.0.78.tgz",
    "integrity": "sha512-HPXMekpWcexRubnf5gA0flYiYktEcsj4kMi0oyC47zTTIO7tmpqjJULH365y8rzDx6vPLUb25Lzyb+rCZPTxwA==",
    "license": "MIT",
    "dependencies": {
@@ -4542,7 +4542,7 @@
   },
   "node_modules/@wix/auto_sdk_members_user-member": {
    "version": "1.0.56",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/@wix/auto_sdk_members_user-member-1.0.56.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/auto_sdk_members_user-member-1.0.56.tgz",
    "integrity": "sha512-FMiVGhE+F6psLwXTKC4Rz2W/dDl1Sa2Fj/P80+jDkTZ5IDR5c4Qq5M3Prlj7MmHIjSx7OsEX6zdRVoGFBjfA0w==",
    "license": "MIT",
    "dependencies": {
@@ -4553,7 +4553,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -4564,7 +4564,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
    "version": "1.0.12",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
    "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
    "license": "MIT",
    "dependencies": {
@@ -4575,7 +4575,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_llms-txt": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/auto_sdk_seo_llms-txt-1.0.0.tgz",
    "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
    "license": "MIT",
    "dependencies": {
@@ -4586,7 +4586,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_redirects": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/auto_sdk_seo_redirects-1.0.2.tgz",
    "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
    "license": "MIT",
    "dependencies": {
@@ -4597,7 +4597,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_robots-txt": {
    "version": "1.0.21",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/auto_sdk_seo_robots-txt-1.0.21.tgz",
    "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
    "license": "MIT",
    "dependencies": {
@@ -4608,7 +4608,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-patterns": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/auto_sdk_seo_seo-patterns-1.0.8.tgz",
    "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
    "license": "MIT",
    "dependencies": {
@@ -4619,7 +4619,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
    "version": "1.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
    "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
    "license": "MIT",
    "dependencies": {
@@ -4630,7 +4630,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-tags": {
    "version": "1.0.28",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/auto_sdk_seo_seo-tags-1.0.28.tgz",
    "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
    "license": "MIT",
    "dependencies": {
@@ -4641,7 +4641,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
    "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
    "license": "MIT",
    "dependencies": {
@@ -4652,7 +4652,7 @@
   },
   "node_modules/@wix/awaiter-utils": {
    "version": "1.0.141",
-   "resolved": "https://registry.npmjs.org/@wix/awaiter-utils/-/@wix/awaiter-utils-1.0.141.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/awaiter-utils/-/awaiter-utils-1.0.141.tgz",
    "integrity": "sha512-ScV5PZNZR/KwX/pmANHWdn2Il0mDqVZL8/0qQRF38zKmiXiUqSipp4uiuRft2ocA2Jz+aP9qvAW1+CJgvW9VNQ==",
    "license": "MIT",
    "engines": {
@@ -4661,7 +4661,7 @@
   },
   "node_modules/@wix/blog": {
    "version": "1.0.645",
-   "resolved": "https://registry.npmjs.org/@wix/blog/-/@wix/blog-1.0.645.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/blog/-/blog-1.0.645.tgz",
    "integrity": "sha512-UnEL4pyLtsrWtmnTniuqX1vWmQNrInVmzfOrSQ6KUGP8W087H2eXU+LM4K5a+m69IY/Oe/D7GjgwhdDcs6/TsA==",
    "license": "MIT",
    "dependencies": {
@@ -4677,7 +4677,7 @@
   },
   "node_modules/@wix/blog_app-extensions": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/blog_app-extensions/-/@wix/blog_app-extensions-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/blog_app-extensions/-/blog_app-extensions-1.0.53.tgz",
    "integrity": "sha512-Zd3o91ln1Sf0K4cgL1R0J5/OuCQSWROM83etZJHtA34xhBCou49MFUIW74GkYWt99dsIQl/YkxjqQhQ21naNOg==",
    "license": "MIT",
    "dependencies": {
@@ -4688,7 +4688,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -4707,7 +4707,7 @@
   },
   "node_modules/@wix/comments": {
    "version": "1.0.197",
-   "resolved": "https://registry.npmjs.org/@wix/comments/-/@wix/comments-1.0.197.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/comments/-/comments-1.0.197.tgz",
    "integrity": "sha512-2OibIsJ4TVlanGz3DYmxAMsu6b9Kg7O6czpnOOrAj0/7tvLONzOy5qR+I2wZ8r9aG7lINjSuy83LFOdwvZuzLQ==",
    "license": "MIT",
    "dependencies": {
@@ -4719,7 +4719,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4729,13 +4729,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4744,7 +4744,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4783,7 +4783,7 @@
   },
   "node_modules/@wix/design-system": {
    "version": "1.317.1",
-   "resolved": "https://registry.npmjs.org/@wix/design-system/-/@wix/design-system-1.317.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/design-system/-/design-system-1.317.1.tgz",
    "integrity": "sha512-BHrr8gXr9ZtcrPYB0xSUTwEviZ6G3duMGA3nAI4wxynkijKUU2P5Y+mlzYC0X1rnISUxxEKP8NQsBzai8B4lWw==",
    "license": "MIT",
    "dependencies": {
@@ -4883,7 +4883,7 @@
   },
   "node_modules/@wix/design-system-illustrations": {
    "version": "2.34.2",
-   "resolved": "https://registry.npmjs.org/@wix/design-system-illustrations/-/@wix/design-system-illustrations-2.34.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/design-system-illustrations/-/design-system-illustrations-2.34.2.tgz",
    "integrity": "sha512-zSOPmTimQ4/wm+gXKuwl81mfMwkRlsaWz1qGOKcMVZBY1OcpgFGdObFflNQwRsB/H8DaKRgZwGoZ3zovw9xi0g==",
    "license": "MIT",
    "peerDependencies": {
@@ -4893,7 +4893,7 @@
   },
   "node_modules/@wix/design-system-tokens": {
    "version": "1.225.2",
-   "resolved": "https://registry.npmjs.org/@wix/design-system-tokens/-/@wix/design-system-tokens-1.225.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/design-system-tokens/-/design-system-tokens-1.225.2.tgz",
    "integrity": "sha512-Y3zhHWuFUoMJMWZhKMDRtVm0WQmkHI9RP9NZvHFIPJfXdunGFvOXR1p/aQttfBl8FSZU6ASmMAsYvFv6uG8AHg==",
    "license": "MIT"
   },
@@ -4969,7 +4969,7 @@
   },
   "node_modules/@wix/design-systems-locale-utils": {
    "version": "1.197.0",
-   "resolved": "https://registry.npmjs.org/@wix/design-systems-locale-utils/-/@wix/design-systems-locale-utils-1.197.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/design-systems-locale-utils/-/design-systems-locale-utils-1.197.0.tgz",
    "integrity": "sha512-dvaFxQGWEK87f81thtfjB8Bq7CSvna+DpnPppAXRycaJTB602o3iGu1R8pVYswSbtsyXJP5eDHoO96meV3+DbA==",
    "dependencies": {
     "@babel/runtime": "^7.29.2"
@@ -4977,7 +4977,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4993,7 +4993,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5005,7 +5005,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5017,7 +5017,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5031,7 +5031,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -5058,7 +5058,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -5068,7 +5068,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -5077,7 +5077,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -5097,7 +5097,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -5130,7 +5130,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -5140,7 +5140,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -5158,7 +5158,7 @@
   },
   "node_modules/@wix/headless-blog": {
    "version": "0.0.29",
-   "resolved": "https://registry.npmjs.org/@wix/headless-blog/-/@wix/headless-blog-0.0.29.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-blog/-/headless-blog-0.0.29.tgz",
    "integrity": "sha512-j+tDgQpVr1h656Gkgxgc6MekK2k8c8avcDlljLhfADjrzMtsgPWB07r0YzHeSHkCaSF8aIVRLwQs9ZOH1HV0UA==",
    "license": "MIT",
    "dependencies": {
@@ -5205,7 +5205,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -5215,7 +5215,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -5226,7 +5226,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5237,7 +5237,7 @@
   },
   "node_modules/@wix/headless-seo": {
    "version": "0.0.16",
-   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/headless-seo-0.0.16.tgz",
    "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
    "license": "MIT",
    "dependencies": {
@@ -5248,7 +5248,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5259,7 +5259,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -5268,7 +5268,7 @@
   },
   "node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -5280,7 +5280,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -5293,7 +5293,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -5303,7 +5303,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -5316,7 +5316,7 @@
   },
   "node_modules/@wix/media/node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -5327,7 +5327,7 @@
   },
   "node_modules/@wix/members": {
    "version": "1.0.511",
-   "resolved": "https://registry.npmjs.org/@wix/members/-/@wix/members-1.0.511.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/members/-/members-1.0.511.tgz",
    "integrity": "sha512-n30tjMx6LAiDiCVT2jnenoFIxEwgIwbn7S5pWbesVvo73+mDuyn0+bxVJJw0acGY00nvnmpJsdrU28VMOz5CKw==",
    "license": "MIT",
    "dependencies": {
@@ -5361,7 +5361,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5371,7 +5371,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5380,13 +5380,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -5398,7 +5398,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5407,13 +5407,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5424,7 +5424,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5435,7 +5435,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5444,19 +5444,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -5468,7 +5468,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5479,7 +5479,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5488,7 +5488,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
@@ -5518,7 +5518,7 @@
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -5528,13 +5528,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5543,7 +5543,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5553,13 +5553,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -5568,7 +5568,7 @@
   },
   "node_modules/@wix/ricos": {
    "version": "11.12.0",
-   "resolved": "https://registry.npmjs.org/@wix/ricos/-/@wix/ricos-11.12.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/ricos/-/ricos-11.12.0.tgz",
    "integrity": "sha512-u3jWIDLhZ8h5mxchsItfP4dsT6Q5wgE1ojhT2NRC/UJBF/HAiQVahLnK4xHu6SjZLTFfV5/3kATXhoLlP8499w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5641,7 +5641,7 @@
   },
   "node_modules/@wix/ricos/node_modules/@wix/ai-assistant-avatar": {
    "version": "0.41.0",
-   "resolved": "https://registry.npmjs.org/@wix/ai-assistant-avatar/-/@wix/ai-assistant-avatar-0.41.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/ai-assistant-avatar/-/ai-assistant-avatar-0.41.0.tgz",
    "integrity": "sha512-ux3xPNEo0p+vFNZx5qf2Bs5StZU0dJGT8+qqqrGhIKDOYv9j8g0SoYJByJPFi5lqTkA9lyRpMQ3PfL8vpITViA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5696,7 +5696,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -5721,7 +5721,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -5730,7 +5730,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -5740,7 +5740,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -5751,7 +5751,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -5761,7 +5761,7 @@
   },
   "node_modules/@wix/seo": {
    "version": "1.0.79",
-   "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/seo-1.0.79.tgz",
    "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
    "license": "MIT",
    "dependencies": {
@@ -5778,7 +5778,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -5786,7 +5786,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -5797,7 +5797,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -5814,7 +5814,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5828,7 +5828,7 @@
   },
   "node_modules/@wix/unidriver-common": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-common/-/@wix/unidriver-common-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-common/-/unidriver-common-1.5.6.tgz",
    "integrity": "sha512-0owm5hJUpAEcackgflRVEha/nKocySZyRrZbVKetmNzWjxf+WGt8rzvr6DDiRZmB9ZRCtXWUXVvJSLTAIkoBWw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5837,13 +5837,13 @@
   },
   "node_modules/@wix/unidriver-core": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-core/-/@wix/unidriver-core-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-core/-/unidriver-core-1.5.6.tgz",
    "integrity": "sha512-5xeIXr5tO0pkCTI71sYkkHC9znK8G8XRoqml2cHMb88nmdGwJndSdmp+CtF2NQkdZm/13ZR82Aj/ZYY3aNz7lw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/unidriver-jsdom-react": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react/-/@wix/unidriver-jsdom-react-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react/-/unidriver-jsdom-react-1.5.6.tgz",
    "integrity": "sha512-85C3LOWi73PtoEt9SnqKp/Lt6euT1iZZO5ciyLhAKyemzI4LV0gIhyl3voQpSCSwgtMqOECKp++2xpUx/2C0Ig==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5859,7 +5859,7 @@
   },
   "node_modules/@wix/unidriver-jsdom-react-legacy": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react-legacy/-/@wix/unidriver-jsdom-react-legacy-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-jsdom-react-legacy/-/unidriver-jsdom-react-legacy-1.5.6.tgz",
    "integrity": "sha512-0FcUfzqepZGI1ny9EJAw1eSjT+xZgMwtyLzuwPT9LZEccLLnveYwmVmbJjku4f/dh6mFOpR0F7TUO40tzP9U3w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5873,7 +5873,7 @@
   },
   "node_modules/@wix/unidriver-playwright": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-playwright/-/@wix/unidriver-playwright-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-playwright/-/unidriver-playwright-1.5.6.tgz",
    "integrity": "sha512-7VFjIgU47f7BHzssGNNg/WwkE2j0tEs7AkfN6h85+nHCgdD+cKRy1pZkok3qLfD54Ii6QxOOzJTFHonxon7uSQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5883,7 +5883,7 @@
   },
   "node_modules/@wix/unidriver-puppeteer": {
    "version": "1.5.6",
-   "resolved": "https://registry.npmjs.org/@wix/unidriver-puppeteer/-/@wix/unidriver-puppeteer-1.5.6.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/unidriver-puppeteer/-/unidriver-puppeteer-1.5.6.tgz",
    "integrity": "sha512-RjTOEsmDCV/rqXIqgVvLh341VPPHpFH/FBq16W5nPH0/drZkOPbdznSS5STpJUQ0C4mYBrXgIC/23U3keB+2Fg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5894,7 +5894,7 @@
   },
   "node_modules/@wix/wix-ui-icons-common": {
    "version": "3.189.14",
-   "resolved": "https://registry.npmjs.org/@wix/wix-ui-icons-common/-/@wix/wix-ui-icons-common-3.189.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/wix-ui-icons-common/-/wix-ui-icons-common-3.189.14.tgz",
    "integrity": "sha512-ZCwih1buJWXgJBdL7jBwTNLSyBLLMIO04U/S7zf+JEl9S2aYAgKNO4kUDSAkDBbfKPotPhcBV/X1EVe3JxbGUw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5905,7 +5905,7 @@
   },
   "node_modules/@wix/wix-ui-test-utils": {
    "version": "1.3.5",
-   "resolved": "https://registry.npmjs.org/@wix/wix-ui-test-utils/-/@wix/wix-ui-test-utils-1.3.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/wix-ui-test-utils/-/wix-ui-test-utils-1.3.5.tgz",
    "integrity": "sha512-tczLyUQw0ChQQ25HHr5zK55o+kvaVgxz/aJzP8Yg7Pca4ja9Qes+pBv1JFQUb8vO9eBohsqrcP0XrNQr4JzTog==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5941,7 +5941,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/bookings/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/bookings/lock/astro/package-lock.json
@@ -1,11962 +1,11962 @@
 {
-  "name": "wix-astro-blank",
-  "version": "0.0.1",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "wix-astro-blank",
-      "version": "0.0.1",
-      "dependencies": {
-        "@tailwindcss/vite": "^4.1.7",
-        "@wix/astro": "^2.39.0",
-        "@wix/astro-pages": "^2.0.4",
-        "@wix/auto_sdk_ecom_cart-v-2": "^1.0.192",
-        "@wix/bookings": "^1.0.1650",
-        "@wix/dashboard": "^1.3.43",
-        "@wix/essentials": "^1.0.6",
-        "@wix/forms": "^1.0.500",
-        "@wix/redirects": "^1.0.125",
-        "@wix/sdk": "^1.21.5",
-        "@wix/seo": "^1.0.79",
-        "astro": "^5.8.0",
-        "tailwindcss": "^4.1.7",
-        "typescript": "^5.8.3"
-      },
-      "devDependencies": {
-        "@astrojs/react": "^4.3.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.1",
-        "@wix/astro-wix-hosting-adapter": "^2.0.0",
-        "@wix/cli": "^1.1.92",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
-      }
-    },
-    "node_modules/@astrojs/cloudflare": {
-      "version": "12.6.13",
-      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
-      "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/underscore-redirects": "1.0.0",
-        "@cloudflare/workers-types": "^4.20260116.0",
-        "tinyglobby": "^0.2.15",
-        "vite": "^6.4.1",
-        "wrangler": "4.59.2"
-      },
-      "peerDependencies": {
-        "astro": "^5.7.0"
-      }
-    },
-    "node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
-      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
-      "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/prism": "3.3.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/@astrojs/prism": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prismjs": "^1.30.0"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      }
-    },
-    "node_modules/@astrojs/react": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
-      "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitejs/plugin-react": "^4.7.0",
-        "ultrahtml": "^1.6.0",
-        "vite": "^6.4.1"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
-        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
-        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
-        "dlv": "^1.1.3",
-        "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
-        "which-pm-runs": "^1.1.0"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      }
-    },
-    "node_modules/@astrojs/underscore-redirects": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
-      "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
-      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@babel/types": "^7.29.8",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
-      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.8"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.8",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.8",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.8",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
-      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@capsizecss/unpack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
-      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "fontkitten": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
-      "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.24",
-        "workerd": "^1.20251221.0"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
-      "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
-      "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
-      "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
-      "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
-      "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
-      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/icu-skeleton-parser": "1.8.16",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
-      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@internationalized/date": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
-      "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
-      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/string": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
-      "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
-      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^22.20 || ^24.12 || >=25"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oslojs/encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
-      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
-    },
-    "node_modules/@poppinss/colors": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
-      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^4.1.5"
-      }
-    },
-    "node_modules/@poppinss/colors/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@poppinss/dumper": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
-      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@sindresorhus/is": "^7.0.2",
-        "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/@poppinss/exception": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
-      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@preact/signals-core": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
-      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@preact/signals-react": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
-      "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-core": "^1.14.4",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "node_modules/@radix-ui/number": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
-      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
-      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
-      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
-      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
-      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
-      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
-      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
-      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-effect-event": "0.0.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
-      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
-      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
-      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-rect": "1.1.4",
-        "@radix-ui/react-use-size": "1.1.4",
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
-      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
-      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
-      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
-      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-is-hydrated": "0.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
-      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/number": "1.1.3",
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-popper": "1.3.7",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-previous": "1.1.4",
-        "@radix-ui/react-visually-hidden": "1.2.11",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
-      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/number": "1.1.3",
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-previous": "1.1.4",
-        "@radix-ui/react-use-size": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
-      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
-      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
-      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-roving-focus": "1.1.19",
-        "@radix-ui/react-toggle": "1.1.18",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
-      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
-      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-use-effect-event": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
-      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
-      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
-      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
-      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
-      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
-      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
-      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/rect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
-      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
-      "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
-      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
-      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
-      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
-      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
-      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
-      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
-      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
-      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
-      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
-      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
-      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
-      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
-      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
-      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
-      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
-      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
-      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
-      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
-      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
-      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
-      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
-      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
-      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@speed-highlight/core": {
-      "version": "1.2.24",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
-      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
-      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.24.1",
-        "jiti": "^2.7.0",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.3"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
-      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.3",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
-        "@tailwindcss/oxide-darwin-x64": "4.3.3",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
-      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
-      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
-      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
-      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
-      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
-      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
-      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
-      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
-      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
-      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.11.1",
-        "@emnapi/runtime": "^1.11.1",
-        "@emnapi/wasi-threads": "^1.2.2",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
-      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
-      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
-      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.3.3",
-        "@tailwindcss/oxide": "4.3.3",
-        "tailwindcss": "4.3.3"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/hast": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
-      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/nlcst": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
-      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "license": "ISC"
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@wix/agent-skills": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
-      "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wix/analytics": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
-      "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wix/app-extensions": {
-      "version": "1.0.133",
-      "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
-      "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
-    },
-    "node_modules/@wix/app-management": {
-      "version": "1.0.158",
-      "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
-      "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_app-management_app-instances": "1.0.48",
-        "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
-        "@wix/auto_sdk_app-management_app-plans": "1.0.37",
-        "@wix/auto_sdk_app-management_bi-events": "1.0.37",
-        "@wix/auto_sdk_app-management_billing": "1.0.45",
-        "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
-        "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
-        "@wix/auto_sdk_app-management_external-billing": "1.0.32"
-      }
-    },
-    "node_modules/@wix/astro": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
-      "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
-      "dependencies": {
-        "@wix/app-management": "^1.0.149",
-        "@wix/auth-management": "^1.0.71",
-        "@wix/dashboard": "^1.3.43",
-        "@wix/editor": "^1.772.0",
-        "@wix/essentials": "^1.0.14",
-        "@wix/headless-localization-utils": "^1.0.13",
-        "@wix/headless-node": "^1.43.0",
-        "@wix/headless-site": "^1.31.0",
-        "@wix/headless-site-assets": "^1.0.13",
-        "@wix/multilingual-manager": "^1.5.0",
-        "@wix/react-component-schema": "^1.4.0",
-        "@wix/sdk": "^1.21.3",
-        "@wix/sdk-runtime": "^1.0.0",
-        "@wix/sdk-types": "^1.17.1",
-        "@wix/site": "^1.66.0"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      }
-    },
-    "node_modules/@wix/astro-pages": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
-      "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
-      "peerDependencies": {
-        "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@wix/astro-wix-hosting-adapter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
-      "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
-      "dev": true,
-      "dependencies": {
-        "@astrojs/cloudflare": "^12.6.10"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@wix/auth-management": {
-      "version": "1.0.91",
-      "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
-      "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
-      }
-    },
-    "node_modules/@wix/authentication": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
-      "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.15",
-        "@wix/sdk-types": "^1.17.9"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-instances": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
-      "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-permissions": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
-      "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-plans": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
-      "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_bi-events": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
-      "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_billing": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
-      "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_custom-charges": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
-      "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
-      "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_external-billing": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
-      "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
-      "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_add-ons": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_add-ons/-/@wix/auto_sdk_bookings_add-ons-1.0.34.tgz",
-      "integrity": "sha512-EXpIGSbS31CC1HSPElQ+euuEWL5UIC22+liUXNJY1xPcbWGYHw2pS5YojR2YaSZrUzpAa+w57Vo+Fgs9lvPSMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_attendance": {
-      "version": "1.0.69",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attendance/-/@wix/auto_sdk_bookings_attendance-1.0.69.tgz",
-      "integrity": "sha512-LL5J6HtOkr4ruXtN0QDav4piROYhiQeaVFc6kEiOdMkURvgl/OStdos8Y3QRqsg4gouAhbL21EgfIdQX9a7/yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_attribute-definition": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attribute-definition/-/@wix/auto_sdk_bookings_attribute-definition-1.0.8.tgz",
-      "integrity": "sha512-3J3nanMM9dO5a7abzn6+rBVzHASXmEIu/C5HH0UyESSMKKzg1gRafshhwRcLMZWG3ekAXq6vtNVh2Vhkn92peA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_attribute-value": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attribute-value/-/@wix/auto_sdk_bookings_attribute-value-1.0.9.tgz",
-      "integrity": "sha512-Mc3o/UrYkdjYykfHZ6m4Vyf0Avk6LewXsNCqN/+JNC0GA1bQW5Oj4MOAdiYfSLQrmjDLtTLxCRa2lBch18cbkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_availability-calendar": {
-      "version": "1.0.196",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-calendar/-/@wix/auto_sdk_bookings_availability-calendar-1.0.196.tgz",
-      "integrity": "sha512-EXtTMMkqJhj0hOdAykz719KXTLnzwTURl/P+uJrKHyZoE8j9ovzJKv20ATr5IbOWHA3tje9oTLivqMMqxqU99w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_availability-time-slots": {
-      "version": "1.0.265",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-time-slots/-/@wix/auto_sdk_bookings_availability-time-slots-1.0.265.tgz",
-      "integrity": "sha512-tbeYcTE6S7qWfYsiYwmHqVhQ73BUCIXDyTLj52QJUql50JiVTUkxnPbh8BmHL1WQ4hstORr4ANYAaTMYFDoXUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_availability-time-slots-configuration": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-time-slots-configuration/-/@wix/auto_sdk_bookings_availability-time-slots-configuration-1.0.9.tgz",
-      "integrity": "sha512-f+UG05ix1tOexL04EEulpH3qJEFvH7Dsj1nB8h13ov0iCuR87Pg/bSb3Zaw6MlJYNq44HRLZ/ydf0BtO4goiCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_booking-fees": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-fees/-/@wix/auto_sdk_bookings_booking-fees-1.0.57.tgz",
-      "integrity": "sha512-bdVdGD8u5EyPn0RGCJ87+I3lA5YanvbqkINrw5EIP/N+decWXoct8CVT5TND0FPsDaSmqJSoWvOFbFPHEr4JEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_booking-policies": {
-      "version": "1.0.143",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policies/-/@wix/auto_sdk_bookings_booking-policies-1.0.143.tgz",
-      "integrity": "sha512-M+mWU4KXaXYBTpno3Wxk8JwO2ksO2Hy/8x24hym0+D/FxnQa+ns6gA/zJ/wbbZyCDEcKfQoUW/41+K539hYSRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_booking-policy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policy/-/@wix/auto_sdk_bookings_booking-policy-1.0.2.tgz",
-      "integrity": "sha512-rW1U4tWLKjs90GwYTLcJcjQOX9APlkr/32t2k7ZCa+wj74NBFPyvW0lwco5DKNCktSFa3SRK2QWQbwzsdSeU+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_booking-policy-snapshots": {
-      "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policy-snapshots/-/@wix/auto_sdk_bookings_booking-policy-snapshots-1.0.52.tgz",
-      "integrity": "sha512-oCL6jlxN7PyWPNrQ4aUGWb5zp5BhS5FlTYc1Dl5+nknVw3Yub+WuZwxSyGTDdScWJ7lDlKlflU8R0ZtCmkp4wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_bookings": {
-      "version": "1.0.230",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings/-/@wix/auto_sdk_bookings_bookings-1.0.230.tgz",
-      "integrity": "sha512-ZnNH+KtdgLKfVooPdbnX2Q7gQWpfZRC32FPu4CVVGwWLashnR7/kzNjfOwiSaVwPJcNeOxcFZs4VgBPTVcFvsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_bookings-provisioner": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-provisioner/-/@wix/auto_sdk_bookings_bookings-provisioner-1.0.2.tgz",
-      "integrity": "sha512-TBjPZaF/0+G4ykoUi+wHG0fZlZYhdPO85sBB2h5dHwzDRjiRv7/+sK48bVE35tZ7yu2BVtdaP0JE0KrdvJn/Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_bookings-settings": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-settings/-/@wix/auto_sdk_bookings_bookings-settings-1.0.6.tgz",
-      "integrity": "sha512-wDyaWMK0+eLuMCPS1PMHWLiakzXQpCDOnBdHLnerHq8jG1QQyucHyUg4Wm6MyxpDlmAN/NtMoN8/SPCvjQonWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_bookings-validation": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-validation/-/@wix/auto_sdk_bookings_bookings-validation-1.0.15.tgz",
-      "integrity": "sha512-MCcfcPNOaQYnJjXy1rDduDuj/4wv0STDFzRERlQkLAU38NyGrY2X8ZiwnX/4Z7gi8BJJ4reyWi6mzv+iD4euRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_catalog-search": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_catalog-search/-/@wix/auto_sdk_bookings_catalog-search-1.0.26.tgz",
-      "integrity": "sha512-87fvruXUslg0SZ5elS0/7vpclp7Eu1pmIlEqJCmF/JAMN1JT4isA8AfkrbZhZ6ihwpzyQH2IpB0SjDsO7mDH5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_categories": {
-      "version": "1.0.58",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_categories/-/@wix/auto_sdk_bookings_categories-1.0.58.tgz",
-      "integrity": "sha512-pk7NxyGPGfu0rM7JrJIl64poKsSk+PefKRaxGx0U1VrIajiZNEoBrocNklRvrqHaq9qxoEobh7EnT0eXBK2mhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_categories-v-2": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_categories-v-2/-/@wix/auto_sdk_bookings_categories-v-2-1.0.57.tgz",
-      "integrity": "sha512-4kyacMeY02iXvWLMKvD29rr9PD6GQNKX7EsvBA5Cj9GlIA14cPdL1gBwNMuxthFY4PWLqOoR3lUSKheOLQOA9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_display-settings": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_display-settings/-/@wix/auto_sdk_bookings_display-settings-1.0.9.tgz",
-      "integrity": "sha512-C0qEdxIlq1UtONn0UR2trxmpTwbQTW/sTwBTkQjYEWMqMP2H7KwI6+z/y1qilej7SpeFUwqI6K3YxWumkkTxcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_event-time-slots": {
-      "version": "1.0.132",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_event-time-slots/-/@wix/auto_sdk_bookings_event-time-slots-1.0.132.tgz",
-      "integrity": "sha512-8zFFpuDIwWscr+xjncXvTxXXEAkgbnqyOPdp5AKkMNFMBkJwfOFDnRhBSZhCpkOg7tV0znTijnVpWe6Pj0nq3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_extended-bookings": {
-      "version": "1.0.127",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_extended-bookings/-/@wix/auto_sdk_bookings_extended-bookings-1.0.127.tgz",
-      "integrity": "sha512-nfqoqGuYHe/b/MPW6Og87DZHlnuIh1mkHUOBvivKqXOHJ3PHlhmmvs+jpckNIzs5+57gmQRHuf4kiczke/4E3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_external-calendars": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_external-calendars/-/@wix/auto_sdk_bookings_external-calendars-1.0.57.tgz",
-      "integrity": "sha512-0WVxa6xRQn5BG4MzCP66hEIrW6CVfCwcR3kG4cQCSLL8tvuaMYOw5eqvGVsCEreygWS3gZ+RLjMbN3xx0XqdkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_multi-service-availability-time-slots": {
-      "version": "1.0.258",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_multi-service-availability-time-slots/-/@wix/auto_sdk_bookings_multi-service-availability-time-slots-1.0.258.tgz",
-      "integrity": "sha512-mDarrs72rKEnwCCwIjWLaPrrB2pr8XLvLZM2jsyBbpTfiTYrqoqijh+8I9+lsqcAmeDoe/7+uPiP904XNkHyFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_pricing": {
-      "version": "1.0.101",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_pricing/-/@wix/auto_sdk_bookings_pricing-1.0.101.tgz",
-      "integrity": "sha512-GzY4HGAQhQKTdOl0btElVZjfyjcnQVaZb22ARc2Ihvqe1lK2YA9MI90sIlECpkEKvuT5ZNzcK9jifeR5JWMekw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_pricing-provider": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_pricing-provider/-/@wix/auto_sdk_bookings_pricing-provider-1.0.29.tgz",
-      "integrity": "sha512-VDcdqL8Ar2pk9pltT8F452AnW9gu/AoM23YVq9NSxInycBmlTB4OkY8GgTklvUZBpXjnReBoOypTfM4LgYcLSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_related-products": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_related-products/-/@wix/auto_sdk_bookings_related-products-1.0.2.tgz",
-      "integrity": "sha512-BYEUBvLQJ2WKk58ThsEmrY/7WfRr0wA2VfjNgBXG/MP18LfL7zN/NVdRkV6guM5u2cWVIBRawp8W2fwoUO//UA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_resource-types": {
-      "version": "1.0.82",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_resource-types/-/@wix/auto_sdk_bookings_resource-types-1.0.82.tgz",
-      "integrity": "sha512-UJ6G9sf0Ruy+slAfEslP8LdJlYYnAwi91dOM/ewOfqq/Jvz8hVgGSqAl5if0EZfSqXpDBv4unsQUx2iuKbbJQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_resources": {
-      "version": "1.0.89",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_resources/-/@wix/auto_sdk_bookings_resources-1.0.89.tgz",
-      "integrity": "sha512-AZg9m5QEVDG5EgLktvQg5K6ep8FoJZR5v3w2hAmlzDRS4klxOZ1BgU+z0gHhy39keWLSYAk59sj/mnPR8pkyxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_service-options-and-variants": {
-      "version": "1.0.90",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_service-options-and-variants/-/@wix/auto_sdk_bookings_service-options-and-variants-1.0.90.tgz",
-      "integrity": "sha512-T6MYlSc0XTqQ6G6ARzXqonIFEgETozmcasJka6KH3MoLgMbtMcvJ956TfsoIa2nEEXdIxD2kGn++DFqw+tQVWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_services": {
-      "version": "1.0.277",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_services/-/@wix/auto_sdk_bookings_services-1.0.277.tgz",
-      "integrity": "sha512-+l+hZmbdDVT2ebARbYB09ok9srTrHAM1TozcKVmDanUSPf02UfHqy4XgqD+siejLrVuBz+7yqmRH9hAKyB/wMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_staff-member-settings": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-member-settings/-/@wix/auto_sdk_bookings_staff-member-settings-1.0.22.tgz",
-      "integrity": "sha512-Km7n6xz9Q1CCAomdiEit2bwEOtKKBXqXEpQ3YTy2SS4Gi6tfvn11xX/J/OQ5dx4ZG9vjxsB4S4VCWa8JA3Vcfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_staff-members": {
-      "version": "1.0.126",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-members/-/@wix/auto_sdk_bookings_staff-members-1.0.126.tgz",
-      "integrity": "sha512-Ovjy8l7aQX3Ke74gpArGwG4voU/5FbWrppPugSzhNcfapd8KLQmPax8ZI6VCVvFaO6yWrylabguIdI7hszHFtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_staff-sorting": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-sorting/-/@wix/auto_sdk_bookings_staff-sorting-1.0.7.tgz",
-      "integrity": "sha512-lo0bmVUDCFolFWiBAU44yBG2RZmcmn6xr8bMx1YQOIYZAbgfLuqueURi6cpIJh2CW6f3Fu4GQnGEzWdBhXJfVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_time-slots-configuration": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_time-slots-configuration/-/@wix/auto_sdk_bookings_time-slots-configuration-1.0.6.tgz",
-      "integrity": "sha512-0diduZHwtRQqZ7bK09fzAE78V4deyOpORYZy31iObsU3lrtU0xKrZhVkCtKw7x5mr4GXksAauFWa1E2FxRly0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
-      "version": "1.0.192",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/@wix/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
-      "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_chat-settings": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_chat-settings/-/@wix/auto_sdk_forms_chat-settings-1.0.27.tgz",
-      "integrity": "sha512-xCXsDzVnRqf2X7FKYl0TCweL75eCkZk4v3DRGVoB6/I2OWze3Jh4wKp/No1ZorvTIK/kfqRURqrl45xlw+ACpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_form-spam-submission-reports": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-spam-submission-reports/-/@wix/auto_sdk_forms_form-spam-submission-reports-1.0.42.tgz",
-      "integrity": "sha512-o+m2UkldVgTxmR/QB1P6Ho0B7A/WO+KUOW2Ryp7o5GvuQNtjvIAbJQVEwVkTMcDTsWbkhZhws5P3ZId10ptYGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_form-submissions": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-submissions/-/@wix/auto_sdk_forms_form-submissions-1.0.25.tgz",
-      "integrity": "sha512-t7DkTvX6ZIvu2xSuv2KnqDrBzeNFJxqBitgh9mm1Rx71KG7qTsOwb2vENKBPq/jz1z4K1W2McHrSm3DQe5vJvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_forms": {
-      "version": "1.0.135",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_forms/-/@wix/auto_sdk_forms_forms-1.0.135.tgz",
-      "integrity": "sha512-5bLRkFzj+0lEr7cO1w257ZQK2tS3aLkYX5QaQJtuHKjveEHlM0vw6ppBBwInC21j5iVa8QuFW/J2Tw9xRvQ05Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_interactive-form-sessions": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_interactive-form-sessions/-/@wix/auto_sdk_forms_interactive-form-sessions-1.0.80.tgz",
-      "integrity": "sha512-15f0e/olrKlOIOoAK1JE+wwD0IKfTwpRbczPBeDiLUsZC/D69XUTzKZRM3ZF9B19Wd5sT7ztzOOt77JDojSknw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_forms_submissions": {
-      "version": "1.0.154",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_submissions/-/@wix/auto_sdk_forms_submissions-1.0.154.tgz",
-      "integrity": "sha512-uE5UFW/bIHVJLfjdNha9n7lW6SsPmW+NwvqXZbUtCmNsya32yEC4qx2l+pqZ4tQdSgEFGaRyi6N2pAqwkB6lnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
-      "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_authentication": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
-      "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_oauth": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
-      "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_recovery": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
-      "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
-      "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_verification": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
-      "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
-      "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
-      "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_files": {
-      "version": "1.0.96",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.96.tgz",
-      "integrity": "sha512-KrPyTF319c/EKKbVA+89xPXhQ1MBl5ShR41OPmiFhRyhbILWe7dRIn/5dgBhopsKj5mBw50SuA5bXeHrntv8Yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_folders": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
-      "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_redirects_redirects": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
-      "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
-      "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_llms-txt": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
-      "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_redirects": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
-      "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_robots-txt": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
-      "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-patterns": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
-      "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
-      "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-tags": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
-      "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
-      "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/bookings": {
-      "version": "1.0.1650",
-      "resolved": "https://registry.npmjs.org/@wix/bookings/-/@wix/bookings-1.0.1650.tgz",
-      "integrity": "sha512-1HdXd3U9CvVZtb4oZNCpBwFpogdtl67zY/rE4rP4H0RbE42+SVjCvVwcxZpe+9quqj3UPx/ANu8MbgHXcERmbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_bookings_add-ons": "1.0.34",
-        "@wix/auto_sdk_bookings_attendance": "1.0.69",
-        "@wix/auto_sdk_bookings_attribute-definition": "1.0.8",
-        "@wix/auto_sdk_bookings_attribute-value": "1.0.9",
-        "@wix/auto_sdk_bookings_availability-calendar": "1.0.196",
-        "@wix/auto_sdk_bookings_availability-time-slots": "1.0.265",
-        "@wix/auto_sdk_bookings_availability-time-slots-configuration": "1.0.9",
-        "@wix/auto_sdk_bookings_booking-fees": "1.0.57",
-        "@wix/auto_sdk_bookings_booking-policies": "1.0.143",
-        "@wix/auto_sdk_bookings_booking-policy": "1.0.2",
-        "@wix/auto_sdk_bookings_booking-policy-snapshots": "1.0.52",
-        "@wix/auto_sdk_bookings_bookings": "1.0.230",
-        "@wix/auto_sdk_bookings_bookings-provisioner": "1.0.2",
-        "@wix/auto_sdk_bookings_bookings-settings": "1.0.6",
-        "@wix/auto_sdk_bookings_bookings-validation": "1.0.15",
-        "@wix/auto_sdk_bookings_catalog-search": "1.0.26",
-        "@wix/auto_sdk_bookings_categories": "1.0.58",
-        "@wix/auto_sdk_bookings_categories-v-2": "1.0.57",
-        "@wix/auto_sdk_bookings_display-settings": "1.0.9",
-        "@wix/auto_sdk_bookings_event-time-slots": "1.0.132",
-        "@wix/auto_sdk_bookings_extended-bookings": "1.0.127",
-        "@wix/auto_sdk_bookings_external-calendars": "1.0.57",
-        "@wix/auto_sdk_bookings_multi-service-availability-time-slots": "1.0.258",
-        "@wix/auto_sdk_bookings_pricing": "1.0.101",
-        "@wix/auto_sdk_bookings_pricing-provider": "1.0.29",
-        "@wix/auto_sdk_bookings_related-products": "1.0.2",
-        "@wix/auto_sdk_bookings_resource-types": "1.0.82",
-        "@wix/auto_sdk_bookings_resources": "1.0.89",
-        "@wix/auto_sdk_bookings_service-options-and-variants": "1.0.90",
-        "@wix/auto_sdk_bookings_services": "1.0.277",
-        "@wix/auto_sdk_bookings_staff-member-settings": "1.0.22",
-        "@wix/auto_sdk_bookings_staff-members": "1.0.126",
-        "@wix/auto_sdk_bookings_staff-sorting": "1.0.7",
-        "@wix/auto_sdk_bookings_time-slots-configuration": "1.0.6",
-        "@wix/bookings_app-extensions": "1.0.106",
-        "@wix/headless-bookings": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/bookings_app-extensions": {
-      "version": "1.0.106",
-      "resolved": "https://registry.npmjs.org/@wix/bookings_app-extensions/-/@wix/bookings_app-extensions-1.0.106.tgz",
-      "integrity": "sha512-IyfO8duvbu9zd6uTCJM0hFLY+QtcvX03PnInnslUYWaymLDr/VvsZ5TUh3fVD9fB+iwaeXmZBppM3xexnFi1fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/cli": {
-      "version": "1.1.239",
-      "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
-      "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
-      "dev": true,
-      "dependencies": {
-        "@wix/agent-skills": "^1.1.0",
-        "node-gyp": "^8.4.1"
-      },
-      "bin": {
-        "wix": "bin/wix.cjs"
-      },
-      "engines": {
-        "node": ">= 20.11.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@wix/communication-channel": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
-      "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "comlink": "4.3.0"
-      }
-    },
-    "node_modules/@wix/consent-policy-manager": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
-      "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
-      "license": "MIT"
-    },
-    "node_modules/@wix/credits-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
-      "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      }
-    },
-    "node_modules/@wix/dashboard": {
-      "version": "1.3.47",
-      "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
-      "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/communication-channel": "1.0.10",
-        "@wix/feedback-loop-structure": "^1.34.0",
-        "@wix/media": "^1.0.249",
-        "@wix/monitoring-browser-sdk-host": "^0.1.27",
-        "@wix/sdk-runtime": "^0.3.62",
-        "@wix/sdk-types": "^1.17.8",
-        "@wix/workspace": "^1.3.14",
-        "zustand": "^4.5.0"
-      },
-      "peerDependencies": {
-        "@wix/sdk": ">=1.12.4",
-        "react": "^16.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@wix/sdk": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
-      "version": "0.3.62",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
-      "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "^1.13.41"
-      }
-    },
-    "node_modules/@wix/editor": {
-      "version": "1.785.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.785.0.tgz",
-      "integrity": "sha512-2gjp52CPDm0NyHmOeSshY8JB8d9cZSim+wLhEtywvonapYmhMUYpk3apg5Y6Nq9EkkQKV78h3VBldbG89bA6zQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/editor-platform-environment-api": "1.161.0",
-        "@wix/monitoring-browser-sdk-host": "^0.1.25",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0",
-        "@wix/sdk-runtime": "^0.7.0",
-        "@wix/sdk-types": "^1.17.11",
-        "@wix/workspace": "^1.3.18"
-      }
-    },
-    "node_modules/@wix/editor-application": {
-      "version": "1.473.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.473.0.tgz",
-      "integrity": "sha512-uMfBLWBF/XBcw5uZcn9Uwng+iQEfm+dWI34DfSgWuy52FrpnFrCiIxZpO/bKMK0lBGzvy6WGIVj9Sbzrd6iLjg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-contexts": {
-      "version": "1.160.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.160.0.tgz",
-      "integrity": "sha512-5nBLeqPsWELDJECxcXVbsTm+uTI8W15e46Mi8wvm8i7SM87RfsOB0BY5kIIP33rfMFyBrZS2NJiRAGO9IzadZQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-transport": "1.15.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-environment-api": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.161.0.tgz",
-      "integrity": "sha512-hjUr8xmqDij0bKCKp2VPCfajz8Wj2JAeDL2ez9pcgtoPhtuPixaSRzrTNegK8Kk+p6sitLlhPxtOEi6FCsBtlw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-application": "1.473.0",
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/editor-platform-transport": "1.15.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-transport": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
-      "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
-      "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.14.0"
-      }
-    },
-    "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
-      "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler-types": "^1.19.0",
-        "@wix/monitoring-types": "^0.12.0",
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/error-handler-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
-      "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-types": "1.20.0"
-      }
-    },
-    "node_modules/@wix/error-handler-types": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
-      "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      }
-    },
-    "node_modules/@wix/essentials": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
-      "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler": "^1.67.0",
-        "@wix/monitoring": "^0.21.0",
-        "@wix/multilingual-manager": "^1.2.0",
-        "@wix/sdk-runtime": "1.0.22",
-        "@wix/sdk-types": "1.17.11",
-        "i18next": "^25.6.3",
-        "i18next-icu": "^2.4.1",
-        "intl-messageformat": "^10.7.18",
-        "react-i18next": "^16.1.2"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
-      "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-core": "1.20.0",
-        "events": "^3.3.0",
-        "http-status-codes": "^2.3.0",
-        "uuid": "^11.0.3"
-      },
-      "peerDependencies": {
-        "@wix/fe-essentials": "^1.233.0",
-        "i18next": ">=19.9.2",
-        "i18next-icu": ">=2.3.0",
-        "intl-messageformat": ">=7.8.4"
-      },
-      "peerDependenciesMeta": {
-        "@wix/fe-essentials": {
-          "optional": true
-        },
-        "i18next": {
-          "optional": true
-        },
-        "i18next-icu": {
-          "optional": true
-        },
-        "intl-messageformat": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
-      "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/feedback-loop-structure": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
-      "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@wix/form-public": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/@wix/form-public/-/@wix/form-public-0.145.0.tgz",
-      "integrity": "sha512-y/K5nWdM0x5oNQHFBgk5b4jtx7Jitu+kDHTbJ4lqFuYQaroekBrAcH2mOqDQB30cXwBMCz+wjtyAWdHOYDPwBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/essentials": "^0.1.28",
-        "i18next": "^19.9.2",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.mapkeys": "^4.6.0",
-        "react-i18next": "^11.18.6"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/@wix/essentials": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
-      "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler": "^1.67.0",
-        "@wix/monitoring": "^0.21.0",
-        "@wix/sdk-runtime": "^0.3.62",
-        "@wix/sdk-types": "^1.13.41",
-        "i18next": "^25.3.2",
-        "i18next-icu": "^2.3.0",
-        "intl-messageformat": "^10.7.16"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
-      "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-core": "1.20.0",
-        "events": "^3.3.0",
-        "http-status-codes": "^2.3.0",
-        "uuid": "^11.0.3"
-      },
-      "peerDependencies": {
-        "@wix/fe-essentials": "^1.233.0",
-        "i18next": ">=19.9.2",
-        "i18next-icu": ">=2.3.0",
-        "intl-messageformat": ">=7.8.4"
-      },
-      "peerDependenciesMeta": {
-        "@wix/fe-essentials": {
-          "optional": true
-        },
-        "i18next": {
-          "optional": true
-        },
-        "i18next-icu": {
-          "optional": true
-        },
-        "intl-messageformat": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://www.locize.com/i18next"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.locize.com"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/@wix/sdk-runtime": {
-      "version": "0.3.62",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
-      "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "^1.13.41"
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/i18next": {
-      "version": "19.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
-      "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0"
-      }
-    },
-    "node_modules/@wix/form-public/node_modules/react-i18next": {
-      "version": "11.18.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
-      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.14.5",
-        "html-parse-stringify": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": ">= 19.0.0",
-        "react": ">= 16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/forms": {
-      "version": "1.0.500",
-      "resolved": "https://registry.npmjs.org/@wix/forms/-/@wix/forms-1.0.500.tgz",
-      "integrity": "sha512-Vrc6Ld6i5TkePv9j263Oz8CWwcaiKlNl2E5APt8dXvM1fPYByNTuAIcwk0nKt26WN9P8dYgh2u41wzgP6jOH9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_forms_chat-settings": "1.0.27",
-        "@wix/auto_sdk_forms_form-spam-submission-reports": "1.0.42",
-        "@wix/auto_sdk_forms_form-submissions": "1.0.25",
-        "@wix/auto_sdk_forms_forms": "1.0.135",
-        "@wix/auto_sdk_forms_interactive-form-sessions": "1.0.80",
-        "@wix/auto_sdk_forms_submissions": "1.0.154",
-        "@wix/headless-forms": "0.0.45"
-      }
-    },
-    "node_modules/@wix/headless-bookings": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@wix/headless-bookings/-/@wix/headless-bookings-1.0.18.tgz",
-      "integrity": "sha512-XBWu8m6kFMZc4zkNms45nK3wT0a8nNOglc6+d7vr9/FdMVdB/Vlm9HAsGAbUKJQjBUte5t1wc86qudGV0yEDSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_bookings_availability-time-slots": "^1.0.244",
-        "@wix/auto_sdk_bookings_bookings": "^1.0.192",
-        "@wix/auto_sdk_bookings_catalog-search": "^1.0.2",
-        "@wix/auto_sdk_bookings_event-time-slots": "^1.0.112",
-        "@wix/auto_sdk_bookings_pricing": "^1.0.87",
-        "@wix/auto_sdk_bookings_services": "^1.0.265",
-        "@wix/auto_sdk_ecom_cart-v-2": "^1.0.86",
-        "@wix/forms": "^1.0.384",
-        "@wix/headless-media": "0.0.25",
-        "@wix/headless-utils": "0.0.12",
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3",
-        "date-fns": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@wix/headless-components": "^0.0.0",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@wix/headless-components": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
-      "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-select": "^2.2.6",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-toggle-group": "^1.1.11",
-        "@wix/headless-utils": "0.0.0"
-      }
-    },
-    "node_modules/@wix/headless-components/node_modules/@wix/headless-utils": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
-      "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@wix/headless-forms": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/@wix/headless-forms-0.0.45.tgz",
-      "integrity": "sha512-I/uXQlR6r7af7iWm5E4xXICXaUbqGmTziApXDlxlMeTOP+zqUyTFSXWcUL4uT683yRfcXH46jog4f8e2NVSHsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/form-public": "^0.145.0",
-        "@wix/forms": "^1.0.399",
-        "@wix/headless-utils": "0.0.12",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3",
-        "react-aria-components": "^1.13.0"
-      }
-    },
-    "node_modules/@wix/headless-localization-utils": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
-      "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/headless-node": "^1.42.0",
-        "@wix/headless-site-assets": "^1.0.9"
-      }
-    },
-    "node_modules/@wix/headless-media": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
-      "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk": "^1.17.1",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/headless-node": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
-      "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/monitoring-velo": "^1.31.0",
-        "@wix/sdk-runtime": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/headless-seo": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
-      "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/seo": "^1.0.14",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/headless-site": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
-      "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/monitoring-velo": "^1.31.0",
-        "@wix/sdk-runtime": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/headless-site-assets": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
-      "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
-      }
-    },
-    "node_modules/@wix/headless-utils": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.12.tgz",
-      "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@wix/identity": {
-      "version": "1.0.230",
-      "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
-      "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_identity_authentication": "1.0.57",
-        "@wix/auto_sdk_identity_oauth": "1.0.53",
-        "@wix/auto_sdk_identity_recovery": "1.0.46",
-        "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
-        "@wix/auto_sdk_identity_verification": "1.0.48"
-      }
-    },
-    "node_modules/@wix/image-kit": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
-      "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@wix/media": {
-      "version": "1.0.271",
-      "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.271.tgz",
-      "integrity": "sha512-Ci/qsi/qouoC9NqIwwgiEvcRxk9xJugivsk59wPRDb0h/kQDAs9Jc8R06bgBPAC8ja3+frRMnBXTrVo2+bmaqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
-        "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
-        "@wix/auto_sdk_media_files": "1.0.96",
-        "@wix/auto_sdk_media_folders": "1.0.57",
-        "@wix/headless-media": "^0.0.25"
-      }
-    },
-    "node_modules/@wix/monitoring": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
-      "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.12.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
-      "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common-sentry": "0.2.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
-      "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-browser-panorama": "0.10.0",
-        "@wix/monitoring-browser-sentry": "0.26.0",
-        "@wix/monitoring-types": "0.17.0",
-        "@wix/monitoring-velo": "1.29.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
-      "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common": "1.13.0",
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
-      "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common-sentry": "0.2.0",
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-common": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
-      "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-common-sentry": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
-      "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
-      "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-velo": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
-      "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.1.0",
-        "@wix/monitoring-common": "1.13.0",
-        "@wix/monitoring-types": "1.0.0"
-      }
-    },
-    "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
-      "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "1.0.0"
-      }
-    },
-    "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
-      "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/multilingual-manager": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
-      "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/headless-localization-utils": "^1.0.11",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@wix/public-editor-platform-errors": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
-      "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/public-editor-platform-events": {
-      "version": "1.394.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.394.0.tgz",
-      "integrity": "sha512-yHxIbhSpHZE8CIPoYonUrkNVDzDRYT36Ssb3HIJ8b1OZRhdtcjF1HNP+okdTVW+mBBiyXjGFNqfe1LWM0R6GDg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/public-editor-platform-interfaces": {
-      "version": "1.103.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.103.0.tgz",
-      "integrity": "sha512-iWupfV581sAgrCd8UyWrlakRNHhjfEeH0tluwVBbD+OEoybKs58c4xLEAw2N4A+VzzRVcwOIk+b6hdF4wI6wjw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/app-extensions": "^1.0.131",
-        "@wix/sdk-types": "^1.17.11"
-      }
-    },
-    "node_modules/@wix/react-component-schema": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
-      "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
-      "license": "ISC"
-    },
-    "node_modules/@wix/redirects": {
-      "version": "1.0.125",
-      "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
-      "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_redirects_redirects": "1.0.53"
-      }
-    },
-    "node_modules/@wix/sdk": {
-      "version": "1.21.16",
-      "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
-      "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/identity": "^1.0.204",
-        "@wix/image-kit": "^1.114.0",
-        "@wix/redirects": "^1.0.70",
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-runtime": "1.0.22",
-        "@wix/sdk-types": "1.17.11",
-        "jose": "^5.10.0",
-        "type-fest": "^4.41.0"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/sdk-context": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
-      "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/sdk-react-context": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
-      "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
-      "license": "UNLICENSED",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@wix/sdk-runtime": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
-      "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/sdk-types": {
-      "version": "1.17.11",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
-      "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler-types": "^1.19.0",
-        "@wix/monitoring-types": "^0.12.0",
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
-      "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/seo": {
-      "version": "1.0.79",
-      "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
-      "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
-        "@wix/auto_sdk_seo_llms-txt": "1.0.0",
-        "@wix/auto_sdk_seo_redirects": "1.0.2",
-        "@wix/auto_sdk_seo_robots-txt": "1.0.21",
-        "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
-        "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
-        "@wix/auto_sdk_seo_seo-tags": "1.0.28",
-        "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
-        "@wix/headless-seo": "^0.0.16"
-      }
-    },
-    "node_modules/@wix/services-definitions": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
-      "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
-      "dependencies": {
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/services-manager": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
-      "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
-      "peer": true,
-      "dependencies": {
-        "@preact/signals-core": "^1.12.1",
-        "@wix/sdk-context": "0.0.1",
-        "@wix/services-definitions": "1.0.5"
-      }
-    },
-    "node_modules/@wix/services-manager-react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
-      "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-react": "^3.6.1",
-        "@wix/sdk-react-context": "1.0.2",
-        "@wix/services-definitions": "1.0.5"
-      },
-      "peerDependencies": {
-        "@wix/services-manager": "^1.0.0",
-        "react": "^16.14.0 || 17.x || 18.x || 19.x",
-        "react-dom": "^18.3.1",
-        "use-sync-external-store": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/site": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
-      "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/analytics": "1.19.0",
-        "@wix/authentication": "1.16.0",
-        "@wix/consent-policy-manager": "1.15.0",
-        "@wix/multilingual-manager": "1.11.0",
-        "@wix/sdk-types": "^1.13.2"
-      }
-    },
-    "node_modules/@wix/workspace": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
-      "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/credits-types": "^1.0.3",
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11"
-      },
-      "peerDependencies": {
-        "@wix/sdk": "^1.21.3"
-      }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/array-iterate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
-      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/astro": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
-      "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/compiler": "^2.13.0",
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/markdown-remark": "6.3.11",
-        "@astrojs/telemetry": "3.3.0",
-        "@capsizecss/unpack": "^4.0.0",
-        "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.3.0",
-        "acorn": "^8.15.0",
-        "aria-query": "^5.3.2",
-        "axobject-query": "^4.1.0",
-        "boxen": "8.0.1",
-        "ci-info": "^4.3.1",
-        "clsx": "^2.1.1",
-        "common-ancestor-path": "^1.0.1",
-        "cookie": "^1.1.1",
-        "cssesc": "^3.0.0",
-        "debug": "^4.4.3",
-        "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.6.2",
-        "diff": "^8.0.3",
-        "dlv": "^1.1.3",
-        "dset": "^3.1.4",
-        "es-module-lexer": "^1.7.0",
-        "esbuild": "^0.27.3",
-        "estree-walker": "^3.0.3",
-        "flattie": "^1.1.1",
-        "fontace": "~0.4.0",
-        "github-slugger": "^2.0.0",
-        "html-escaper": "3.0.3",
-        "http-cache-semantics": "^4.2.0",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
-        "magic-string": "^0.30.21",
-        "magicast": "^0.5.1",
-        "mrmime": "^2.0.1",
-        "neotraverse": "^0.6.18",
-        "p-limit": "^6.2.0",
-        "p-queue": "^8.1.1",
-        "package-manager-detector": "^1.6.0",
-        "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
-        "prompts": "^2.4.2",
-        "rehype": "^13.0.2",
-        "semver": "^7.7.3",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tsconfck": "^3.1.6",
-        "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.3",
-        "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.17.4",
-        "vfile": "^6.0.3",
-        "vite": "^6.4.1",
-        "vitefu": "^1.1.1",
-        "xxhash-wasm": "^1.1.0",
-        "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.2.3",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.25.1",
-        "zod-to-ts": "^1.2.0"
-      },
-      "bin": {
-        "astro": "astro.js"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/astrodotbuild"
-      },
-      "optionalDependencies": {
-        "sharp": "^0.34.0"
-      }
-    },
-    "node_modules/astro/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/astro/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/astro/node_modules/unstorage": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
-      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^3.1.3",
-        "chokidar": "^5.0.0",
-        "destr": "^2.0.5",
-        "h3": "^1.15.10",
-        "lru-cache": "^11.2.7",
-        "node-fetch-native": "^1.6.7",
-        "ofetch": "^1.5.1",
-        "ufo": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@azure/app-configuration": "^1.8.0",
-        "@azure/cosmos": "^4.2.0",
-        "@azure/data-tables": "^13.3.0",
-        "@azure/identity": "^4.6.0",
-        "@azure/keyvault-secrets": "^4.9.0",
-        "@azure/storage-blob": "^12.26.0",
-        "@capacitor/preferences": "^6 || ^7 || ^8",
-        "@deno/kv": ">=0.9.0",
-        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
-        "@planetscale/database": "^1.19.0",
-        "@upstash/redis": "^1.34.3",
-        "@vercel/blob": ">=0.27.1",
-        "@vercel/functions": "^2.2.12 || ^3.0.0",
-        "@vercel/kv": "^1 || ^2 || ^3",
-        "aws4fetch": "^1.0.20",
-        "db0": ">=0.2.1",
-        "idb-keyval": "^6.2.1",
-        "ioredis": "^5.4.2",
-        "uploadthing": "^7.4.4"
-      },
-      "peerDependenciesMeta": {
-        "@azure/app-configuration": {
-          "optional": true
-        },
-        "@azure/cosmos": {
-          "optional": true
-        },
-        "@azure/data-tables": {
-          "optional": true
-        },
-        "@azure/identity": {
-          "optional": true
-        },
-        "@azure/keyvault-secrets": {
-          "optional": true
-        },
-        "@azure/storage-blob": {
-          "optional": true
-        },
-        "@capacitor/preferences": {
-          "optional": true
-        },
-        "@deno/kv": {
-          "optional": true
-        },
-        "@netlify/blobs": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/blob": {
-          "optional": true
-        },
-        "@vercel/functions": {
-          "optional": true
-        },
-        "@vercel/kv": {
-          "optional": true
-        },
-        "aws4fetch": {
-          "optional": true
-        },
-        "db0": {
-          "optional": true
-        },
-        "idb-keyval": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        },
-        "uploadthing": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/astro/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/astro/node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/bail": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.11.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/blake3-wasm": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
-    },
-    "node_modules/boxen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^8.0.0",
-        "chalk": "^5.3.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^7.2.0",
-        "type-fest": "^4.21.0",
-        "widest-line": "^5.0.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/camelcase": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT"
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/comlink": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
-      "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-      "license": "ISC"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cookie-es": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
-      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
-      "license": "MIT"
-    },
-    "node_modules/crossws": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
-    },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "license": "MIT"
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/destr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/deterministic-object-hash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/devalue": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
-      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
-      "license": "MIT"
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.405",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
-      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.24.5",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
-      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/error-stack-parser-es": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
-      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/flattie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
-      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fontace": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
-      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
-      "license": "MIT",
-      "dependencies": {
-        "fontkitten": "^1.0.2"
-      }
-    },
-    "node_modules/fontkitten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
-      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-inflate": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/graphql": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
-      "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
-      }
-    },
-    "node_modules/h3": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
-      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie-es": "^1.2.3",
-        "crossws": "^0.3.5",
-        "defu": "^6.1.6",
-        "destr": "^2.0.5",
-        "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.4",
-        "radix3": "^1.1.2",
-        "ufo": "^1.6.3",
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "hast-util-to-parse5": "^8.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "parse5": "^7.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-text": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unist-util-find-after": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "license": "MIT"
-    },
-    "node_modules/html-parse-stringify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
-      "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "license": "MIT"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://www.locize.com/i18next"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.locize.com"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/i18next-icu": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
-      "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "intl-messageformat": ">=10.3.3 <12.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/intl-messageformat": {
-      "version": "10.7.18",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
-      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/iron-webcrypto": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
-      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/brc-dd"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.mapkeys": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
-      "integrity": "sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA==",
-      "license": "MIT"
-    },
-    "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
-      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mdast-util-definitions": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
-      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/micromark": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-destination": "^2.0.0",
-        "micromark-factory-label": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-title": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-html-tag-name": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/miniflare": {
-      "version": "4.20260114.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
-      "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.14.0",
-        "workerd": "1.20260114.0",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10",
-        "zod": "^3.25.76"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
-    "node_modules/miniflare/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/nlcst-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
-      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "license": "MIT"
-    },
-    "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-mock-http": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
-      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
-      "license": "MIT"
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
-      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/ofetch": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
-      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
-      "license": "MIT",
-      "dependencies": {
-        "destr": "^2.0.5",
-        "node-fetch-native": "^1.6.7",
-        "ufo": "^1.6.1"
-      }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "license": "MIT"
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/oniguruma-parser": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
-      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
-      "license": "MIT"
-    },
-    "node_modules/oniguruma-to-es": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
-      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
-      "license": "MIT",
-      "dependencies": {
-        "oniguruma-parser": "^0.12.2",
-        "regex": "^6.1.0",
-        "regex-recursion": "^6.0.2"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-manager-detector": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-      "license": "MIT"
-    },
-    "node_modules/parse-latin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
-      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "@types/unist": "^3.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unist-util-modify-children": "^4.0.0",
-        "unist-util-visit-children": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/piccolore": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
-      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
-      "license": "ISC"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/property-information": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
-      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/radix3": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
-      "license": "MIT"
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-aria": {
-      "version": "3.51.0",
-      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
-      "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.12.3",
-        "@internationalized/number": "^3.6.7",
-        "@internationalized/string": "^3.2.10",
-        "@react-types/shared": "^3.36.1",
-        "@swc/helpers": "^0.5.0",
-        "aria-hidden": "^1.2.3",
-        "clsx": "^2.0.0",
-        "react-stately": "3.49.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-aria-components": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.20.0.tgz",
-      "integrity": "sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.12.3",
-        "@internationalized/string": "^3.2.10",
-        "@react-types/shared": "^3.36.1",
-        "@swc/helpers": "^0.5.0",
-        "client-only": "^0.0.1",
-        "react-aria": "3.51.0",
-        "react-stately": "3.49.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-i18next": {
-      "version": "16.6.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "html-parse-stringify": "^3.0.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "i18next": ">= 25.10.9",
-        "react": ">= 16.8.0",
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-stately": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
-      "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.12.3",
-        "@internationalized/number": "^3.6.7",
-        "@internationalized/string": "^3.2.10",
-        "@react-types/shared": "^3.36.1",
-        "@swc/helpers": "^0.5.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
-      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "license": "MIT"
-    },
-    "node_modules/rehype": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "rehype-parse": "^9.0.0",
-        "rehype-stringify": "^10.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-raw": "^9.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-stringify": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-gfm": "^3.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-smartypants": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
-      "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
-      "license": "MIT",
-      "dependencies": {
-        "retext": "^9.0.0",
-        "retext-smartypants": "^6.0.0",
-        "unified": "^11.0.4",
-        "unist-util-visit": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
-      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "retext-latin": "^4.0.0",
-        "retext-stringify": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-latin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
-      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "parse-latin": "^7.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-smartypants": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
-      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-stringify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
-      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
-      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.9"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
-        "@rollup/rollup-android-arm-eabi": "4.62.4",
-        "@rollup/rollup-android-arm64": "4.62.4",
-        "@rollup/rollup-darwin-arm64": "4.62.4",
-        "@rollup/rollup-darwin-x64": "4.62.4",
-        "@rollup/rollup-freebsd-arm64": "4.62.4",
-        "@rollup/rollup-freebsd-x64": "4.62.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
-        "@rollup/rollup-linux-arm64-musl": "4.62.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
-        "@rollup/rollup-linux-loong64-musl": "4.62.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-musl": "4.62.4",
-        "@rollup/rollup-openbsd-x64": "4.62.4",
-        "@rollup/rollup-openharmony-arm64": "4.62.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
-        "@rollup/rollup-win32-x64-gnu": "4.62.4",
-        "@rollup/rollup-win32-x64-msvc": "4.62.4",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/sax": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
-      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "license": "MIT"
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/smol-toml": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
-      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^11.1.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
-      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trough": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-      "license": "MIT"
-    },
-    "node_modules/ultrahtml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
-      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
-      "license": "MIT"
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/unenv": {
-      "version": "2.0.0-rc.24",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
-      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/unified": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "bail": "^2.0.0",
-        "devlop": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unifont": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
-      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.1.0",
-        "ohash": "^2.0.11",
-        "undici": "^8.0.0"
-      }
-    },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/unist-util-find-after": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-modify-children": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
-      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "array-iterate": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-children": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
-      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
-      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vite": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
-      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/vitefu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
-      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
-      "license": "MIT",
-      "workspaces": [
-        "tests/deps/*",
-        "tests/projects/*",
-        "tests/projects/workspace/packages/*"
-      ],
-      "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/workerd": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
-      "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260114.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
-        "@cloudflare/workerd-linux-64": "1.20260114.0",
-        "@cloudflare/workerd-linux-arm64": "1.20260114.0",
-        "@cloudflare/workerd-windows-64": "1.20260114.0"
-      }
-    },
-    "node_modules/wrangler": {
-      "version": "4.59.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
-      "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.10.0",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.0",
-        "miniflare": "4.20260114.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260114.0"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260114.0"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xxhash-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-      "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yocto-spinner": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-      "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.19"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
-      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/youch": {
-      "version": "4.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
-      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@poppinss/dumper": "^0.6.4",
-        "@speed-highlight/core": "^1.2.7",
-        "cookie": "^1.0.2",
-        "youch-core": "^0.3.3"
-      }
-    },
-    "node_modules/youch-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
-      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/exception": "^1.2.2",
-        "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
+ "name": "wix-astro-blank",
+ "version": "0.0.1",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-astro-blank",
+   "version": "0.0.1",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/auto_sdk_ecom_cart-v-2": "^1.0.192",
+    "@wix/bookings": "^1.0.1650",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/essentials": "^1.0.6",
+    "@wix/forms": "^1.0.500",
+    "@wix/redirects": "^1.0.125",
+    "@wix/sdk": "^1.21.5",
+    "@wix/seo": "^1.0.79",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
     }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@internationalized/date": {
+   "version": "3.12.3",
+   "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+   "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/number": {
+   "version": "3.6.7",
+   "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+   "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@internationalized/string": {
+   "version": "3.2.10",
+   "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+   "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@react-types/shared": {
+   "version": "3.36.1",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+   "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+   "license": "Apache-2.0",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@swc/helpers": {
+   "version": "0.5.23",
+   "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+   "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_add-ons": {
+   "version": "1.0.34",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_add-ons/-/auto_sdk_bookings_add-ons-1.0.34.tgz",
+   "integrity": "sha512-EXpIGSbS31CC1HSPElQ+euuEWL5UIC22+liUXNJY1xPcbWGYHw2pS5YojR2YaSZrUzpAa+w57Vo+Fgs9lvPSMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_attendance": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attendance/-/auto_sdk_bookings_attendance-1.0.69.tgz",
+   "integrity": "sha512-LL5J6HtOkr4ruXtN0QDav4piROYhiQeaVFc6kEiOdMkURvgl/OStdos8Y3QRqsg4gouAhbL21EgfIdQX9a7/yw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_attribute-definition": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attribute-definition/-/auto_sdk_bookings_attribute-definition-1.0.8.tgz",
+   "integrity": "sha512-3J3nanMM9dO5a7abzn6+rBVzHASXmEIu/C5HH0UyESSMKKzg1gRafshhwRcLMZWG3ekAXq6vtNVh2Vhkn92peA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_attribute-value": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_attribute-value/-/auto_sdk_bookings_attribute-value-1.0.9.tgz",
+   "integrity": "sha512-Mc3o/UrYkdjYykfHZ6m4Vyf0Avk6LewXsNCqN/+JNC0GA1bQW5Oj4MOAdiYfSLQrmjDLtTLxCRa2lBch18cbkA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_availability-calendar": {
+   "version": "1.0.196",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-calendar/-/auto_sdk_bookings_availability-calendar-1.0.196.tgz",
+   "integrity": "sha512-EXtTMMkqJhj0hOdAykz719KXTLnzwTURl/P+uJrKHyZoE8j9ovzJKv20ATr5IbOWHA3tje9oTLivqMMqxqU99w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_availability-time-slots": {
+   "version": "1.0.265",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-time-slots/-/auto_sdk_bookings_availability-time-slots-1.0.265.tgz",
+   "integrity": "sha512-tbeYcTE6S7qWfYsiYwmHqVhQ73BUCIXDyTLj52QJUql50JiVTUkxnPbh8BmHL1WQ4hstORr4ANYAaTMYFDoXUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_availability-time-slots-configuration": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-time-slots-configuration/-/auto_sdk_bookings_availability-time-slots-configuration-1.0.9.tgz",
+   "integrity": "sha512-f+UG05ix1tOexL04EEulpH3qJEFvH7Dsj1nB8h13ov0iCuR87Pg/bSb3Zaw6MlJYNq44HRLZ/ydf0BtO4goiCg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_booking-fees": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-fees/-/auto_sdk_bookings_booking-fees-1.0.57.tgz",
+   "integrity": "sha512-bdVdGD8u5EyPn0RGCJ87+I3lA5YanvbqkINrw5EIP/N+decWXoct8CVT5TND0FPsDaSmqJSoWvOFbFPHEr4JEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_booking-policies": {
+   "version": "1.0.143",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policies/-/auto_sdk_bookings_booking-policies-1.0.143.tgz",
+   "integrity": "sha512-M+mWU4KXaXYBTpno3Wxk8JwO2ksO2Hy/8x24hym0+D/FxnQa+ns6gA/zJ/wbbZyCDEcKfQoUW/41+K539hYSRg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_booking-policy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policy/-/auto_sdk_bookings_booking-policy-1.0.2.tgz",
+   "integrity": "sha512-rW1U4tWLKjs90GwYTLcJcjQOX9APlkr/32t2k7ZCa+wj74NBFPyvW0lwco5DKNCktSFa3SRK2QWQbwzsdSeU+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_booking-policy-snapshots": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_booking-policy-snapshots/-/auto_sdk_bookings_booking-policy-snapshots-1.0.52.tgz",
+   "integrity": "sha512-oCL6jlxN7PyWPNrQ4aUGWb5zp5BhS5FlTYc1Dl5+nknVw3Yub+WuZwxSyGTDdScWJ7lDlKlflU8R0ZtCmkp4wA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_bookings": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings/-/auto_sdk_bookings_bookings-1.0.230.tgz",
+   "integrity": "sha512-ZnNH+KtdgLKfVooPdbnX2Q7gQWpfZRC32FPu4CVVGwWLashnR7/kzNjfOwiSaVwPJcNeOxcFZs4VgBPTVcFvsQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_bookings-provisioner": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-provisioner/-/auto_sdk_bookings_bookings-provisioner-1.0.2.tgz",
+   "integrity": "sha512-TBjPZaF/0+G4ykoUi+wHG0fZlZYhdPO85sBB2h5dHwzDRjiRv7/+sK48bVE35tZ7yu2BVtdaP0JE0KrdvJn/Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_bookings-settings": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-settings/-/auto_sdk_bookings_bookings-settings-1.0.6.tgz",
+   "integrity": "sha512-wDyaWMK0+eLuMCPS1PMHWLiakzXQpCDOnBdHLnerHq8jG1QQyucHyUg4Wm6MyxpDlmAN/NtMoN8/SPCvjQonWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_bookings-validation": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_bookings-validation/-/auto_sdk_bookings_bookings-validation-1.0.15.tgz",
+   "integrity": "sha512-MCcfcPNOaQYnJjXy1rDduDuj/4wv0STDFzRERlQkLAU38NyGrY2X8ZiwnX/4Z7gi8BJJ4reyWi6mzv+iD4euRQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_catalog-search": {
+   "version": "1.0.26",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_catalog-search/-/auto_sdk_bookings_catalog-search-1.0.26.tgz",
+   "integrity": "sha512-87fvruXUslg0SZ5elS0/7vpclp7Eu1pmIlEqJCmF/JAMN1JT4isA8AfkrbZhZ6ihwpzyQH2IpB0SjDsO7mDH5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_categories": {
+   "version": "1.0.58",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_categories/-/auto_sdk_bookings_categories-1.0.58.tgz",
+   "integrity": "sha512-pk7NxyGPGfu0rM7JrJIl64poKsSk+PefKRaxGx0U1VrIajiZNEoBrocNklRvrqHaq9qxoEobh7EnT0eXBK2mhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_categories-v-2": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_categories-v-2/-/auto_sdk_bookings_categories-v-2-1.0.57.tgz",
+   "integrity": "sha512-4kyacMeY02iXvWLMKvD29rr9PD6GQNKX7EsvBA5Cj9GlIA14cPdL1gBwNMuxthFY4PWLqOoR3lUSKheOLQOA9w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_display-settings": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_display-settings/-/auto_sdk_bookings_display-settings-1.0.9.tgz",
+   "integrity": "sha512-C0qEdxIlq1UtONn0UR2trxmpTwbQTW/sTwBTkQjYEWMqMP2H7KwI6+z/y1qilej7SpeFUwqI6K3YxWumkkTxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_event-time-slots": {
+   "version": "1.0.132",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_event-time-slots/-/auto_sdk_bookings_event-time-slots-1.0.132.tgz",
+   "integrity": "sha512-8zFFpuDIwWscr+xjncXvTxXXEAkgbnqyOPdp5AKkMNFMBkJwfOFDnRhBSZhCpkOg7tV0znTijnVpWe6Pj0nq3g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_extended-bookings": {
+   "version": "1.0.127",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_extended-bookings/-/auto_sdk_bookings_extended-bookings-1.0.127.tgz",
+   "integrity": "sha512-nfqoqGuYHe/b/MPW6Og87DZHlnuIh1mkHUOBvivKqXOHJ3PHlhmmvs+jpckNIzs5+57gmQRHuf4kiczke/4E3w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_external-calendars": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_external-calendars/-/auto_sdk_bookings_external-calendars-1.0.57.tgz",
+   "integrity": "sha512-0WVxa6xRQn5BG4MzCP66hEIrW6CVfCwcR3kG4cQCSLL8tvuaMYOw5eqvGVsCEreygWS3gZ+RLjMbN3xx0XqdkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_multi-service-availability-time-slots": {
+   "version": "1.0.258",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_multi-service-availability-time-slots/-/auto_sdk_bookings_multi-service-availability-time-slots-1.0.258.tgz",
+   "integrity": "sha512-mDarrs72rKEnwCCwIjWLaPrrB2pr8XLvLZM2jsyBbpTfiTYrqoqijh+8I9+lsqcAmeDoe/7+uPiP904XNkHyFA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_pricing": {
+   "version": "1.0.101",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_pricing/-/auto_sdk_bookings_pricing-1.0.101.tgz",
+   "integrity": "sha512-GzY4HGAQhQKTdOl0btElVZjfyjcnQVaZb22ARc2Ihvqe1lK2YA9MI90sIlECpkEKvuT5ZNzcK9jifeR5JWMekw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_pricing-provider": {
+   "version": "1.0.29",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_pricing-provider/-/auto_sdk_bookings_pricing-provider-1.0.29.tgz",
+   "integrity": "sha512-VDcdqL8Ar2pk9pltT8F452AnW9gu/AoM23YVq9NSxInycBmlTB4OkY8GgTklvUZBpXjnReBoOypTfM4LgYcLSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_related-products": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_related-products/-/auto_sdk_bookings_related-products-1.0.2.tgz",
+   "integrity": "sha512-BYEUBvLQJ2WKk58ThsEmrY/7WfRr0wA2VfjNgBXG/MP18LfL7zN/NVdRkV6guM5u2cWVIBRawp8W2fwoUO//UA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_resource-types": {
+   "version": "1.0.82",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_resource-types/-/auto_sdk_bookings_resource-types-1.0.82.tgz",
+   "integrity": "sha512-UJ6G9sf0Ruy+slAfEslP8LdJlYYnAwi91dOM/ewOfqq/Jvz8hVgGSqAl5if0EZfSqXpDBv4unsQUx2iuKbbJQg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_resources": {
+   "version": "1.0.89",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_resources/-/auto_sdk_bookings_resources-1.0.89.tgz",
+   "integrity": "sha512-AZg9m5QEVDG5EgLktvQg5K6ep8FoJZR5v3w2hAmlzDRS4klxOZ1BgU+z0gHhy39keWLSYAk59sj/mnPR8pkyxw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_service-options-and-variants": {
+   "version": "1.0.90",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_service-options-and-variants/-/auto_sdk_bookings_service-options-and-variants-1.0.90.tgz",
+   "integrity": "sha512-T6MYlSc0XTqQ6G6ARzXqonIFEgETozmcasJka6KH3MoLgMbtMcvJ956TfsoIa2nEEXdIxD2kGn++DFqw+tQVWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_services": {
+   "version": "1.0.277",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_services/-/auto_sdk_bookings_services-1.0.277.tgz",
+   "integrity": "sha512-+l+hZmbdDVT2ebARbYB09ok9srTrHAM1TozcKVmDanUSPf02UfHqy4XgqD+siejLrVuBz+7yqmRH9hAKyB/wMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_staff-member-settings": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-member-settings/-/auto_sdk_bookings_staff-member-settings-1.0.22.tgz",
+   "integrity": "sha512-Km7n6xz9Q1CCAomdiEit2bwEOtKKBXqXEpQ3YTy2SS4Gi6tfvn11xX/J/OQ5dx4ZG9vjxsB4S4VCWa8JA3Vcfg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_staff-members": {
+   "version": "1.0.126",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-members/-/auto_sdk_bookings_staff-members-1.0.126.tgz",
+   "integrity": "sha512-Ovjy8l7aQX3Ke74gpArGwG4voU/5FbWrppPugSzhNcfapd8KLQmPax8ZI6VCVvFaO6yWrylabguIdI7hszHFtQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_staff-sorting": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_staff-sorting/-/auto_sdk_bookings_staff-sorting-1.0.7.tgz",
+   "integrity": "sha512-lo0bmVUDCFolFWiBAU44yBG2RZmcmn6xr8bMx1YQOIYZAbgfLuqueURi6cpIJh2CW6f3Fu4GQnGEzWdBhXJfVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_time-slots-configuration": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_time-slots-configuration/-/auto_sdk_bookings_time-slots-configuration-1.0.6.tgz",
+   "integrity": "sha512-0diduZHwtRQqZ7bK09fzAE78V4deyOpORYZy31iObsU3lrtU0xKrZhVkCtKw7x5mr4GXksAauFWa1E2FxRly0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
+   "version": "1.0.192",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
+   "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_chat-settings": {
+   "version": "1.0.27",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_chat-settings/-/auto_sdk_forms_chat-settings-1.0.27.tgz",
+   "integrity": "sha512-xCXsDzVnRqf2X7FKYl0TCweL75eCkZk4v3DRGVoB6/I2OWze3Jh4wKp/No1ZorvTIK/kfqRURqrl45xlw+ACpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_form-spam-submission-reports": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-spam-submission-reports/-/auto_sdk_forms_form-spam-submission-reports-1.0.42.tgz",
+   "integrity": "sha512-o+m2UkldVgTxmR/QB1P6Ho0B7A/WO+KUOW2Ryp7o5GvuQNtjvIAbJQVEwVkTMcDTsWbkhZhws5P3ZId10ptYGg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_form-submissions": {
+   "version": "1.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-submissions/-/auto_sdk_forms_form-submissions-1.0.25.tgz",
+   "integrity": "sha512-t7DkTvX6ZIvu2xSuv2KnqDrBzeNFJxqBitgh9mm1Rx71KG7qTsOwb2vENKBPq/jz1z4K1W2McHrSm3DQe5vJvA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_forms": {
+   "version": "1.0.135",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_forms/-/auto_sdk_forms_forms-1.0.135.tgz",
+   "integrity": "sha512-5bLRkFzj+0lEr7cO1w257ZQK2tS3aLkYX5QaQJtuHKjveEHlM0vw6ppBBwInC21j5iVa8QuFW/J2Tw9xRvQ05Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_interactive-form-sessions": {
+   "version": "1.0.80",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_interactive-form-sessions/-/auto_sdk_forms_interactive-form-sessions-1.0.80.tgz",
+   "integrity": "sha512-15f0e/olrKlOIOoAK1JE+wwD0IKfTwpRbczPBeDiLUsZC/D69XUTzKZRM3ZF9B19Wd5sT7ztzOOt77JDojSknw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_forms_submissions": {
+   "version": "1.0.154",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_submissions/-/auto_sdk_forms_submissions-1.0.154.tgz",
+   "integrity": "sha512-uE5UFW/bIHVJLfjdNha9n7lW6SsPmW+NwvqXZbUtCmNsya32yEC4qx2l+pqZ4tQdSgEFGaRyi6N2pAqwkB6lnQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.96",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.96.tgz",
+   "integrity": "sha512-KrPyTF319c/EKKbVA+89xPXhQ1MBl5ShR41OPmiFhRyhbILWe7dRIn/5dgBhopsKj5mBw50SuA5bXeHrntv8Yw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_llms-txt": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_redirects": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/auto_sdk_seo_redirects-1.0.2.tgz",
+   "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_robots-txt": {
+   "version": "1.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-patterns": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
+   "version": "1.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-tags": {
+   "version": "1.0.28",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/bookings": {
+   "version": "1.0.1650",
+   "resolved": "https://registry.npmjs.org/@wix/bookings/-/bookings-1.0.1650.tgz",
+   "integrity": "sha512-1HdXd3U9CvVZtb4oZNCpBwFpogdtl67zY/rE4rP4H0RbE42+SVjCvVwcxZpe+9quqj3UPx/ANu8MbgHXcERmbg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_bookings_add-ons": "1.0.34",
+    "@wix/auto_sdk_bookings_attendance": "1.0.69",
+    "@wix/auto_sdk_bookings_attribute-definition": "1.0.8",
+    "@wix/auto_sdk_bookings_attribute-value": "1.0.9",
+    "@wix/auto_sdk_bookings_availability-calendar": "1.0.196",
+    "@wix/auto_sdk_bookings_availability-time-slots": "1.0.265",
+    "@wix/auto_sdk_bookings_availability-time-slots-configuration": "1.0.9",
+    "@wix/auto_sdk_bookings_booking-fees": "1.0.57",
+    "@wix/auto_sdk_bookings_booking-policies": "1.0.143",
+    "@wix/auto_sdk_bookings_booking-policy": "1.0.2",
+    "@wix/auto_sdk_bookings_booking-policy-snapshots": "1.0.52",
+    "@wix/auto_sdk_bookings_bookings": "1.0.230",
+    "@wix/auto_sdk_bookings_bookings-provisioner": "1.0.2",
+    "@wix/auto_sdk_bookings_bookings-settings": "1.0.6",
+    "@wix/auto_sdk_bookings_bookings-validation": "1.0.15",
+    "@wix/auto_sdk_bookings_catalog-search": "1.0.26",
+    "@wix/auto_sdk_bookings_categories": "1.0.58",
+    "@wix/auto_sdk_bookings_categories-v-2": "1.0.57",
+    "@wix/auto_sdk_bookings_display-settings": "1.0.9",
+    "@wix/auto_sdk_bookings_event-time-slots": "1.0.132",
+    "@wix/auto_sdk_bookings_extended-bookings": "1.0.127",
+    "@wix/auto_sdk_bookings_external-calendars": "1.0.57",
+    "@wix/auto_sdk_bookings_multi-service-availability-time-slots": "1.0.258",
+    "@wix/auto_sdk_bookings_pricing": "1.0.101",
+    "@wix/auto_sdk_bookings_pricing-provider": "1.0.29",
+    "@wix/auto_sdk_bookings_related-products": "1.0.2",
+    "@wix/auto_sdk_bookings_resource-types": "1.0.82",
+    "@wix/auto_sdk_bookings_resources": "1.0.89",
+    "@wix/auto_sdk_bookings_service-options-and-variants": "1.0.90",
+    "@wix/auto_sdk_bookings_services": "1.0.277",
+    "@wix/auto_sdk_bookings_staff-member-settings": "1.0.22",
+    "@wix/auto_sdk_bookings_staff-members": "1.0.126",
+    "@wix/auto_sdk_bookings_staff-sorting": "1.0.7",
+    "@wix/auto_sdk_bookings_time-slots-configuration": "1.0.6",
+    "@wix/bookings_app-extensions": "1.0.106",
+    "@wix/headless-bookings": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/bookings_app-extensions": {
+   "version": "1.0.106",
+   "resolved": "https://registry.npmjs.org/@wix/bookings_app-extensions/-/bookings_app-extensions-1.0.106.tgz",
+   "integrity": "sha512-IyfO8duvbu9zd6uTCJM0hFLY+QtcvX03PnInnslUYWaymLDr/VvsZ5TUh3fVD9fB+iwaeXmZBppM3xexnFi1fg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.785.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.785.0.tgz",
+   "integrity": "sha512-2gjp52CPDm0NyHmOeSshY8JB8d9cZSim+wLhEtywvonapYmhMUYpk3apg5Y6Nq9EkkQKV78h3VBldbG89bA6zQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/editor-platform-environment-api": "1.161.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.473.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.473.0.tgz",
+   "integrity": "sha512-uMfBLWBF/XBcw5uZcn9Uwng+iQEfm+dWI34DfSgWuy52FrpnFrCiIxZpO/bKMK0lBGzvy6WGIVj9Sbzrd6iLjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.160.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.160.0.tgz",
+   "integrity": "sha512-5nBLeqPsWELDJECxcXVbsTm+uTI8W15e46Mi8wvm8i7SM87RfsOB0BY5kIIP33rfMFyBrZS2NJiRAGO9IzadZQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.161.0.tgz",
+   "integrity": "sha512-hjUr8xmqDij0bKCKp2VPCfajz8Wj2JAeDL2ez9pcgtoPhtuPixaSRzrTNegK8Kk+p6sitLlhPxtOEi6FCsBtlw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.473.0",
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/form-public": {
+   "version": "0.145.0",
+   "resolved": "https://registry.npmjs.org/@wix/form-public/-/form-public-0.145.0.tgz",
+   "integrity": "sha512-y/K5nWdM0x5oNQHFBgk5b4jtx7Jitu+kDHTbJ4lqFuYQaroekBrAcH2mOqDQB30cXwBMCz+wjtyAWdHOYDPwBA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/essentials": "^0.1.28",
+    "i18next": "^19.9.2",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.mapkeys": "^4.6.0",
+    "react-i18next": "^11.18.6"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/i18next": {
+   "version": "19.9.2",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+   "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.12.0"
+   }
+  },
+  "node_modules/@wix/form-public/node_modules/react-i18next": {
+   "version": "11.18.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+   "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.14.5",
+    "html-parse-stringify": "^3.0.1"
+   },
+   "peerDependencies": {
+    "i18next": ">= 19.0.0",
+    "react": ">= 16.8.0"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/forms": {
+   "version": "1.0.500",
+   "resolved": "https://registry.npmjs.org/@wix/forms/-/forms-1.0.500.tgz",
+   "integrity": "sha512-Vrc6Ld6i5TkePv9j263Oz8CWwcaiKlNl2E5APt8dXvM1fPYByNTuAIcwk0nKt26WN9P8dYgh2u41wzgP6jOH9A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_forms_chat-settings": "1.0.27",
+    "@wix/auto_sdk_forms_form-spam-submission-reports": "1.0.42",
+    "@wix/auto_sdk_forms_form-submissions": "1.0.25",
+    "@wix/auto_sdk_forms_forms": "1.0.135",
+    "@wix/auto_sdk_forms_interactive-form-sessions": "1.0.80",
+    "@wix/auto_sdk_forms_submissions": "1.0.154",
+    "@wix/headless-forms": "0.0.45"
+   }
+  },
+  "node_modules/@wix/headless-bookings": {
+   "version": "1.0.18",
+   "resolved": "https://registry.npmjs.org/@wix/headless-bookings/-/headless-bookings-1.0.18.tgz",
+   "integrity": "sha512-XBWu8m6kFMZc4zkNms45nK3wT0a8nNOglc6+d7vr9/FdMVdB/Vlm9HAsGAbUKJQjBUte5t1wc86qudGV0yEDSw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_bookings_availability-time-slots": "^1.0.244",
+    "@wix/auto_sdk_bookings_bookings": "^1.0.192",
+    "@wix/auto_sdk_bookings_catalog-search": "^1.0.2",
+    "@wix/auto_sdk_bookings_event-time-slots": "^1.0.112",
+    "@wix/auto_sdk_bookings_pricing": "^1.0.87",
+    "@wix/auto_sdk_bookings_services": "^1.0.265",
+    "@wix/auto_sdk_ecom_cart-v-2": "^1.0.86",
+    "@wix/forms": "^1.0.384",
+    "@wix/headless-media": "0.0.25",
+    "@wix/headless-utils": "0.0.12",
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "date-fns": "^4.1.0"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0",
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-components/node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-forms": {
+   "version": "0.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/headless-forms-0.0.45.tgz",
+   "integrity": "sha512-I/uXQlR6r7af7iWm5E4xXICXaUbqGmTziApXDlxlMeTOP+zqUyTFSXWcUL4uT683yRfcXH46jog4f8e2NVSHsg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/form-public": "^0.145.0",
+    "@wix/forms": "^1.0.399",
+    "@wix/headless-utils": "0.0.12",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "react-aria-components": "^1.13.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-seo": {
+   "version": "0.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/headless-seo-0.0.16.tgz",
+   "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/seo": "^1.0.14",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.12.tgz",
+   "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.271",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.271.tgz",
+   "integrity": "sha512-Ci/qsi/qouoC9NqIwwgiEvcRxk9xJugivsk59wPRDb0h/kQDAs9Jc8R06bgBPAC8ja3+frRMnBXTrVo2+bmaqw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.96",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.394.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.394.0.tgz",
+   "integrity": "sha512-yHxIbhSpHZE8CIPoYonUrkNVDzDRYT36Ssb3HIJ8b1OZRhdtcjF1HNP+okdTVW+mBBiyXjGFNqfe1LWM0R6GDg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.103.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.103.0.tgz",
+   "integrity": "sha512-iWupfV581sAgrCd8UyWrlakRNHhjfEeH0tluwVBbD+OEoybKs58c4xLEAw2N4A+VzzRVcwOIk+b6hdF4wI6wjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.131",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/seo": {
+   "version": "1.0.79",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/seo-1.0.79.tgz",
+   "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
+    "@wix/auto_sdk_seo_llms-txt": "1.0.0",
+    "@wix/auto_sdk_seo_redirects": "1.0.2",
+    "@wix/auto_sdk_seo_robots-txt": "1.0.21",
+    "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
+    "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
+    "@wix/auto_sdk_seo_seo-tags": "1.0.28",
+    "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
+    "@wix/headless-seo": "^0.0.16"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.13",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+   "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/client-only": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+   "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+   "license": "MIT"
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/date-fns": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+   "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/kossnocorp"
+   }
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "peer": true,
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.camelcase": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+   "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+   "license": "MIT"
+  },
+  "node_modules/lodash.mapkeys": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
+   "integrity": "sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-aria": {
+   "version": "3.51.0",
+   "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+   "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "aria-hidden": "^1.2.3",
+    "clsx": "^2.0.0",
+    "react-stately": "3.49.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-aria-components": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.20.0.tgz",
+   "integrity": "sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "client-only": "^0.0.1",
+    "react-aria": "3.51.0",
+    "react-stately": "3.49.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-stately": {
+   "version": "3.49.0",
+   "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+   "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.12.3",
+    "@internationalized/number": "^3.6.7",
+    "@internationalized/string": "^3.2.10",
+    "@react-types/shared": "^3.36.1",
+    "@swc/helpers": "^0.5.0",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
   }
+ }
 }

--- a/skills/wix-headless-fast/references/cms/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/cms/lock/astro/package-lock.json
@@ -3379,18 +3379,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -3406,7 +3406,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -3433,7 +3433,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -3441,7 +3441,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -3453,7 +3453,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -3462,7 +3462,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -3472,7 +3472,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -3483,7 +3483,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -3494,7 +3494,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -3505,7 +3505,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -3516,7 +3516,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -3527,7 +3527,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -3538,7 +3538,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -3549,7 +3549,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -3560,7 +3560,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -3571,7 +3571,7 @@
   },
   "node_modules/@wix/auto_sdk_data_backups": {
    "version": "1.0.69",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_backups/-/@wix/auto_sdk_data_backups-1.0.69.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_backups/-/auto_sdk_data_backups-1.0.69.tgz",
    "integrity": "sha512-I6fQKHZqnnwugixuKis1bP+QUSgAGhsa/EU6re9fcL/qF4QWE089luNaDclxFw2NuE4DkApknmWQBimTc3mZog==",
    "license": "MIT",
    "dependencies": {
@@ -3582,7 +3582,7 @@
   },
   "node_modules/@wix/auto_sdk_data_collections": {
    "version": "1.0.94",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_collections/-/@wix/auto_sdk_data_collections-1.0.94.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_collections/-/auto_sdk_data_collections-1.0.94.tgz",
    "integrity": "sha512-FtdUIcNqZbtwp2cM1heM643bi2ILn9NQFBtUZE0zRY5VF17nqNBneZpZ/IihKZbMHKxB0Deazmh5XhDZ7rpZNQ==",
    "license": "MIT",
    "dependencies": {
@@ -3593,7 +3593,7 @@
   },
   "node_modules/@wix/auto_sdk_data_external-database": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database/-/@wix/auto_sdk_data_external-database-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database/-/auto_sdk_data_external-database-1.0.32.tgz",
    "integrity": "sha512-ASLrBaGM2/kfrUc+FVfw2pGqNpd26XE5yXtczF2IEKTackWLWHk/vTCAJhIZO4SziiJKmr+4QA1DTBOtLIJhMw==",
    "license": "MIT",
    "dependencies": {
@@ -3604,7 +3604,7 @@
   },
   "node_modules/@wix/auto_sdk_data_external-database-connections": {
    "version": "1.0.51",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database-connections/-/@wix/auto_sdk_data_external-database-connections-1.0.51.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_external-database-connections/-/auto_sdk_data_external-database-connections-1.0.51.tgz",
    "integrity": "sha512-MO+Xza005HbSk+3npgsU+9cJ1AnsYW1pBnf6iJQaTkE+0oCA56/k4+NNgK8asQKQY9aEW/UKwUpAwVWPhw81AA==",
    "license": "MIT",
    "dependencies": {
@@ -3615,7 +3615,7 @@
   },
   "node_modules/@wix/auto_sdk_data_indexes": {
    "version": "1.0.55",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_indexes/-/@wix/auto_sdk_data_indexes-1.0.55.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_indexes/-/auto_sdk_data_indexes-1.0.55.tgz",
    "integrity": "sha512-+L4iwriLernM6No4qzHS+zr6B5boo+6FwSZjm7PDbDFUleNwaCTRiTgmvSIpt01UwnqKxU/msxG9s9BfZjn3EA==",
    "license": "MIT",
    "dependencies": {
@@ -3626,7 +3626,7 @@
   },
   "node_modules/@wix/auto_sdk_data_movement-jobs": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_movement-jobs/-/@wix/auto_sdk_data_movement-jobs-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_movement-jobs/-/auto_sdk_data_movement-jobs-1.0.59.tgz",
    "integrity": "sha512-Mz1Fh/U4+sIUwG8CIqOwJW4JZ1OzuTo6YcfWQygRFYL0qP5Im9bQzlKX290TN57FfkF+VgdQWPfCF6a2ysnwcA==",
    "license": "MIT",
    "dependencies": {
@@ -3637,7 +3637,7 @@
   },
   "node_modules/@wix/auto_sdk_data_permissions": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_permissions/-/@wix/auto_sdk_data_permissions-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_permissions/-/auto_sdk_data_permissions-1.0.52.tgz",
    "integrity": "sha512-KN7pGm54KVjnLDKD2j6MLfXYg35sUl2X204Tsga888jUwJi4Ta3djIF7ybn+zKlj0jeNfnAWpSc64Ume22oqaQ==",
    "license": "MIT",
    "dependencies": {
@@ -3648,7 +3648,7 @@
   },
   "node_modules/@wix/auto_sdk_data_scheduled-workflows": {
    "version": "1.0.11",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_scheduled-workflows/-/@wix/auto_sdk_data_scheduled-workflows-1.0.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_scheduled-workflows/-/auto_sdk_data_scheduled-workflows-1.0.11.tgz",
    "integrity": "sha512-d8DkGwGMFVwg2ygUgq/hN6py6uj71kQFqgf/0MorO0SYU5JHe3yPBnFQwwH2Zwfn3PVbZ/KQp+zguNd3gllkig==",
    "license": "MIT",
    "dependencies": {
@@ -3659,7 +3659,7 @@
   },
   "node_modules/@wix/auto_sdk_data_sharing": {
    "version": "1.0.26",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_sharing/-/@wix/auto_sdk_data_sharing-1.0.26.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_sharing/-/auto_sdk_data_sharing-1.0.26.tgz",
    "integrity": "sha512-aMlELsMlXCtlEVlu5AE+CZzBSj1Cxz1ZjFj2dxq4y3U3hZ4EPS34dOwBgthtHx1/RQQpLK0ZYaj9a8nMmOhlWw==",
    "license": "MIT",
    "dependencies": {
@@ -3670,7 +3670,7 @@
   },
   "node_modules/@wix/auto_sdk_data_tasks": {
    "version": "1.0.42",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_tasks/-/@wix/auto_sdk_data_tasks-1.0.42.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_data_tasks/-/auto_sdk_data_tasks-1.0.42.tgz",
    "integrity": "sha512-ILRyAHqykahNE7CP3OUu2yJFraZo3wzEkM+MyBNzK2MoTqkXjpFB3BLQuuAbd/ISzRGq2crg1b2exLKo88QXQg==",
    "license": "MIT",
    "dependencies": {
@@ -3681,7 +3681,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout": {
    "version": "1.0.168",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/auto_sdk_ecom_checkout-1.0.168.tgz",
    "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
    "license": "MIT",
    "dependencies": {
@@ -3692,7 +3692,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_current-cart": {
    "version": "1.0.184",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/auto_sdk_ecom_current-cart-1.0.184.tgz",
    "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
    "license": "MIT",
    "dependencies": {
@@ -3703,7 +3703,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -3714,7 +3714,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -3725,7 +3725,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -3736,7 +3736,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -3747,7 +3747,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -3758,7 +3758,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -3769,7 +3769,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -3780,7 +3780,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -3791,7 +3791,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -3802,7 +3802,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -3813,7 +3813,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -3824,7 +3824,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -3843,7 +3843,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3853,13 +3853,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3868,7 +3868,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3907,7 +3907,7 @@
   },
   "node_modules/@wix/data": {
    "version": "1.0.512",
-   "resolved": "https://registry.npmjs.org/@wix/data/-/@wix/data-1.0.512.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/data/-/data-1.0.512.tgz",
    "integrity": "sha512-Zgwd0Z/WRyMwEUVttlfz7NRglRDkK3/lsBOA07b93sFRF3/7pH27A8moUdPIL/aPbIDcm9DIcKhdKh/P4/HsXA==",
    "license": "MIT",
    "dependencies": {
@@ -3927,7 +3927,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3943,7 +3943,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3955,7 +3955,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3967,7 +3967,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3981,7 +3981,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -4008,7 +4008,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -4018,7 +4018,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -4027,7 +4027,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -4047,7 +4047,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4080,7 +4080,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -4090,7 +4090,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -4108,7 +4108,7 @@
   },
   "node_modules/@wix/filter-builder": {
    "version": "1.0.248",
-   "resolved": "https://registry.npmjs.org/@wix/filter-builder/-/@wix/filter-builder-1.0.248.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/filter-builder/-/filter-builder-1.0.248.tgz",
    "integrity": "sha512-06lIiDP+0rLIWL2+513fkr7ONKw61s89XVnX1f9Xyg/aaGjmPqqTYRcLUUQqPOedmOJmr//IuLpA+nTDD1+JNg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4118,7 +4118,7 @@
   },
   "node_modules/@wix/headless-cms": {
    "version": "0.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/headless-cms/-/@wix/headless-cms-0.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-cms/-/headless-cms-0.0.45.tgz",
    "integrity": "sha512-wSX5M8axWYFw3DI1OUBoMrrU1mqzfranSAB4qBonXcM0/M8O3ciZ3rzYhNIVwHXgiNW580ptjmq8yX6ERGiJwA==",
    "license": "MIT",
    "dependencies": {
@@ -4160,7 +4160,7 @@
   },
   "node_modules/@wix/headless-ecom": {
    "version": "0.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/headless-ecom-0.0.40.tgz",
    "integrity": "sha512-ib8dYXCeHlo/UYck/CE9v3AkFXI0r5Dn+6ZRH1I2ylxrZMy7Lqj2GF0gwvoOwEKdDbjuNhWEvTY9X4tg6tN0Qg==",
    "license": "MIT",
    "dependencies": {
@@ -4179,7 +4179,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -4189,7 +4189,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -4200,7 +4200,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4211,7 +4211,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4222,7 +4222,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -4231,7 +4231,7 @@
   },
   "node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -4243,7 +4243,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -4256,7 +4256,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -4266,7 +4266,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -4279,7 +4279,7 @@
   },
   "node_modules/@wix/media/node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -4299,7 +4299,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4309,7 +4309,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4318,13 +4318,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -4336,7 +4336,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4345,13 +4345,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4362,7 +4362,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4373,7 +4373,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4382,19 +4382,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -4406,7 +4406,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4417,7 +4417,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4426,13 +4426,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -4442,13 +4442,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4457,7 +4457,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4467,13 +4467,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -4482,7 +4482,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -4507,7 +4507,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -4516,7 +4516,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -4526,7 +4526,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -4537,7 +4537,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -4547,7 +4547,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -4555,7 +4555,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -4566,7 +4566,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -4583,7 +4583,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4597,7 +4597,7 @@
   },
   "node_modules/@wix/wix-data-items-common": {
    "version": "1.0.324",
-   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-common/-/@wix/wix-data-items-common-1.0.324.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-common/-/wix-data-items-common-1.0.324.tgz",
    "integrity": "sha512-qHa8aSEBz5A1v5pgR06lz02TSCcXn3I29BDZoXIpIveTmV5QPYEL2WFAgdYhAcGKtSAy55qmnKmhrkAjG3Nmng==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4608,7 +4608,7 @@
   },
   "node_modules/@wix/wix-data-items-sdk": {
    "version": "1.0.545",
-   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-sdk/-/@wix/wix-data-items-sdk-1.0.545.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/wix-data-items-sdk/-/wix-data-items-sdk-1.0.545.tgz",
    "integrity": "sha512-8omSNIyI16L+SsfmOGsrDEBDl8DeF7Cuo1vyaIKwxBBwTZ5N/gqp+BY9WdVaeXfg0s5dWUbROG1I8/m2Wv30zQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4640,7 +4640,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/events/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/events/lock/astro/package-lock.json
@@ -3427,18 +3427,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -3454,7 +3454,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -3481,7 +3481,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -3489,7 +3489,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -3501,7 +3501,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -3510,7 +3510,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -3520,7 +3520,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -3531,7 +3531,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -3542,7 +3542,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -3553,7 +3553,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -3564,7 +3564,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -3575,7 +3575,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -3586,7 +3586,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -3597,7 +3597,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -3608,7 +3608,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -3619,7 +3619,7 @@
   },
   "node_modules/@wix/auto_sdk_events_categories": {
    "version": "1.0.58",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_categories/-/@wix/auto_sdk_events_categories-1.0.58.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_categories/-/auto_sdk_events_categories-1.0.58.tgz",
    "integrity": "sha512-Sp7AA2sI422OuAxhnWdDTDR8qozKmh0NRZjchLlv0390l51oiDQTMqryMdFvhL6gsnaEEVFI2a+KwzrSEHllqQ==",
    "license": "MIT",
    "dependencies": {
@@ -3630,7 +3630,7 @@
   },
   "node_modules/@wix/auto_sdk_events_events-settings": {
    "version": "1.0.51",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_events-settings/-/@wix/auto_sdk_events_events-settings-1.0.51.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_events-settings/-/auto_sdk_events_events-settings-1.0.51.tgz",
    "integrity": "sha512-VATXB7YerjTaCYNTF8jMd55qL8ODnGHBqyuDQZ2uEy6QFP7U23vieCbzbKwY29rhSSo/NIZUruh8h00bEa0ciw==",
    "license": "MIT",
    "dependencies": {
@@ -3641,7 +3641,7 @@
   },
   "node_modules/@wix/auto_sdk_events_forms": {
    "version": "1.0.110",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_forms/-/@wix/auto_sdk_events_forms-1.0.110.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_forms/-/auto_sdk_events_forms-1.0.110.tgz",
    "integrity": "sha512-8xfFueeJPD40M+P74XhvDbiAUrh5ZJNFbdwfqXXca37YNS1AttTW3XSgaoG6tWUdm5Bw/tp3VoEGk+5Gn9PxcQ==",
    "license": "MIT",
    "dependencies": {
@@ -3652,7 +3652,7 @@
   },
   "node_modules/@wix/auto_sdk_events_guests": {
    "version": "1.0.63",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_guests/-/@wix/auto_sdk_events_guests-1.0.63.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_guests/-/auto_sdk_events_guests-1.0.63.tgz",
    "integrity": "sha512-O/WYimxL77K8c26EPnaQwmTz69ZI+JyoCtnF04JjFih2bpXKpLaUXoB53CQD9FZEQJ+LaKWXM37/xDqBXrxowQ==",
    "license": "MIT",
    "dependencies": {
@@ -3663,7 +3663,7 @@
   },
   "node_modules/@wix/auto_sdk_events_notifications": {
    "version": "1.0.79",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_notifications/-/@wix/auto_sdk_events_notifications-1.0.79.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_notifications/-/auto_sdk_events_notifications-1.0.79.tgz",
    "integrity": "sha512-TzQnEKrd+3kKD8GVXuCt7CKjjfWVG6yKhiclKtIeRq0QYi0v1gC6dbEexCqvZ2M6O1g6/bpMIfG3zWfn5Qv59Q==",
    "license": "MIT",
    "dependencies": {
@@ -3674,7 +3674,7 @@
   },
   "node_modules/@wix/auto_sdk_events_orders": {
    "version": "1.0.69",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_orders/-/@wix/auto_sdk_events_orders-1.0.69.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_orders/-/auto_sdk_events_orders-1.0.69.tgz",
    "integrity": "sha512-bGGMhwz/SNXjgTLvLRfyfqRc5oR0hbtYTGAkv4vqxn3GBOHPOnBp50P8groHjs6hU702Ry0Lmhx4wONhsHEhhw==",
    "license": "MIT",
    "dependencies": {
@@ -3685,7 +3685,7 @@
   },
   "node_modules/@wix/auto_sdk_events_policies": {
    "version": "1.0.50",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_policies/-/@wix/auto_sdk_events_policies-1.0.50.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_policies/-/auto_sdk_events_policies-1.0.50.tgz",
    "integrity": "sha512-Qq+hLP69yapIABZ1dptrFEKDeAzgTzkPS4dzeS+xcxwWZIJ+KTuFG0wByW+XNJ06Q41gub913XqHPm6ZFI2x1w==",
    "license": "MIT",
    "dependencies": {
@@ -3696,7 +3696,7 @@
   },
   "node_modules/@wix/auto_sdk_events_rsvp": {
    "version": "1.0.44",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp/-/@wix/auto_sdk_events_rsvp-1.0.44.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp/-/auto_sdk_events_rsvp-1.0.44.tgz",
    "integrity": "sha512-grcVSbqyD0h4yMUwiakC9yfTDf7+yzGWTafbU8mDTICj51B5dC5cla1Z6GN46xTBeIZ8Ou0yUf5qYALRL8vgPQ==",
    "license": "MIT",
    "dependencies": {
@@ -3707,7 +3707,7 @@
   },
   "node_modules/@wix/auto_sdk_events_rsvp-v-2": {
    "version": "1.0.114",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp-v-2/-/@wix/auto_sdk_events_rsvp-v-2-1.0.114.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_rsvp-v-2/-/auto_sdk_events_rsvp-v-2-1.0.114.tgz",
    "integrity": "sha512-axtsWJNdxU50B1SChVCTspfccyjQj2Ps9UK/aa1Di5swKwc/Vmy1pHj/nrq/h8B6rXFi+IminFaFIJB4BLz6+g==",
    "license": "MIT",
    "dependencies": {
@@ -3718,7 +3718,7 @@
   },
   "node_modules/@wix/auto_sdk_events_schedule": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule/-/@wix/auto_sdk_events_schedule-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule/-/auto_sdk_events_schedule-1.0.45.tgz",
    "integrity": "sha512-ufOwvb3WHDYzgjFC82kVaZANyy6PmTv2F8QZMBF5BJA2PJ52kLF/pSg9/Z3ZQy2S32OuUQ6KgQ8ThFLqV2wiqw==",
    "license": "MIT",
    "dependencies": {
@@ -3729,7 +3729,7 @@
   },
   "node_modules/@wix/auto_sdk_events_schedule-bookmarks": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule-bookmarks/-/@wix/auto_sdk_events_schedule-bookmarks-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_schedule-bookmarks/-/auto_sdk_events_schedule-bookmarks-1.0.37.tgz",
    "integrity": "sha512-IHtPONbjkMJpoKLFIX5Nj7SalV32EBAXvN8EiSqyyXH4Wo2/7QP2TYxpGHTcb6aPNsxZbRgT300sqUGp9fFHbg==",
    "license": "MIT",
    "dependencies": {
@@ -3740,7 +3740,7 @@
   },
   "node_modules/@wix/auto_sdk_events_staff-members": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_staff-members/-/@wix/auto_sdk_events_staff-members-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_staff-members/-/auto_sdk_events_staff-members-1.0.53.tgz",
    "integrity": "sha512-J6AzL5ujvkV4/8VjFBHErczEWKgH3MOcuO1ugLLoCG/ym7PB8C0i+k4v9e88UQ4g3YGZ468fGioTsJPr3EGgZA==",
    "license": "MIT",
    "dependencies": {
@@ -3751,7 +3751,7 @@
   },
   "node_modules/@wix/auto_sdk_events_ticket-definitions": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions/-/@wix/auto_sdk_events_ticket-definitions-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions/-/auto_sdk_events_ticket-definitions-1.0.53.tgz",
    "integrity": "sha512-J6DFzkaJvk43kYXVk3y59xGvHRsrfEIHmONHxXuOnbNa9jr2An3tNriYzSPL57qigkf/cgHPzI8GGQTMMpJh0g==",
    "license": "MIT",
    "dependencies": {
@@ -3762,7 +3762,7 @@
   },
   "node_modules/@wix/auto_sdk_events_ticket-definitions-v-2": {
    "version": "1.0.135",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions-v-2/-/@wix/auto_sdk_events_ticket-definitions-v-2-1.0.135.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-definitions-v-2/-/auto_sdk_events_ticket-definitions-v-2-1.0.135.tgz",
    "integrity": "sha512-50awcVdOUKURKwkQ5MCm9RW700mux/m3N2qH3/2bX/pAxx2m7xN38ZVvjtKX3KLv6+7GBsqoi3PWO4LNMfDNOA==",
    "license": "MIT",
    "dependencies": {
@@ -3773,7 +3773,7 @@
   },
   "node_modules/@wix/auto_sdk_events_ticket-reservations": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-reservations/-/@wix/auto_sdk_events_ticket-reservations-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_ticket-reservations/-/auto_sdk_events_ticket-reservations-1.0.52.tgz",
    "integrity": "sha512-NJm8RlvzvA5r0d9QYbLc5GjzQJ6nXhEOC4HiLxQqSxbOU8XHK4zpMO+3ekxpGGYkTmwDQfET3cwedETC0bI+8A==",
    "license": "MIT",
    "dependencies": {
@@ -3784,7 +3784,7 @@
   },
   "node_modules/@wix/auto_sdk_events_tickets": {
    "version": "1.0.51",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_tickets/-/@wix/auto_sdk_events_tickets-1.0.51.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_tickets/-/auto_sdk_events_tickets-1.0.51.tgz",
    "integrity": "sha512-L59XMp5X7pSzzYGBvKt3tH0neYCCgrJwy3NbARoXncFaZdpRlbkV7Wgbrumikc0hqSmVGgDJNMklCSt+CODxgg==",
    "license": "MIT",
    "dependencies": {
@@ -3795,7 +3795,7 @@
   },
   "node_modules/@wix/auto_sdk_events_wix-events-v-2": {
    "version": "1.0.114",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_wix-events-v-2/-/@wix/auto_sdk_events_wix-events-v-2-1.0.114.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_events_wix-events-v-2/-/auto_sdk_events_wix-events-v-2-1.0.114.tgz",
    "integrity": "sha512-SU5JlVWE3RTstfItDZLkf0bOMfjo6iKt69XiGlbzTNuVEag6/UDts6IsBDeEPla9m/jJ9EwOOPxORgFDwdPuug==",
    "license": "MIT",
    "dependencies": {
@@ -3806,7 +3806,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_chat-settings": {
    "version": "1.0.27",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_chat-settings/-/@wix/auto_sdk_forms_chat-settings-1.0.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_chat-settings/-/auto_sdk_forms_chat-settings-1.0.27.tgz",
    "integrity": "sha512-xCXsDzVnRqf2X7FKYl0TCweL75eCkZk4v3DRGVoB6/I2OWze3Jh4wKp/No1ZorvTIK/kfqRURqrl45xlw+ACpw==",
    "license": "MIT",
    "dependencies": {
@@ -3817,7 +3817,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_form-spam-submission-reports": {
    "version": "1.0.42",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-spam-submission-reports/-/@wix/auto_sdk_forms_form-spam-submission-reports-1.0.42.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-spam-submission-reports/-/auto_sdk_forms_form-spam-submission-reports-1.0.42.tgz",
    "integrity": "sha512-o+m2UkldVgTxmR/QB1P6Ho0B7A/WO+KUOW2Ryp7o5GvuQNtjvIAbJQVEwVkTMcDTsWbkhZhws5P3ZId10ptYGg==",
    "license": "MIT",
    "dependencies": {
@@ -3828,7 +3828,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_form-submissions": {
    "version": "1.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-submissions/-/@wix/auto_sdk_forms_form-submissions-1.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_form-submissions/-/auto_sdk_forms_form-submissions-1.0.25.tgz",
    "integrity": "sha512-t7DkTvX6ZIvu2xSuv2KnqDrBzeNFJxqBitgh9mm1Rx71KG7qTsOwb2vENKBPq/jz1z4K1W2McHrSm3DQe5vJvA==",
    "license": "MIT",
    "dependencies": {
@@ -3839,7 +3839,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_forms": {
    "version": "1.0.135",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_forms/-/@wix/auto_sdk_forms_forms-1.0.135.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_forms/-/auto_sdk_forms_forms-1.0.135.tgz",
    "integrity": "sha512-5bLRkFzj+0lEr7cO1w257ZQK2tS3aLkYX5QaQJtuHKjveEHlM0vw6ppBBwInC21j5iVa8QuFW/J2Tw9xRvQ05Q==",
    "license": "MIT",
    "dependencies": {
@@ -3850,7 +3850,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_interactive-form-sessions": {
    "version": "1.0.80",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_interactive-form-sessions/-/@wix/auto_sdk_forms_interactive-form-sessions-1.0.80.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_interactive-form-sessions/-/auto_sdk_forms_interactive-form-sessions-1.0.80.tgz",
    "integrity": "sha512-15f0e/olrKlOIOoAK1JE+wwD0IKfTwpRbczPBeDiLUsZC/D69XUTzKZRM3ZF9B19Wd5sT7ztzOOt77JDojSknw==",
    "license": "MIT",
    "dependencies": {
@@ -3861,7 +3861,7 @@
   },
   "node_modules/@wix/auto_sdk_forms_submissions": {
    "version": "1.0.154",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_submissions/-/@wix/auto_sdk_forms_submissions-1.0.154.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_forms_submissions/-/auto_sdk_forms_submissions-1.0.154.tgz",
    "integrity": "sha512-uE5UFW/bIHVJLfjdNha9n7lW6SsPmW+NwvqXZbUtCmNsya32yEC4qx2l+pqZ4tQdSgEFGaRyi6N2pAqwkB6lnQ==",
    "license": "MIT",
    "dependencies": {
@@ -3872,7 +3872,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -3883,7 +3883,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -3894,7 +3894,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -3905,7 +3905,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -3916,7 +3916,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -3927,7 +3927,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -3938,7 +3938,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -3949,7 +3949,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -3960,7 +3960,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -3971,7 +3971,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -3982,7 +3982,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -3993,7 +3993,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
    "version": "1.0.12",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
    "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
    "license": "MIT",
    "dependencies": {
@@ -4004,7 +4004,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_llms-txt": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/auto_sdk_seo_llms-txt-1.0.0.tgz",
    "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
    "license": "MIT",
    "dependencies": {
@@ -4015,7 +4015,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_redirects": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/auto_sdk_seo_redirects-1.0.2.tgz",
    "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
    "license": "MIT",
    "dependencies": {
@@ -4026,7 +4026,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_robots-txt": {
    "version": "1.0.21",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/auto_sdk_seo_robots-txt-1.0.21.tgz",
    "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
    "license": "MIT",
    "dependencies": {
@@ -4037,7 +4037,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-patterns": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/auto_sdk_seo_seo-patterns-1.0.8.tgz",
    "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
    "license": "MIT",
    "dependencies": {
@@ -4048,7 +4048,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
    "version": "1.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
    "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
    "license": "MIT",
    "dependencies": {
@@ -4059,7 +4059,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_seo-tags": {
    "version": "1.0.28",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/auto_sdk_seo_seo-tags-1.0.28.tgz",
    "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
    "license": "MIT",
    "dependencies": {
@@ -4070,7 +4070,7 @@
   },
   "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
    "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
    "license": "MIT",
    "dependencies": {
@@ -4081,7 +4081,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -4100,7 +4100,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4110,13 +4110,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4125,7 +4125,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4164,7 +4164,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4180,7 +4180,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4192,7 +4192,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4204,7 +4204,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4218,7 +4218,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -4245,7 +4245,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -4255,7 +4255,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -4264,7 +4264,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -4284,7 +4284,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4317,7 +4317,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -4327,7 +4327,7 @@
   },
   "node_modules/@wix/events": {
    "version": "1.0.860",
-   "resolved": "https://registry.npmjs.org/@wix/events/-/@wix/events-1.0.860.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/events/-/events-1.0.860.tgz",
    "integrity": "sha512-5vG7A+dpLCIVEiF3r65waMHGXauSH6z/7zpZ6cDV2mrQsxfXNCd5aIWKSFmvGHWAh9dLglbVyqPC5EG+c3dNrQ==",
    "license": "MIT",
    "dependencies": {
@@ -4354,7 +4354,7 @@
   },
   "node_modules/@wix/events_app-extensions": {
    "version": "1.0.49",
-   "resolved": "https://registry.npmjs.org/@wix/events_app-extensions/-/@wix/events_app-extensions-1.0.49.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/events_app-extensions/-/events_app-extensions-1.0.49.tgz",
    "integrity": "sha512-/NL1UHZgZvNbPn+lWdOWlglhhlAq1reC0nDf4BfKiJiaBcddPs+lhIe/Erg5bkMSazvxzqoeZA9I8h3Twt+nrQ==",
    "license": "MIT",
    "dependencies": {
@@ -4365,7 +4365,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -4383,7 +4383,7 @@
   },
   "node_modules/@wix/form-public": {
    "version": "0.128.0",
-   "resolved": "https://registry.npmjs.org/@wix/form-public/-/@wix/form-public-0.128.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/form-public/-/form-public-0.128.0.tgz",
    "integrity": "sha512-uk7NeZe0p2R8+WHHeXdid9hNb0cmYg+7j1lF3zVYpowsJxPPJCAPf5JpQxMQl92OQfvDdsd85zQ9OrmoDdWHKw==",
    "license": "MIT",
    "dependencies": {
@@ -4417,7 +4417,7 @@
   },
   "node_modules/@wix/form-public/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4522,7 +4522,7 @@
   },
   "node_modules/@wix/forms": {
    "version": "1.0.500",
-   "resolved": "https://registry.npmjs.org/@wix/forms/-/@wix/forms-1.0.500.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/forms/-/forms-1.0.500.tgz",
    "integrity": "sha512-Vrc6Ld6i5TkePv9j263Oz8CWwcaiKlNl2E5APt8dXvM1fPYByNTuAIcwk0nKt26WN9P8dYgh2u41wzgP6jOH9A==",
    "license": "MIT",
    "dependencies": {
@@ -4555,7 +4555,7 @@
   },
   "node_modules/@wix/forms/node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4588,7 +4588,7 @@
   },
   "node_modules/@wix/forms/node_modules/@wix/form-public": {
    "version": "0.145.0",
-   "resolved": "https://registry.npmjs.org/@wix/form-public/-/@wix/form-public-0.145.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/form-public/-/form-public-0.145.0.tgz",
    "integrity": "sha512-y/K5nWdM0x5oNQHFBgk5b4jtx7Jitu+kDHTbJ4lqFuYQaroekBrAcH2mOqDQB30cXwBMCz+wjtyAWdHOYDPwBA==",
    "license": "MIT",
    "dependencies": {
@@ -4635,7 +4635,7 @@
   },
   "node_modules/@wix/forms/node_modules/@wix/headless-forms": {
    "version": "0.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/@wix/headless-forms-0.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/headless-forms-0.0.45.tgz",
    "integrity": "sha512-I/uXQlR6r7af7iWm5E4xXICXaUbqGmTziApXDlxlMeTOP+zqUyTFSXWcUL4uT683yRfcXH46jog4f8e2NVSHsg==",
    "license": "MIT",
    "dependencies": {
@@ -4649,7 +4649,7 @@
   },
   "node_modules/@wix/forms/node_modules/@wix/headless-forms/node_modules/@wix/headless-utils": {
    "version": "0.0.12",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.12.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.12.tgz",
    "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
    "license": "MIT",
    "dependencies": {
@@ -4684,7 +4684,7 @@
   },
   "node_modules/@wix/headless-events": {
    "version": "0.0.60",
-   "resolved": "https://registry.npmjs.org/@wix/headless-events/-/@wix/headless-events-0.0.60.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-events/-/headless-events-0.0.60.tgz",
    "integrity": "sha512-VK2HA64bk5Wk3fNUFQvljYCY35MfeqEKkToShS1rvWHyhM4GRPHLJ7/G95wpiKIU0PO5sKDIMQaftTvrC6o9lA==",
    "license": "MIT",
    "dependencies": {
@@ -4703,7 +4703,7 @@
   },
   "node_modules/@wix/headless-events/node_modules/@wix/headless-utils": {
    "version": "0.0.11",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.11.tgz",
    "integrity": "sha512-zmFqqlcFVXE7A/q4yxZhx5kYcofkZGaHeKTMMIRIgNWDLxTt7O2CBWnlW7wyKuJnqZfGEO84hQlWW0yirrzq9w==",
    "license": "MIT",
    "dependencies": {
@@ -4715,7 +4715,7 @@
   },
   "node_modules/@wix/headless-forms": {
    "version": "0.0.39",
-   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/@wix/headless-forms-0.0.39.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-forms/-/headless-forms-0.0.39.tgz",
    "integrity": "sha512-6lFSw18ZjCM3M6L4KB4BMVM2HLHZkhUv9nb07QvLhU0ykJcNTQVafHuswRzxNjHJHtLHXQGldCJcEfAsxDgvaQ==",
    "license": "MIT",
    "dependencies": {
@@ -4729,7 +4729,7 @@
   },
   "node_modules/@wix/headless-forms/node_modules/@wix/headless-utils": {
    "version": "0.0.11",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.11.tgz",
    "integrity": "sha512-zmFqqlcFVXE7A/q4yxZhx5kYcofkZGaHeKTMMIRIgNWDLxTt7O2CBWnlW7wyKuJnqZfGEO84hQlWW0yirrzq9w==",
    "license": "MIT",
    "dependencies": {
@@ -4741,7 +4741,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -4751,7 +4751,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.24.tgz",
    "integrity": "sha512-1e/ZEv3y/xdYYgCikygZuBsn9FbBaktMBJYLma1zCAEH5r+jcoo1fvK3xAxd2bdQu/sreWxjewHVqpy+izV4rg==",
    "license": "MIT",
    "dependencies": {
@@ -4762,7 +4762,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4773,7 +4773,7 @@
   },
   "node_modules/@wix/headless-seo": {
    "version": "0.0.16",
-   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/headless-seo-0.0.16.tgz",
    "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
    "license": "MIT",
    "dependencies": {
@@ -4784,7 +4784,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4795,7 +4795,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -4817,7 +4817,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -4830,7 +4830,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -4840,7 +4840,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -4853,7 +4853,7 @@
   },
   "node_modules/@wix/media/node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -4873,7 +4873,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4883,7 +4883,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4892,13 +4892,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -4910,7 +4910,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4919,13 +4919,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4936,7 +4936,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4947,7 +4947,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4956,19 +4956,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -4980,7 +4980,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4991,7 +4991,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5000,13 +5000,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -5016,13 +5016,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5031,7 +5031,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5041,13 +5041,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -5056,7 +5056,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -5081,7 +5081,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -5090,7 +5090,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -5100,7 +5100,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -5111,7 +5111,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -5121,7 +5121,7 @@
   },
   "node_modules/@wix/seo": {
    "version": "1.0.79",
-   "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/seo-1.0.79.tgz",
    "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
    "license": "MIT",
    "dependencies": {
@@ -5138,7 +5138,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -5146,7 +5146,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -5157,7 +5157,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -5174,7 +5174,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5188,7 +5188,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/members/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/members/lock/astro/package-lock.json
@@ -2670,18 +2670,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -2697,7 +2697,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -2724,7 +2724,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -2732,7 +2732,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -2744,7 +2744,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -2753,7 +2753,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -2763,7 +2763,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -2774,7 +2774,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -2785,7 +2785,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -2796,7 +2796,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -2807,7 +2807,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -2818,7 +2818,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -2829,7 +2829,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -2840,7 +2840,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -2851,7 +2851,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -2862,7 +2862,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -2873,7 +2873,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -2884,7 +2884,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -2895,7 +2895,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -2906,7 +2906,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -2917,7 +2917,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -2928,7 +2928,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -2939,7 +2939,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -2950,7 +2950,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -2961,7 +2961,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -2972,7 +2972,7 @@
   },
   "node_modules/@wix/auto_sdk_members_authentication": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/@wix/auto_sdk_members_authentication-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authentication/-/auto_sdk_members_authentication-1.0.45.tgz",
    "integrity": "sha512-rYbM07KLz3FQgjxb1tUO/7Ns+ZnI15XCdXQI13NZRmWLLU6NhxfVuy7EyHNxb+IgeEXzAyiqB1taGY4IriMx9g==",
    "license": "MIT",
    "dependencies": {
@@ -2983,7 +2983,7 @@
   },
   "node_modules/@wix/auto_sdk_members_authorization": {
    "version": "1.0.36",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/@wix/auto_sdk_members_authorization-1.0.36.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_authorization/-/auto_sdk_members_authorization-1.0.36.tgz",
    "integrity": "sha512-hpaTseJXSv9CpQWwFItXjmIPgq0NjNBBm98XX6We7m+lDMXkoDHvIgo645xS/jIMpWbwRS26/iY61W9A9Is02g==",
    "license": "MIT",
    "dependencies": {
@@ -2994,7 +2994,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badge-assignments": {
    "version": "1.0.30",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/@wix/auto_sdk_members_badge-assignments-1.0.30.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badge-assignments/-/auto_sdk_members_badge-assignments-1.0.30.tgz",
    "integrity": "sha512-0RggesluwvfP8lEpLTaJlKtz9LKEuuPzIKpxce+iGbSZin6CyvmaV9HIGEO+G64QSOdWCzXUY8JU+9/4ni1xPA==",
    "license": "MIT",
    "dependencies": {
@@ -3005,7 +3005,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badges": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/@wix/auto_sdk_members_badges-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges/-/auto_sdk_members_badges-1.0.52.tgz",
    "integrity": "sha512-vJPXfwIKobCLFvW6EalpbP9mZe/fTL7WiZsdlZJUX7igr64udS65JAnnDb73Ge7l9SoiWtXUDLPcvbMMF+mw8w==",
    "license": "MIT",
    "dependencies": {
@@ -3016,7 +3016,7 @@
   },
   "node_modules/@wix/auto_sdk_members_badges-v-2": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/@wix/auto_sdk_members_badges-v-2-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_badges-v-2/-/auto_sdk_members_badges-v-2-1.0.37.tgz",
    "integrity": "sha512-KHy7ZizF1KW+icDRabv3swQtR0i+WQ43XcqQ3sFYVowpXsb73rg9XgpZ8/3gc+d5sEedIh9OuCOtYfzZi2htsg==",
    "license": "MIT",
    "dependencies": {
@@ -3027,7 +3027,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-field-applications": {
    "version": "1.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/@wix/auto_sdk_members_custom-field-applications-1.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-applications/-/auto_sdk_members_custom-field-applications-1.0.41.tgz",
    "integrity": "sha512-GnCIAZ7ATgCr9gEqxuClE4y9VHEN1ayxq2nJrdHatIkxsoElvWp2E/Uw9e7O0TUdkNXLLlBvd3mjeKpdrUhUvQ==",
    "license": "MIT",
    "dependencies": {
@@ -3038,7 +3038,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-field-suggestions": {
    "version": "1.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/@wix/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-field-suggestions/-/auto_sdk_members_custom-field-suggestions-1.0.40.tgz",
    "integrity": "sha512-2LCuljSdthAoIoiw4A+ZjSIOqCam4TnsJI1meZLmvOUBenQghzeflwvFvmIG13h+lkKWiLc0WmkhrmEo8Iosog==",
    "license": "MIT",
    "dependencies": {
@@ -3049,7 +3049,7 @@
   },
   "node_modules/@wix/auto_sdk_members_custom-fields": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/@wix/auto_sdk_members_custom-fields-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_custom-fields/-/auto_sdk_members_custom-fields-1.0.59.tgz",
    "integrity": "sha512-e0Gj3mWXzv1VDGY95CMh1zVp6YQGbLuURD4TTDuxETvqEYMFzTtDXfTuGi90MbEWAwTk1aqYF8BR0gKL0ILV8Q==",
    "license": "MIT",
    "dependencies": {
@@ -3060,7 +3060,7 @@
   },
   "node_modules/@wix/auto_sdk_members_default-privacy": {
    "version": "1.0.34",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/@wix/auto_sdk_members_default-privacy-1.0.34.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_default-privacy/-/auto_sdk_members_default-privacy-1.0.34.tgz",
    "integrity": "sha512-pgAe1M898aSSnYKn0mIf8SdGNeA2lK8OI9vncLv9kV1wknP5ue6/eNr3GEBl5JawspoifxbyuD7C+c1R8WiLBw==",
    "license": "MIT",
    "dependencies": {
@@ -3071,7 +3071,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-followers": {
    "version": "1.0.44",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/@wix/auto_sdk_members_member-followers-1.0.44.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-followers/-/auto_sdk_members_member-followers-1.0.44.tgz",
    "integrity": "sha512-LVxdoeXewsZul72frlyLY5PYU6Ycz6ddbvYkhZr09TCgP6sPvwCuI+br/r3sxGwJ3XlM3w9cFtwOc6cZf40+eA==",
    "license": "MIT",
    "dependencies": {
@@ -3082,7 +3082,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-privacy-settings": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/@wix/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-privacy-settings/-/auto_sdk_members_member-privacy-settings-1.0.59.tgz",
    "integrity": "sha512-JpcWY+fppyjBXfwcIX7ztlo34ZpA+b7Cbhh62oaH8fzQq7PpfVk9zc94FT2EEiwutaipgJOU4SyrLl3/JULwGA==",
    "license": "MIT",
    "dependencies": {
@@ -3093,7 +3093,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-report": {
    "version": "1.0.49",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/@wix/auto_sdk_members_member-report-1.0.49.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-report/-/auto_sdk_members_member-report-1.0.49.tgz",
    "integrity": "sha512-kx+netTOEhPS32d98pgko+fbwyR4HT87TlxdKqg1aBaJBrDEz2M533wc8wTJX1TArj9B41ew39k/fXdbfCEozA==",
    "license": "MIT",
    "dependencies": {
@@ -3104,7 +3104,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-role-definition": {
    "version": "1.0.47",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/@wix/auto_sdk_members_member-role-definition-1.0.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-role-definition/-/auto_sdk_members_member-role-definition-1.0.47.tgz",
    "integrity": "sha512-PpGcfee/QCqtCU4U7KdGjqe8CB8ereXnMxLleisyapNWhwfWo1r1XBfq4EaVc0GF9uLdozWWx6Oums/bB42E6g==",
    "license": "MIT",
    "dependencies": {
@@ -3115,7 +3115,7 @@
   },
   "node_modules/@wix/auto_sdk_members_member-to-member-block": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/@wix/auto_sdk_members_member-to-member-block-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_member-to-member-block/-/auto_sdk_members_member-to-member-block-1.0.35.tgz",
    "integrity": "sha512-U5Z5l7KGpYztXtz0E3V7JNogdJGNCPmcR5yjeEZdT0u8yZTQKsnF7hNvMxxyv2RMGJwCNmdYLHbFYj/ic/Futw==",
    "license": "MIT",
    "dependencies": {
@@ -3126,7 +3126,7 @@
   },
   "node_modules/@wix/auto_sdk_members_members": {
    "version": "1.0.131",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/@wix/auto_sdk_members_members-1.0.131.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members/-/auto_sdk_members_members-1.0.131.tgz",
    "integrity": "sha512-kgPFRm1faDjRsCv7kOcALlZiHpBJ9Ix5PZy8NJxzJEu2kKBdkdH6kVBTk+R13lRO6XkK5NRPytY9cinu2suP2g==",
    "license": "MIT",
    "dependencies": {
@@ -3137,7 +3137,7 @@
   },
   "node_modules/@wix/auto_sdk_members_members-about": {
    "version": "1.0.78",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/@wix/auto_sdk_members_members-about-1.0.78.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_members-about/-/auto_sdk_members_members-about-1.0.78.tgz",
    "integrity": "sha512-HPXMekpWcexRubnf5gA0flYiYktEcsj4kMi0oyC47zTTIO7tmpqjJULH365y8rzDx6vPLUb25Lzyb+rCZPTxwA==",
    "license": "MIT",
    "dependencies": {
@@ -3148,7 +3148,7 @@
   },
   "node_modules/@wix/auto_sdk_members_user-member": {
    "version": "1.0.56",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/@wix/auto_sdk_members_user-member-1.0.56.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_members_user-member/-/auto_sdk_members_user-member-1.0.56.tgz",
    "integrity": "sha512-FMiVGhE+F6psLwXTKC4Rz2W/dDl1Sa2Fj/P80+jDkTZ5IDR5c4Qq5M3Prlj7MmHIjSx7OsEX6zdRVoGFBjfA0w==",
    "license": "MIT",
    "dependencies": {
@@ -3159,7 +3159,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -3170,7 +3170,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -3189,7 +3189,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3199,13 +3199,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3214,7 +3214,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3253,7 +3253,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3269,7 +3269,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3281,7 +3281,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3293,7 +3293,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3307,7 +3307,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -3334,7 +3334,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -3344,7 +3344,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -3353,7 +3353,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -3373,7 +3373,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -3406,7 +3406,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -3416,7 +3416,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -3434,7 +3434,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -3444,7 +3444,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -3455,7 +3455,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3466,7 +3466,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3477,7 +3477,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -3486,7 +3486,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -3499,7 +3499,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -3509,7 +3509,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -3522,7 +3522,7 @@
   },
   "node_modules/@wix/members": {
    "version": "1.0.511",
-   "resolved": "https://registry.npmjs.org/@wix/members/-/@wix/members-1.0.511.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/members/-/members-1.0.511.tgz",
    "integrity": "sha512-n30tjMx6LAiDiCVT2jnenoFIxEwgIwbn7S5pWbesVvo73+mDuyn0+bxVJJw0acGY00nvnmpJsdrU28VMOz5CKw==",
    "license": "MIT",
    "dependencies": {
@@ -3556,7 +3556,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3566,7 +3566,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3575,13 +3575,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -3593,7 +3593,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3602,13 +3602,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3619,7 +3619,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3630,7 +3630,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3639,19 +3639,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -3663,7 +3663,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3674,7 +3674,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3683,13 +3683,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -3699,13 +3699,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3714,7 +3714,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3724,13 +3724,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -3739,7 +3739,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -3764,7 +3764,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -3773,7 +3773,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -3783,7 +3783,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -3794,7 +3794,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -3804,7 +3804,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -3812,7 +3812,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -3823,7 +3823,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -3840,7 +3840,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3854,7 +3854,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/portfolio/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/portfolio/lock/astro/package-lock.json
@@ -2670,18 +2670,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -2697,7 +2697,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -2724,7 +2724,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -2732,7 +2732,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -2744,7 +2744,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -2753,7 +2753,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -2763,7 +2763,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -2774,7 +2774,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -2785,7 +2785,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -2796,7 +2796,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -2807,7 +2807,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -2818,7 +2818,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -2829,7 +2829,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -2840,7 +2840,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -2851,7 +2851,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -2862,7 +2862,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -2873,7 +2873,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -2884,7 +2884,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -2895,7 +2895,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -2906,7 +2906,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -2917,7 +2917,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -2928,7 +2928,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -2939,7 +2939,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -2950,7 +2950,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -2961,7 +2961,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -2972,7 +2972,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_collections": {
    "version": "1.0.44",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_collections/-/@wix/auto_sdk_portfolio_collections-1.0.44.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_collections/-/auto_sdk_portfolio_collections-1.0.44.tgz",
    "integrity": "sha512-XrnVP9shj7IggnXRO4dkuUKbfjhQCFCu5HI7Llntj1mogiSkMCmuEN6HF9lVOFCwBY22m5+0qMJx8b0HtdsoaQ==",
    "license": "MIT",
    "dependencies": {
@@ -2983,7 +2983,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_portfolio-settings": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_portfolio-settings/-/@wix/auto_sdk_portfolio_portfolio-settings-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_portfolio-settings/-/auto_sdk_portfolio_portfolio-settings-1.0.38.tgz",
    "integrity": "sha512-KmS+0vJpQMpKpZSaf1dtS3c3CxsDSZnBHl23BQ5TOHdCmF6gynygVWMlIF36cC0rE4nxpIbZEVLO10w/GiMzRQ==",
    "license": "MIT",
    "dependencies": {
@@ -2994,7 +2994,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_project-in-collections": {
    "version": "1.0.43",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-in-collections/-/@wix/auto_sdk_portfolio_project-in-collections-1.0.43.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-in-collections/-/auto_sdk_portfolio_project-in-collections-1.0.43.tgz",
    "integrity": "sha512-Sg1X8u5K7d1Ssa0JKgdVp1R5Kqw2JsjDbHF9HWV2VhaJxP2KTg3cvQuNNleFEx+T25ZWWeQ9E/2WNUXdtbx6Xw==",
    "license": "MIT",
    "dependencies": {
@@ -3005,7 +3005,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_project-items": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-items/-/@wix/auto_sdk_portfolio_project-items-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_project-items/-/auto_sdk_portfolio_project-items-1.0.46.tgz",
    "integrity": "sha512-Ps1XfzcB7b+bRZSAvXzdw3aeVvI34/efG3XV9jLHiDe4hDA7Ppkc1f4UprGkTCe+6KGy7A5j2bBimVy0iTAM4Q==",
    "license": "MIT",
    "dependencies": {
@@ -3016,7 +3016,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_projects": {
    "version": "1.0.59",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_projects/-/@wix/auto_sdk_portfolio_projects-1.0.59.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_projects/-/auto_sdk_portfolio_projects-1.0.59.tgz",
    "integrity": "sha512-VeuLjnpjtq/VygzqU+pmcKoPve0T3yRRT54LLeW/xb/D4sN51OapMXgGDhQZVs47VOBwbUbFU5iDrOxExlcgFw==",
    "license": "MIT",
    "dependencies": {
@@ -3027,7 +3027,7 @@
   },
   "node_modules/@wix/auto_sdk_portfolio_synced-project": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_synced-project/-/@wix/auto_sdk_portfolio_synced-project-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_portfolio_synced-project/-/auto_sdk_portfolio_synced-project-1.0.46.tgz",
    "integrity": "sha512-kQMxHJeKIVMo0mxmwNlHc2O8CzB31jP6/QQdnCf7UhpaHJoDTLcPFXKz0Ton0rHjeenI/O3Xz54C/WByEFFshQ==",
    "license": "MIT",
    "dependencies": {
@@ -3038,7 +3038,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -3049,7 +3049,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -3068,7 +3068,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3078,13 +3078,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3093,7 +3093,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3132,7 +3132,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3148,7 +3148,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3160,7 +3160,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3172,7 +3172,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3186,7 +3186,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -3213,7 +3213,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -3223,7 +3223,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -3232,7 +3232,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -3252,7 +3252,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -3285,7 +3285,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -3295,7 +3295,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -3313,7 +3313,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -3323,7 +3323,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -3334,7 +3334,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3345,7 +3345,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3356,7 +3356,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -3365,7 +3365,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -3378,7 +3378,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -3388,7 +3388,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -3410,7 +3410,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3420,7 +3420,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3429,13 +3429,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -3447,7 +3447,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3456,13 +3456,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3473,7 +3473,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3484,7 +3484,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3493,19 +3493,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -3517,7 +3517,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3528,7 +3528,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3537,13 +3537,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -3553,7 +3553,7 @@
   },
   "node_modules/@wix/portfolio": {
    "version": "1.0.229",
-   "resolved": "https://registry.npmjs.org/@wix/portfolio/-/@wix/portfolio-1.0.229.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/portfolio/-/portfolio-1.0.229.tgz",
    "integrity": "sha512-eAK3mRJ6q7Ca5/Ror6926jbZLqzfo7dNDG9A6iI1XAyuUwpDaFseLHgwFsz+EnH2y5y6mXRfwh8QS7/Pa78yMg==",
    "license": "MIT",
    "dependencies": {
@@ -3567,13 +3567,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3582,7 +3582,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3592,13 +3592,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -3607,7 +3607,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -3632,7 +3632,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -3641,7 +3641,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -3651,7 +3651,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -3662,7 +3662,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -3672,7 +3672,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -3680,7 +3680,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -3691,7 +3691,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -3708,7 +3708,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3722,7 +3722,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/pricing-plans/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/pricing-plans/lock/astro/package-lock.json
@@ -3380,18 +3380,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -3407,7 +3407,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -3434,7 +3434,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -3442,7 +3442,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -3454,7 +3454,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -3463,7 +3463,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -3473,7 +3473,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -3484,7 +3484,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -3495,7 +3495,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -3506,7 +3506,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -3517,7 +3517,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -3528,7 +3528,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -3539,7 +3539,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -3550,7 +3550,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -3561,7 +3561,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -3572,7 +3572,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout": {
    "version": "1.0.168",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/auto_sdk_ecom_checkout-1.0.168.tgz",
    "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
    "license": "MIT",
    "dependencies": {
@@ -3583,7 +3583,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_current-cart": {
    "version": "1.0.184",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/auto_sdk_ecom_current-cart-1.0.184.tgz",
    "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
    "license": "MIT",
    "dependencies": {
@@ -3594,7 +3594,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -3605,7 +3605,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -3616,7 +3616,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -3627,7 +3627,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -3638,7 +3638,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -3649,7 +3649,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -3660,7 +3660,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -3671,7 +3671,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -3682,7 +3682,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -3693,7 +3693,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -3704,7 +3704,7 @@
   },
   "node_modules/@wix/auto_sdk_pricing-plans_orders": {
    "version": "1.0.123",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_orders/-/@wix/auto_sdk_pricing-plans_orders-1.0.123.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_orders/-/auto_sdk_pricing-plans_orders-1.0.123.tgz",
    "integrity": "sha512-EbQCnpIZj1G3qmBpDKjjthxwmDq7KZHjZYkL/qipbCk/Bpzk4bcZPv3KLk6zePxDY4vARtayWjtWUL1qc5487w==",
    "license": "MIT",
    "dependencies": {
@@ -3715,7 +3715,7 @@
   },
   "node_modules/@wix/auto_sdk_pricing-plans_plan-benefits": {
    "version": "1.0.11",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plan-benefits/-/@wix/auto_sdk_pricing-plans_plan-benefits-1.0.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plan-benefits/-/auto_sdk_pricing-plans_plan-benefits-1.0.11.tgz",
    "integrity": "sha512-wcuZw3A1vBQ9EeW/i8mRXF3U6C98xz9Coa38Jvwx3EEhPQSY884CSIrtL/ceYK3oGiwLYjkHFbbAxukjrRIilQ==",
    "license": "MIT",
    "dependencies": {
@@ -3726,7 +3726,7 @@
   },
   "node_modules/@wix/auto_sdk_pricing-plans_plans": {
    "version": "1.0.114",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans/-/@wix/auto_sdk_pricing-plans_plans-1.0.114.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans/-/auto_sdk_pricing-plans_plans-1.0.114.tgz",
    "integrity": "sha512-5s78KfEzQ9ZPXPsLC4iF7KZZa0HJ3jruu9oMkcOlTLrbZvYrRQ5d/nPxWElvD/uvrThiWwe0LzYArY7YUMkbUg==",
    "license": "MIT",
    "dependencies": {
@@ -3737,7 +3737,7 @@
   },
   "node_modules/@wix/auto_sdk_pricing-plans_plans-v-3": {
    "version": "1.0.109",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans-v-3/-/@wix/auto_sdk_pricing-plans_plans-v-3-1.0.109.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_plans-v-3/-/auto_sdk_pricing-plans_plans-v-3-1.0.109.tgz",
    "integrity": "sha512-Cz8G41eYA3LVY7+OmHlP8Omi8sExn9QlXiAb7C/6MSWUZQYUPRhJlfe0JJhk3dUZkrE0uhMz6YagtvcJYyevTA==",
    "license": "MIT",
    "dependencies": {
@@ -3748,7 +3748,7 @@
   },
   "node_modules/@wix/auto_sdk_pricing-plans_pricing-plans-settings": {
    "version": "1.0.50",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_pricing-plans-settings/-/@wix/auto_sdk_pricing-plans_pricing-plans-settings-1.0.50.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_pricing-plans_pricing-plans-settings/-/auto_sdk_pricing-plans_pricing-plans-settings-1.0.50.tgz",
    "integrity": "sha512-KcZNYW1ADc4shcy4IQYDY5AZEsPGAE5owjtq2eFOIYzCthd8cOoNBRNhG+GbEJcZn0jafprM6m7AtQMB/CsuWw==",
    "license": "MIT",
    "dependencies": {
@@ -3759,7 +3759,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -3770,7 +3770,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -3789,7 +3789,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3799,13 +3799,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3814,7 +3814,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3853,7 +3853,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3869,7 +3869,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3881,7 +3881,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3893,7 +3893,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -3907,7 +3907,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -3934,7 +3934,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -3944,7 +3944,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -3953,7 +3953,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -3973,7 +3973,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4006,7 +4006,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -4016,7 +4016,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -4047,7 +4047,7 @@
   },
   "node_modules/@wix/headless-ecom": {
    "version": "0.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/headless-ecom-0.0.40.tgz",
    "integrity": "sha512-ib8dYXCeHlo/UYck/CE9v3AkFXI0r5Dn+6ZRH1I2ylxrZMy7Lqj2GF0gwvoOwEKdDbjuNhWEvTY9X4tg6tN0Qg==",
    "license": "MIT",
    "dependencies": {
@@ -4066,7 +4066,7 @@
   },
   "node_modules/@wix/headless-ecom/node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -4077,7 +4077,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -4087,7 +4087,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -4098,7 +4098,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4109,7 +4109,7 @@
   },
   "node_modules/@wix/headless-pricing-plans": {
    "version": "0.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/headless-pricing-plans/-/@wix/headless-pricing-plans-0.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-pricing-plans/-/headless-pricing-plans-0.0.22.tgz",
    "integrity": "sha512-UoEveDTVRuolrnu4b38cJi4DmTfndCcnfV3KCCvsdlX6ubo929gVJ2wEZ06m3Op4+cSldCNVQruk0ISIyCM/fA==",
    "license": "MIT",
    "dependencies": {
@@ -4130,7 +4130,7 @@
   },
   "node_modules/@wix/headless-pricing-plans/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -4181,7 +4181,7 @@
   },
   "node_modules/@wix/headless-pricing-plans/node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -4192,7 +4192,7 @@
   },
   "node_modules/@wix/headless-pricing-plans/node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -4214,7 +4214,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4225,7 +4225,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -4247,7 +4247,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -4260,7 +4260,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -4270,7 +4270,7 @@
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -4292,7 +4292,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4302,7 +4302,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4311,13 +4311,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -4329,7 +4329,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4338,13 +4338,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4355,7 +4355,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4366,7 +4366,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4375,19 +4375,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -4399,7 +4399,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4410,7 +4410,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4419,13 +4419,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -4435,7 +4435,7 @@
   },
   "node_modules/@wix/pricing-plans": {
    "version": "1.0.378",
-   "resolved": "https://registry.npmjs.org/@wix/pricing-plans/-/@wix/pricing-plans-1.0.378.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/pricing-plans/-/pricing-plans-1.0.378.tgz",
    "integrity": "sha512-eHYkjXxbnneilhlA2pNWGiS6eAR66yaQIb3SEdp4Afj4z3F1aYp5ETs6iwJOs1suVbQXsr2t74S8DUfiHzDq3w==",
    "license": "MIT",
    "dependencies": {
@@ -4449,13 +4449,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4464,7 +4464,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4474,13 +4474,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -4489,7 +4489,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -4514,7 +4514,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -4523,7 +4523,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -4533,7 +4533,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -4544,7 +4544,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -4554,7 +4554,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -4562,7 +4562,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "peer": true,
    "dependencies": {
@@ -4573,7 +4573,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -4590,7 +4590,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4604,7 +4604,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/restaurants/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/restaurants/lock/astro/package-lock.json
@@ -3448,18 +3448,18 @@
   },
   "node_modules/@wix/analytics": {
    "version": "1.19.0",
-   "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
    "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
    "license": "MIT"
   },
   "node_modules/@wix/app-extensions": {
    "version": "1.0.133",
-   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
    "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
   },
   "node_modules/@wix/app-management": {
    "version": "1.0.158",
-   "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
    "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
    "license": "MIT",
    "dependencies": {
@@ -3475,7 +3475,7 @@
   },
   "node_modules/@wix/astro": {
    "version": "2.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
    "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
    "dependencies": {
     "@wix/app-management": "^1.0.149",
@@ -3502,7 +3502,7 @@
   },
   "node_modules/@wix/astro-pages": {
    "version": "2.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
    "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
    "peerDependencies": {
     "astro": "^5.0.0"
@@ -3510,7 +3510,7 @@
   },
   "node_modules/@wix/astro-wix-hosting-adapter": {
    "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
    "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
    "dev": true,
    "dependencies": {
@@ -3522,7 +3522,7 @@
   },
   "node_modules/@wix/atlas": {
    "version": "1.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/atlas/-/@wix/atlas-1.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/atlas/-/atlas-1.0.41.tgz",
    "integrity": "sha512-DC7EbCMrXKHjh9tG3dwIY4yXZxZv+dB8I1EqifqA65N035vJaTHep3Pqam82TuJ4ykq1Fy+GAnvewF0oXukAjQ==",
    "license": "MIT",
    "dependencies": {
@@ -3533,7 +3533,7 @@
   },
   "node_modules/@wix/auth-management": {
    "version": "1.0.91",
-   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
    "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
    "license": "MIT",
    "dependencies": {
@@ -3542,7 +3542,7 @@
   },
   "node_modules/@wix/authentication": {
    "version": "1.16.0",
-   "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
    "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
    "license": "MIT",
    "dependencies": {
@@ -3552,7 +3552,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-instances": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
    "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
    "license": "MIT",
    "dependencies": {
@@ -3563,7 +3563,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-permissions": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
    "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
    "license": "MIT",
    "dependencies": {
@@ -3574,7 +3574,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_app-plans": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
    "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
    "license": "MIT",
    "dependencies": {
@@ -3585,7 +3585,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_bi-events": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
    "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
    "license": "MIT",
    "dependencies": {
@@ -3596,7 +3596,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_billing": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
    "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
    "license": "MIT",
    "dependencies": {
@@ -3607,7 +3607,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_custom-charges": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
    "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
    "license": "MIT",
    "dependencies": {
@@ -3618,7 +3618,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
    "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
    "license": "MIT",
    "dependencies": {
@@ -3629,7 +3629,7 @@
   },
   "node_modules/@wix/auto_sdk_app-management_external-billing": {
    "version": "1.0.32",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
    "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
    "license": "MIT",
    "dependencies": {
@@ -3640,7 +3640,7 @@
   },
   "node_modules/@wix/auto_sdk_atlas_autocomplete": {
    "version": "1.0.16",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_autocomplete/-/@wix/auto_sdk_atlas_autocomplete-1.0.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_autocomplete/-/auto_sdk_atlas_autocomplete-1.0.16.tgz",
    "integrity": "sha512-h0mtI9WxJzhyvEbgD0Cjj4iWaVuOcr6byHGPTQrLUoFVC5Sgj/YIP4+g1qPydnkzyJhR33PQP5ew56fFKu8nHA==",
    "license": "MIT",
    "dependencies": {
@@ -3651,7 +3651,7 @@
   },
   "node_modules/@wix/auto_sdk_atlas_location": {
    "version": "1.0.16",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_location/-/@wix/auto_sdk_atlas_location-1.0.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_location/-/auto_sdk_atlas_location-1.0.16.tgz",
    "integrity": "sha512-KhxUJ/7V5AU+w3rqeFoI6Y6Fjpc01HPW5r1oX0iq/fgWU3pglbXHilzzBruEawsPqrzhTnLryfYqzwjo5eITcg==",
    "license": "MIT",
    "dependencies": {
@@ -3662,7 +3662,7 @@
   },
   "node_modules/@wix/auto_sdk_atlas_places": {
    "version": "1.0.16",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_places/-/@wix/auto_sdk_atlas_places-1.0.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_atlas_places/-/auto_sdk_atlas_places-1.0.16.tgz",
    "integrity": "sha512-0ZqxQpoUfl4UOD8QMQ+B3g1SQWbTRRdGS5u8iG2NkZtVbA+sQuvOH3iLNlcOKzKVUyjh4XtbEnBlmCx66cpibg==",
    "license": "MIT",
    "dependencies": {
@@ -3673,7 +3673,7 @@
   },
   "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
    "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
    "license": "MIT",
    "dependencies": {
@@ -3684,7 +3684,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_abandoned-checkouts": {
    "version": "1.0.83",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_abandoned-checkouts/-/@wix/auto_sdk_ecom_abandoned-checkouts-1.0.83.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_abandoned-checkouts/-/auto_sdk_ecom_abandoned-checkouts-1.0.83.tgz",
    "integrity": "sha512-k7mo7MuxcFgwyq6aUrBEaVjsDOkSceXb0jDSKYRFMsysivlQ3H5Io+ZOvFJ2NlBJT4Kq3OStXj4hyvIEFuJNzQ==",
    "license": "MIT",
    "dependencies": {
@@ -3695,7 +3695,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_additional-fees": {
    "version": "1.0.49",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_additional-fees/-/@wix/auto_sdk_ecom_additional-fees-1.0.49.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_additional-fees/-/auto_sdk_ecom_additional-fees-1.0.49.tgz",
    "integrity": "sha512-ouF6gC/hZQXIiQM3HN/88Svf/TUEmHpDRyEGCSGNiG+DDb7WMQ5lgo+elnrZ5xsrK8nh3ir9wCcZf4Et511wuw==",
    "license": "MIT",
    "dependencies": {
@@ -3706,7 +3706,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_back-in-stock-notifications": {
    "version": "1.0.63",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-notifications/-/@wix/auto_sdk_ecom_back-in-stock-notifications-1.0.63.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-notifications/-/auto_sdk_ecom_back-in-stock-notifications-1.0.63.tgz",
    "integrity": "sha512-9enqO6pwJU114uhnaa4v0f2qj8VWYexYHUutP86qxmadNVi0ekEQUrif5VonByPRgIgGTFlGwIPP5BD4L0BeoA==",
    "license": "MIT",
    "dependencies": {
@@ -3717,7 +3717,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_back-in-stock-settings": {
    "version": "1.0.42",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-settings/-/@wix/auto_sdk_ecom_back-in-stock-settings-1.0.42.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-settings/-/auto_sdk_ecom_back-in-stock-settings-1.0.42.tgz",
    "integrity": "sha512-YKRGIjbKqhtXnfSrGjqPSwqLDCjt2Se9q11ro0vI+9zoyyfWmsRIR4oYt1quZ/m7w8Qz79auLt1z80WRFJehOA==",
    "license": "MIT",
    "dependencies": {
@@ -3728,7 +3728,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_cart": {
    "version": "1.0.174",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart/-/@wix/auto_sdk_ecom_cart-1.0.174.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart/-/auto_sdk_ecom_cart-1.0.174.tgz",
    "integrity": "sha512-bng9lfcWQ0XJ1Nr0SKe2v7yen9SprlZRHRuQ+iXe27VJWjmFhGcUGj7xqCtbLj9zTQ91DBU916eYIo9YBM5WRw==",
    "license": "MIT",
    "dependencies": {
@@ -3739,7 +3739,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
    "version": "1.0.192",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/@wix/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
    "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
    "license": "MIT",
    "dependencies": {
@@ -3750,7 +3750,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_catalog": {
    "version": "1.0.64",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_catalog/-/@wix/auto_sdk_ecom_catalog-1.0.64.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_catalog/-/auto_sdk_ecom_catalog-1.0.64.tgz",
    "integrity": "sha512-fKmFDucjlRKPCiLiTseBSTVGTQQyvn6Hap9gLzkF/+IFsKCg515Z+pSs2ds8os8D3V4DZCUkOfYJenzleJw01Q==",
    "license": "MIT",
    "dependencies": {
@@ -3761,7 +3761,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout": {
    "version": "1.0.168",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/auto_sdk_ecom_checkout-1.0.168.tgz",
    "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
    "license": "MIT",
    "dependencies": {
@@ -3772,7 +3772,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout-content": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-content/-/@wix/auto_sdk_ecom_checkout-content-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-content/-/auto_sdk_ecom_checkout-content-1.0.37.tgz",
    "integrity": "sha512-RrG3rzJBFGTCQR1hG9RX9/p9z07dfqNHjDtZs9DZUbHlsgqZlo8mJ6H28Th2tUlc7LaFBJ90l+3/qlJwSCzL/g==",
    "license": "MIT",
    "dependencies": {
@@ -3783,7 +3783,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout-settings": {
    "version": "1.0.73",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-settings/-/@wix/auto_sdk_ecom_checkout-settings-1.0.73.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-settings/-/auto_sdk_ecom_checkout-settings-1.0.73.tgz",
    "integrity": "sha512-2j8Z3dbhox4Hs0n0VmUUcEyreOX02OYkPyRk9MTGI51L6i4Bd5rWWxaqn74boDURcgQjF9JTxAlXXQvfvDC0eA==",
    "license": "MIT",
    "dependencies": {
@@ -3794,7 +3794,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_checkout-templates": {
    "version": "1.0.150",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-templates/-/@wix/auto_sdk_ecom_checkout-templates-1.0.150.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-templates/-/auto_sdk_ecom_checkout-templates-1.0.150.tgz",
    "integrity": "sha512-jomZhO1xhmmHX/FYaijYI8+g8b05rSn+X2bGIpVFGsjynZCj0lXyxcMKJxANk+t6D11pxf4oIoF8o45EpzkVBg==",
    "license": "MIT",
    "dependencies": {
@@ -3805,7 +3805,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_contact-tax-details": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_contact-tax-details/-/@wix/auto_sdk_ecom_contact-tax-details-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_contact-tax-details/-/auto_sdk_ecom_contact-tax-details-1.0.3.tgz",
    "integrity": "sha512-kx7Q+0QWzc0TCqPINuhLjXuFacrkxl1Vc3hmF/ZtqiTpHZ4xoegAaHOhiQ20l7mNXbgAWajn1bVVNS/ZNHxD1g==",
    "license": "MIT",
    "dependencies": {
@@ -3816,7 +3816,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_currencies": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_currencies/-/@wix/auto_sdk_ecom_currencies-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_currencies/-/auto_sdk_ecom_currencies-1.0.35.tgz",
    "integrity": "sha512-gfCYsiJ4zsDbm9PGxhi/paZEW8lJZdUnIEAPneRU9lfvGK+6QbM5TRJd74Fwcgsp8K82O15DPfzlZ0tH9Y02kQ==",
    "license": "MIT",
    "dependencies": {
@@ -3827,7 +3827,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_current-cart": {
    "version": "1.0.184",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/auto_sdk_ecom_current-cart-1.0.184.tgz",
    "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
    "license": "MIT",
    "dependencies": {
@@ -3838,7 +3838,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_current-cart-v-2": {
    "version": "1.0.193",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart-v-2/-/@wix/auto_sdk_ecom_current-cart-v-2-1.0.193.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart-v-2/-/auto_sdk_ecom_current-cart-v-2-1.0.193.tgz",
    "integrity": "sha512-H9v8Jsmm+TXPSZ/WlQD9Gz/lLJIKzZIQHW/FOB/VfOBC20yufghAhZl9g05YgBWoBydtmNePS/wOQGzVwJ1nVQ==",
    "license": "MIT",
    "dependencies": {
@@ -3849,7 +3849,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_custom-triggers": {
    "version": "1.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_custom-triggers/-/@wix/auto_sdk_ecom_custom-triggers-1.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_custom-triggers/-/auto_sdk_ecom_custom-triggers-1.0.40.tgz",
    "integrity": "sha512-4pbt7WOMuMSQIEre/Do0LmcF3RdSVvE6Z3538pTg9jCvg6R+uBb/mycBNu/Za3iJNrcsYmv62Zq6p8y+BuHdbA==",
    "license": "MIT",
    "dependencies": {
@@ -3860,7 +3860,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_delivery-profile": {
    "version": "1.0.440",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-profile/-/@wix/auto_sdk_ecom_delivery-profile-1.0.440.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-profile/-/auto_sdk_ecom_delivery-profile-1.0.440.tgz",
    "integrity": "sha512-KZA+tN85AR65oUvmsVr0WTOBLkwYq18piO+8QE5ug5XxLSLLnwC7WUBqGDbm5N6GWxW1L2cJu8eIIqBzPxPY+A==",
    "license": "MIT",
    "dependencies": {
@@ -3871,7 +3871,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_delivery-solutions": {
    "version": "1.0.62",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-solutions/-/@wix/auto_sdk_ecom_delivery-solutions-1.0.62.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-solutions/-/auto_sdk_ecom_delivery-solutions-1.0.62.tgz",
    "integrity": "sha512-YuLWOYsSSrfhZ/RpKa/67Qel8O9Ft1Qz8VebclOuAB1JrAV25zsMVh3Ks8yJeBPdOfawlcL4ECGbMi4t6v9b4A==",
    "license": "MIT",
    "dependencies": {
@@ -3882,7 +3882,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_discount-rules": {
    "version": "1.0.115",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discount-rules/-/@wix/auto_sdk_ecom_discount-rules-1.0.115.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discount-rules/-/auto_sdk_ecom_discount-rules-1.0.115.tgz",
    "integrity": "sha512-K0TMVir6a7o5pSvetPebJELwuVrhMiPwhyC6dtnTmdHNYwmMVpGZlkloJowNcra9kCiPm1iGKRSrvSu4SxtjmQ==",
    "license": "MIT",
    "dependencies": {
@@ -3893,7 +3893,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_discounts": {
    "version": "1.0.34",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts/-/@wix/auto_sdk_ecom_discounts-1.0.34.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts/-/auto_sdk_ecom_discounts-1.0.34.tgz",
    "integrity": "sha512-UBSaqNnZrivhDAhrDYmGceibwe0sYCd+RQEbAOPn/8ZlXKnS9R6VCVjxvmgMqrnQ9Cpyht8WGS/df61g2ID8Sg==",
    "license": "MIT",
    "dependencies": {
@@ -3904,7 +3904,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_discounts-custom-trigger": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts-custom-trigger/-/@wix/auto_sdk_ecom_discounts-custom-trigger-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts-custom-trigger/-/auto_sdk_ecom_discounts-custom-trigger-1.0.45.tgz",
    "integrity": "sha512-ykH8JVbiXukiHCtikksv5NjrjLec+8I9M6kf8RrwGekgD1NXX73hvij4XV8tJp8Pxm14OTPocGmTl/vPA00/gA==",
    "license": "MIT",
    "dependencies": {
@@ -3915,7 +3915,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_draft-orders": {
    "version": "1.0.171",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-orders/-/@wix/auto_sdk_ecom_draft-orders-1.0.171.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-orders/-/auto_sdk_ecom_draft-orders-1.0.171.tgz",
    "integrity": "sha512-DZkSx3spJDmXsDxf0EhQg30EjNJoEuaixlJGPcXJn43mQTtFeb0pI4s3hlikS1ZsXsJPdyefhYcPn6d8/jq9Eg==",
    "license": "MIT",
    "dependencies": {
@@ -3926,7 +3926,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_draft-subscription-contracts": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-subscription-contracts/-/@wix/auto_sdk_ecom_draft-subscription-contracts-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-subscription-contracts/-/auto_sdk_ecom_draft-subscription-contracts-1.0.7.tgz",
    "integrity": "sha512-IqP/MoK8T0YlDvcmrH9OkZrvaUMKnPyky1/+aXZ4qM4IQH1AiVi6S34vU/BwOlwMC37EMaJWVnaZ82j986xS/Q==",
    "license": "MIT",
    "dependencies": {
@@ -3937,7 +3937,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_ecommerce-settings": {
    "version": "1.0.33",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_ecommerce-settings/-/@wix/auto_sdk_ecom_ecommerce-settings-1.0.33.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_ecommerce-settings/-/auto_sdk_ecom_ecommerce-settings-1.0.33.tgz",
    "integrity": "sha512-2Wy6YrZV488ENvXmy9lIUYW65qSJ7KkgLYVZeH211EESGXqpKYHjSeMafopBpN+ycz3huzwYtyhoTqVQ577uwg==",
    "license": "MIT",
    "dependencies": {
@@ -3948,7 +3948,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_gift-vouchers": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers/-/@wix/auto_sdk_ecom_gift-vouchers-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers/-/auto_sdk_ecom_gift-vouchers-1.0.45.tgz",
    "integrity": "sha512-z+n1zAZ/EHFP1fKjRNXNDNbUsx/G/sy5KFJES2+l/Ipzgsu/m/9smBzjtJlKndf0MMCxeSQk6sU2pa92pEt0fQ==",
    "license": "MIT",
    "dependencies": {
@@ -3959,7 +3959,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_gift-vouchers-provider": {
    "version": "1.0.35",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers-provider/-/@wix/auto_sdk_ecom_gift-vouchers-provider-1.0.35.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers-provider/-/auto_sdk_ecom_gift-vouchers-provider-1.0.35.tgz",
    "integrity": "sha512-57/A3DK88Awz8fgmfkEc51tPEsCfJgzkQCYrCUsgaHPyJZ2froVF+UfDvBDPqlFCJhbmI4ZAtYWhXUXzsxezfg==",
    "license": "MIT",
    "dependencies": {
@@ -3970,7 +3970,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_inventory": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_inventory/-/@wix/auto_sdk_ecom_inventory-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_inventory/-/auto_sdk_ecom_inventory-1.0.24.tgz",
    "integrity": "sha512-gvhjYT5NtAcsfSuvth7Y3JNsKajAPJswdot7Vtvojx+tOAQLgdCtvBdS+CY27Ms1HRcVUjqGSUg1czu4IKaZUw==",
    "license": "MIT",
    "dependencies": {
@@ -3981,7 +3981,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_local-delivery-options": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_local-delivery-options/-/@wix/auto_sdk_ecom_local-delivery-options-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_local-delivery-options/-/auto_sdk_ecom_local-delivery-options-1.0.53.tgz",
    "integrity": "sha512-9Bw2w1MNgMaQNNmNNegDWn4YHuycjJMzBH3CObEZuSrpGk0pBz/oHJyUAGFLcfrNu3QHSMfqqHUk78T1wXi7bg==",
    "license": "MIT",
    "dependencies": {
@@ -3992,7 +3992,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_manual-tax-mappings": {
    "version": "1.0.43",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_manual-tax-mappings/-/@wix/auto_sdk_ecom_manual-tax-mappings-1.0.43.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_manual-tax-mappings/-/auto_sdk_ecom_manual-tax-mappings-1.0.43.tgz",
    "integrity": "sha512-5lOIYwVHFoiHMTumdGO/Hz8EBMUUHaolJ2cBhopfQE4KM0g4iWQad8tmQxNAo229azQB3LySnFm3O0dQSA/fSg==",
    "license": "MIT",
    "dependencies": {
@@ -4003,7 +4003,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_memberships": {
    "version": "1.0.66",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_memberships/-/@wix/auto_sdk_ecom_memberships-1.0.66.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_memberships/-/auto_sdk_ecom_memberships-1.0.66.tgz",
    "integrity": "sha512-oSjsAhJOk/a7v5+Pfd3AYLx43sdU6knnc8kiGRuZdeZg4Mu1mhqLXsmhfdLo/dvILqbgf/bEkLwLQ6Gg/yxmOQ==",
    "license": "MIT",
    "dependencies": {
@@ -4014,7 +4014,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_order-billing": {
    "version": "1.0.104",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-billing/-/@wix/auto_sdk_ecom_order-billing-1.0.104.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-billing/-/auto_sdk_ecom_order-billing-1.0.104.tgz",
    "integrity": "sha512-mhC2hVZb65oPwc0/y4gthsSgnWqiaanNrog9qAFj7NxS9Gz3QC1hw0GbXzog814paZlB/QETm5jKu1FxzXweMA==",
    "license": "MIT",
    "dependencies": {
@@ -4025,7 +4025,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_order-fulfillments": {
    "version": "1.0.62",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-fulfillments/-/@wix/auto_sdk_ecom_order-fulfillments-1.0.62.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-fulfillments/-/auto_sdk_ecom_order-fulfillments-1.0.62.tgz",
    "integrity": "sha512-Rsjbrq6aeXlQXQD42HH4es5a+1R9hePBca0I3sb+/XsPnszB+GvaCyUwsX8a/UpimHciqN+aQ07p1yMKN8M+rg==",
    "license": "MIT",
    "dependencies": {
@@ -4036,7 +4036,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_order-invoices": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-invoices/-/@wix/auto_sdk_ecom_order-invoices-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-invoices/-/auto_sdk_ecom_order-invoices-1.0.52.tgz",
    "integrity": "sha512-htA5vi/lACC20BF4dfnxZ8GaY9viaemZi4oQQqf8FOIHuItlMzoscwF21viybu/XKzghXfZqi/vX+jJBWXdTZQ==",
    "license": "MIT",
    "dependencies": {
@@ -4047,7 +4047,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_order-payment-requests": {
    "version": "1.0.67",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-payment-requests/-/@wix/auto_sdk_ecom_order-payment-requests-1.0.67.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-payment-requests/-/auto_sdk_ecom_order-payment-requests-1.0.67.tgz",
    "integrity": "sha512-zqVQlZztMspEG2TguG+hmw8yFVqsipjdyxudraOwxqTcpHTA71ay+35EDHRGsH36WvORHNGM1DHj8D6PyojKJQ==",
    "license": "MIT",
    "dependencies": {
@@ -4058,7 +4058,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_order-transactions": {
    "version": "1.0.104",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-transactions/-/@wix/auto_sdk_ecom_order-transactions-1.0.104.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-transactions/-/auto_sdk_ecom_order-transactions-1.0.104.tgz",
    "integrity": "sha512-vZwoWGPWgG273L4omJLBTItvqBWiqCqUQgPOpIKaU6PnbA5R8xib5VdjQ853zqjnAZFlrkPztWNLiFn7AnqlXA==",
    "license": "MIT",
    "dependencies": {
@@ -4069,7 +4069,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_orders": {
    "version": "1.0.286",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders/-/@wix/auto_sdk_ecom_orders-1.0.286.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders/-/auto_sdk_ecom_orders-1.0.286.tgz",
    "integrity": "sha512-YJVe5RjcF+heHig9Bai64O/SbhaRVeO5qc6K2trN8dQDD7RMJiZndRNgDzo0+sGxggDsnd3jLpH4a0AZcVmkgg==",
    "license": "MIT",
    "dependencies": {
@@ -4080,7 +4080,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_orders-settings": {
    "version": "1.0.55",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders-settings/-/@wix/auto_sdk_ecom_orders-settings-1.0.55.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders-settings/-/auto_sdk_ecom_orders-settings-1.0.55.tgz",
    "integrity": "sha512-RY+rDh307GkVr8aEnHri+N3EgW0wzKc4gKRJw2/RcjAGDX8QY9JDb7C8ep2vhgm/FcMXA3csxddV/TyPeZ0LGA==",
    "license": "MIT",
    "dependencies": {
@@ -4091,7 +4091,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_payment-settings": {
    "version": "1.0.143",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_payment-settings/-/@wix/auto_sdk_ecom_payment-settings-1.0.143.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_payment-settings/-/auto_sdk_ecom_payment-settings-1.0.143.tgz",
    "integrity": "sha512-9LOI5E1p5aZZ5sC2k4q6T+uZ4Ylp2bYuVeOdj/4quXfT45OqPotAH+66ET5vhzPhaRSY3VfuAC5EnwHrdDH0PA==",
    "license": "MIT",
    "dependencies": {
@@ -4102,7 +4102,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_pickup-locations": {
    "version": "1.0.52",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_pickup-locations/-/@wix/auto_sdk_ecom_pickup-locations-1.0.52.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_pickup-locations/-/auto_sdk_ecom_pickup-locations-1.0.52.tgz",
    "integrity": "sha512-E4+UEDHHNU4jV7KsyoJR++tTw9cqcROOBltG8CNJCAhQCnDbqxK3gfOdK9gYvgPrAWNoJ1Jzq2bCmTaK7Ru/QA==",
    "license": "MIT",
    "dependencies": {
@@ -4113,7 +4113,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_recommendations": {
    "version": "1.0.47",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations/-/@wix/auto_sdk_ecom_recommendations-1.0.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations/-/auto_sdk_ecom_recommendations-1.0.47.tgz",
    "integrity": "sha512-kIX4fnm/IYDMdV7BJMK8eUx05lP0hm/0v8PvviCKlhG/0LtLQ9SrusRZn8pZOEyG2Lp+7RAYkS3F/t4SRBAdTg==",
    "license": "MIT",
    "dependencies": {
@@ -4124,7 +4124,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_recommendations-provider": {
    "version": "1.0.33",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations-provider/-/@wix/auto_sdk_ecom_recommendations-provider-1.0.33.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations-provider/-/auto_sdk_ecom_recommendations-provider-1.0.33.tgz",
    "integrity": "sha512-x00UHSPpdXDt/bKwRx9fhspPKbOWH74cHuzSJRj7+7rp5hAAySBepNvbY+V4YKtq1W2wZ3au+b0fSBQ2BDdOPg==",
    "license": "MIT",
    "dependencies": {
@@ -4135,7 +4135,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_shipping-options": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-options/-/@wix/auto_sdk_ecom_shipping-options-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-options/-/auto_sdk_ecom_shipping-options-1.0.230.tgz",
    "integrity": "sha512-PqlZiJqSKHde7yZbom0KhndP6Pe+UsdzUx0C2EH2XBszXSv1FKymBNVEw2+PaI0JxDfZ2E4WpWWaGHuIm9E2dA==",
    "license": "MIT",
    "dependencies": {
@@ -4146,7 +4146,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_shipping-rates": {
    "version": "1.0.39",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-rates/-/@wix/auto_sdk_ecom_shipping-rates-1.0.39.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-rates/-/auto_sdk_ecom_shipping-rates-1.0.39.tgz",
    "integrity": "sha512-WzM3aB28G/XeaBjaXWYAAEXP5niKQprw2Cchpd4jHOPC1atWy91lox8Vvi080WZQUdOWuw9eUfGpci9D+/jTLw==",
    "license": "MIT",
    "dependencies": {
@@ -4157,7 +4157,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_shippo-configurations": {
    "version": "1.0.71",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shippo-configurations/-/@wix/auto_sdk_ecom_shippo-configurations-1.0.71.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shippo-configurations/-/auto_sdk_ecom_shippo-configurations-1.0.71.tgz",
    "integrity": "sha512-h7kJJpsPYQTMQKelbeECsEDLZM6VLEb37FBE//Nmiap1ff+PUcFFZ0DsHuXktsWkoa3oQp4JBuCWbqojvy6dOA==",
    "license": "MIT",
    "dependencies": {
@@ -4168,7 +4168,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_subscription-contracts": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_subscription-contracts/-/@wix/auto_sdk_ecom_subscription-contracts-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_subscription-contracts/-/auto_sdk_ecom_subscription-contracts-1.0.125.tgz",
    "integrity": "sha512-elR3LIlzu/dM1eBBc8Jbklni/lD3QL4eeEuHp470g4QF9TXq/a1e4cJ9qzqC1EUm8L+y5VsWZXI1G8Q8rwuI3w==",
    "license": "MIT",
    "dependencies": {
@@ -4179,7 +4179,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-calculation": {
    "version": "1.0.54",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation/-/@wix/auto_sdk_ecom_tax-calculation-1.0.54.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation/-/auto_sdk_ecom_tax-calculation-1.0.54.tgz",
    "integrity": "sha512-wkXEshZoXgBm8LtxX/38iJ9tdnzRTpBKtY0PpvMmhp/AHt4z8nFSKPhLJHo35U3XJSLxBnt7meiVWnZY+0v9Fw==",
    "license": "MIT",
    "dependencies": {
@@ -4190,7 +4190,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-calculation-provider": {
    "version": "1.0.31",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation-provider/-/@wix/auto_sdk_ecom_tax-calculation-provider-1.0.31.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation-provider/-/auto_sdk_ecom_tax-calculation-provider-1.0.31.tgz",
    "integrity": "sha512-X8WgM60a+qMqKOHwH3kdvJMEB+mCnrnFRZbVSLjigAqwL5YcVYBltAovI8viR05LLQd6s0MOqntjew/pDPzZeQ==",
    "license": "MIT",
    "dependencies": {
@@ -4201,7 +4201,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-exempt-groups": {
    "version": "1.0.4",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-exempt-groups/-/@wix/auto_sdk_ecom_tax-exempt-groups-1.0.4.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-exempt-groups/-/auto_sdk_ecom_tax-exempt-groups-1.0.4.tgz",
    "integrity": "sha512-yk7U1z5enPiVxeNVFH05lr7UtCM5xn0IAXDW7pswkknrdAOk0axrjc279CY5jTHaZTmEgqyEv0/39ZZTycDCkA==",
    "license": "MIT",
    "dependencies": {
@@ -4212,7 +4212,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-groups": {
    "version": "1.0.64",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-groups/-/@wix/auto_sdk_ecom_tax-groups-1.0.64.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-groups/-/auto_sdk_ecom_tax-groups-1.0.64.tgz",
    "integrity": "sha512-df8Zise8uEfHFgj7tDvTTcT7DRn+771j6eI4tWqL6fPIQGPN0rURY7kGQehBi3jnDHLOohI5ksg7hlKKsjCQzw==",
    "license": "MIT",
    "dependencies": {
@@ -4223,7 +4223,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-regions": {
    "version": "1.0.61",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-regions/-/@wix/auto_sdk_ecom_tax-regions-1.0.61.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-regions/-/auto_sdk_ecom_tax-regions-1.0.61.tgz",
    "integrity": "sha512-o2Gmc89SlO5pQuOngj+l8y+vm7HQJ0qxuEJzqdJwx0siRIwRqb8hkmT0+HXn+zM1e0Ntc9kMxHHabYf2OtqCmg==",
    "license": "MIT",
    "dependencies": {
@@ -4234,7 +4234,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tax-settings": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-settings/-/@wix/auto_sdk_ecom_tax-settings-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-settings/-/auto_sdk_ecom_tax-settings-1.0.2.tgz",
    "integrity": "sha512-8+566igMSdW6dOK9RHRmoatin7w6U+H10ren7YqlNixf3qJBazSyv2CdMwFvf1MFSFSY319u3VgkW64OPWrQKg==",
    "license": "MIT",
    "dependencies": {
@@ -4245,7 +4245,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tip-settings": {
    "version": "1.0.54",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tip-settings/-/@wix/auto_sdk_ecom_tip-settings-1.0.54.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tip-settings/-/auto_sdk_ecom_tip-settings-1.0.54.tgz",
    "integrity": "sha512-4N1l/X0KTIXOzkbCVO/oYuDnApCpz/MToDg0IEbfjeEnm1SX/gk1DkXnSjuGv6ttOEusekyL1WdOXwL5qKvQmw==",
    "license": "MIT",
    "dependencies": {
@@ -4256,7 +4256,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tippable-staff": {
    "version": "1.0.40",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tippable-staff/-/@wix/auto_sdk_ecom_tippable-staff-1.0.40.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tippable-staff/-/auto_sdk_ecom_tippable-staff-1.0.40.tgz",
    "integrity": "sha512-FvIEtLdx3qbMSvQcr5czVDjzP7BvV9c69FquHuvrBOVotq6xjEiqs9+durHHHcqNpWgs/DjVIeT+GZ2rwWrozw==",
    "license": "MIT",
    "dependencies": {
@@ -4267,7 +4267,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_tips": {
    "version": "1.0.62",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tips/-/@wix/auto_sdk_ecom_tips-1.0.62.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tips/-/auto_sdk_ecom_tips-1.0.62.tgz",
    "integrity": "sha512-zPUDIRSXEdghPH7G049nzNsyB+5JYeiOLtwUelQasibHwln1sb/rG7R5xP9ifIVuy6u7kzwN7Oisuk8NDrNyCg==",
    "license": "MIT",
    "dependencies": {
@@ -4278,7 +4278,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_totals-calculator": {
    "version": "1.0.115",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_totals-calculator/-/@wix/auto_sdk_ecom_totals-calculator-1.0.115.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_totals-calculator/-/auto_sdk_ecom_totals-calculator-1.0.115.tgz",
    "integrity": "sha512-N1rp4LtZSfTooN3J/3OmfMpcbrWIIHkskSm7NYo74TmnJFLpE5sAUyAMGbCwamZjYFXKVWdCJnWMjn8PgQq3Pg==",
    "license": "MIT",
    "dependencies": {
@@ -4289,7 +4289,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_validations": {
    "version": "1.0.56",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_validations/-/@wix/auto_sdk_ecom_validations-1.0.56.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_validations/-/auto_sdk_ecom_validations-1.0.56.tgz",
    "integrity": "sha512-UUbTbVI5qTYkJYg+DBtJN2dAGJqYuZ1FyFlTEI5sgqxRHeFlalKxWppAGG0stlk5E2Tweb52/OLb3UvMQ7zLVg==",
    "license": "MIT",
    "dependencies": {
@@ -4300,7 +4300,7 @@
   },
   "node_modules/@wix/auto_sdk_ecom_wishlists": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_wishlists/-/@wix/auto_sdk_ecom_wishlists-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_wishlists/-/auto_sdk_ecom_wishlists-1.0.2.tgz",
    "integrity": "sha512-W1VkbP9U40aHpk1eu27Z9PoFFgWO1FuTUhpm346jlHBK//9kL8Zktwbag9P6Taxp3/CeILsqsriAvJtb1LkE9Q==",
    "license": "MIT",
    "dependencies": {
@@ -4311,7 +4311,7 @@
   },
   "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
    "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
    "license": "MIT",
    "dependencies": {
@@ -4322,7 +4322,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_authentication": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
    "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
    "license": "MIT",
    "dependencies": {
@@ -4333,7 +4333,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_oauth": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
    "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
    "license": "MIT",
    "dependencies": {
@@ -4344,7 +4344,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_recovery": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
    "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
    "license": "MIT",
    "dependencies": {
@@ -4355,7 +4355,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
    "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
    "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
    "license": "MIT",
    "dependencies": {
@@ -4366,7 +4366,7 @@
   },
   "node_modules/@wix/auto_sdk_identity_verification": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
    "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
    "license": "MIT",
    "dependencies": {
@@ -4377,7 +4377,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
    "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
    "license": "MIT",
    "dependencies": {
@@ -4388,7 +4388,7 @@
   },
   "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
    "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
    "license": "MIT",
    "dependencies": {
@@ -4399,7 +4399,7 @@
   },
   "node_modules/@wix/auto_sdk_media_files": {
    "version": "1.0.97",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.97.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.97.tgz",
    "integrity": "sha512-QhHazANhb3gc5CSYLQf2EJo5QtBNQtlMxZI9FDtM2IaGc2oTbH8JMN7RQHzL4JrA9xRYXjuB5ZhwNysdg5mDmg==",
    "license": "MIT",
    "dependencies": {
@@ -4410,7 +4410,7 @@
   },
   "node_modules/@wix/auto_sdk_media_folders": {
    "version": "1.0.57",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
    "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
    "license": "MIT",
    "dependencies": {
@@ -4421,7 +4421,7 @@
   },
   "node_modules/@wix/auto_sdk_redirects_redirects": {
    "version": "1.0.53",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
    "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
    "license": "MIT",
    "dependencies": {
@@ -4432,7 +4432,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_availability-exceptions": {
    "version": "1.0.61",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_availability-exceptions/-/@wix/auto_sdk_restaurants_availability-exceptions-1.0.61.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_availability-exceptions/-/auto_sdk_restaurants_availability-exceptions-1.0.61.tgz",
    "integrity": "sha512-eT6NclNAglX1v0hUYglLO6p20Fq98wqm49nm2lblEG7kC7KVjUlSpfkH8DuaUYCfdCRUIjPpzRytWx3ylIKuig==",
    "license": "MIT",
    "dependencies": {
@@ -4443,7 +4443,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_catalogs": {
    "version": "1.0.72",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_catalogs/-/@wix/auto_sdk_restaurants_catalogs-1.0.72.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_catalogs/-/auto_sdk_restaurants_catalogs-1.0.72.tgz",
    "integrity": "sha512-5KDutDFj7YM7iWCcG8eyRLBeMU4NPnGczoSTWiZKPfwvMAPz2ngO1cNAc+9HDK9tA1Kd74neVef8YR2OSBQYEw==",
    "license": "MIT",
    "dependencies": {
@@ -4454,7 +4454,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_discount": {
    "version": "1.0.54",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_discount/-/@wix/auto_sdk_restaurants_discount-1.0.54.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_discount/-/auto_sdk_restaurants_discount-1.0.54.tgz",
    "integrity": "sha512-Yh4puzATO43U2JKTAkmbWY1XMuLFIBg0imeX4tpaIP+EOIb3+eta7TsKRMmQQxFLbryPvyvCnFCez6GDi+j0cw==",
    "license": "MIT",
    "dependencies": {
@@ -4465,7 +4465,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_fulfillemt-methods": {
    "version": "1.0.39",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillemt-methods/-/@wix/auto_sdk_restaurants_fulfillemt-methods-1.0.39.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillemt-methods/-/auto_sdk_restaurants_fulfillemt-methods-1.0.39.tgz",
    "integrity": "sha512-jihrWRvfUanmXIE6LfIwG//1qtRcCm3mti7sLzfGtVUhbW9wHW3IZikiF7s6Fu0ARGNihf6lxwf4b0tQtqZOMA==",
    "license": "MIT",
    "dependencies": {
@@ -4476,7 +4476,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_fulfillment-methods": {
    "version": "1.0.71",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillment-methods/-/@wix/auto_sdk_restaurants_fulfillment-methods-1.0.71.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_fulfillment-methods/-/auto_sdk_restaurants_fulfillment-methods-1.0.71.tgz",
    "integrity": "sha512-Tww45umJfU8KcE0BdwjAH5biUPXLVMDLinMul4fcLx/JWfXwBUjkFUmMuo4WDqtaprni/VixyYvit8xvL6ZJ+g==",
    "license": "MIT",
    "dependencies": {
@@ -4487,7 +4487,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_item-labels": {
    "version": "1.0.68",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-labels/-/@wix/auto_sdk_restaurants_item-labels-1.0.68.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-labels/-/auto_sdk_restaurants_item-labels-1.0.68.tgz",
    "integrity": "sha512-ph+ogTlky/QEmNgrt3gcyC7qO/XSFwOW8I5WnA9YD/efakmQYt+q1fy08sK843f074zRwYPuU9VxEzjdAzYqOg==",
    "license": "MIT",
    "dependencies": {
@@ -4498,7 +4498,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_item-modifier-groups": {
    "version": "1.0.73",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifier-groups/-/@wix/auto_sdk_restaurants_item-modifier-groups-1.0.73.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifier-groups/-/auto_sdk_restaurants_item-modifier-groups-1.0.73.tgz",
    "integrity": "sha512-im6r2hnejsnWUTodqfoNOp4/fm767h049qDGGeO5QTVF0aNIToCU/s2IP6ptUtaw+hLFDb/Zm9eg7i/+6JBVbw==",
    "license": "MIT",
    "dependencies": {
@@ -4509,7 +4509,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_item-modifiers": {
    "version": "1.0.69",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifiers/-/@wix/auto_sdk_restaurants_item-modifiers-1.0.69.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-modifiers/-/auto_sdk_restaurants_item-modifiers-1.0.69.tgz",
    "integrity": "sha512-h6i1zUlm6nn+qfgEAMYV2TEO1QJS/+ZvzwUcmwcFFYNW3TjclimnpDgFBBCsMwfFbit03g6wEq+c+xQJW8HjfA==",
    "license": "MIT",
    "dependencies": {
@@ -4520,7 +4520,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_item-variants": {
    "version": "1.0.65",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-variants/-/@wix/auto_sdk_restaurants_item-variants-1.0.65.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_item-variants/-/auto_sdk_restaurants_item-variants-1.0.65.tgz",
    "integrity": "sha512-EwqZ+uR9zGZa1EmvsvZTFKYdzrXHOrCYzTMHUOgWfzADK0n4AXizPLGkTvdokgVuwtszIA236+F5NN2TiuD8YQ==",
    "license": "MIT",
    "dependencies": {
@@ -4531,7 +4531,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_items": {
    "version": "1.0.87",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_items/-/@wix/auto_sdk_restaurants_items-1.0.87.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_items/-/auto_sdk_restaurants_items-1.0.87.tgz",
    "integrity": "sha512-KzJoNlz6ES3CY1SrVet6E/sejDhvLRnz8gTtrDYnozFooEy/VWxYVzrl0i4B9JRwfijHTOQler0Q6ML69tr6RQ==",
    "license": "MIT",
    "dependencies": {
@@ -4542,7 +4542,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_local-delivery-spi": {
    "version": "1.0.45",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_local-delivery-spi/-/@wix/auto_sdk_restaurants_local-delivery-spi-1.0.45.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_local-delivery-spi/-/auto_sdk_restaurants_local-delivery-spi-1.0.45.tgz",
    "integrity": "sha512-8iCNDrnr6GeHCdrfQaPcRx4B9XwB+PAIciMgXZcU9Iw7OxRBsBNMDolJG6zhYzqV94ryfXj40vrKN3m/5UempQ==",
    "license": "MIT",
    "dependencies": {
@@ -4553,7 +4553,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_menu-ordering-settings": {
    "version": "1.0.60",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menu-ordering-settings/-/@wix/auto_sdk_restaurants_menu-ordering-settings-1.0.60.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menu-ordering-settings/-/auto_sdk_restaurants_menu-ordering-settings-1.0.60.tgz",
    "integrity": "sha512-sPdXRoIsFvZwjbgA40hGPDrcH7dawh0XTqdX0JwhmeYB4mLbwJvP5wgDXj32WoXU9GzacMjBNC2FLvWfHioxTw==",
    "license": "MIT",
    "dependencies": {
@@ -4564,7 +4564,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_menus": {
    "version": "1.0.80",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menus/-/@wix/auto_sdk_restaurants_menus-1.0.80.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_menus/-/auto_sdk_restaurants_menus-1.0.80.tgz",
    "integrity": "sha512-7VcoQ9+VfrAE0Q2+6OZzRX38RCFwSLSAXEltUooDhdwlfSitZDJJe4IzkJZL8Rxg7/puRyeBnaHaLVzFe+6mhw==",
    "license": "MIT",
    "dependencies": {
@@ -4575,7 +4575,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_operation-groups": {
    "version": "1.0.64",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operation-groups/-/@wix/auto_sdk_restaurants_operation-groups-1.0.64.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operation-groups/-/auto_sdk_restaurants_operation-groups-1.0.64.tgz",
    "integrity": "sha512-jKr7QGGsaFmqr4W/kNzNynzU5n8Iwusp4yZj2JHyybnASZZYWoQyBZSzQ7CAsNXuNhSA2NTmacs3Hy4R0LR4jg==",
    "license": "MIT",
    "dependencies": {
@@ -4586,7 +4586,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_operations": {
    "version": "1.0.98",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operations/-/@wix/auto_sdk_restaurants_operations-1.0.98.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_operations/-/auto_sdk_restaurants_operations-1.0.98.tgz",
    "integrity": "sha512-VjuegEKmzAg0tqneLWS2YHfcEhl2BG4nPeeIAe74gfUslvymOyMg2CuMeIROjeBAfGND9bsXiC9s+21FgV5ahg==",
    "license": "MIT",
    "dependencies": {
@@ -4597,7 +4597,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_order-pacing-order": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-order/-/@wix/auto_sdk_restaurants_order-pacing-order-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-order/-/auto_sdk_restaurants_order-pacing-order-1.0.37.tgz",
    "integrity": "sha512-90shXv/haozmcJVB6CN22p8ZEZ8jQclmjoy3X6KS5eyiziWt+EXtXs+r6zCkcZRLCeZ9jO3+CGSu8+c+wpVx3Q==",
    "license": "MIT",
    "dependencies": {
@@ -4608,7 +4608,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_order-pacing-policy": {
    "version": "1.0.46",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-policy/-/@wix/auto_sdk_restaurants_order-pacing-policy-1.0.46.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-pacing-policy/-/auto_sdk_restaurants_order-pacing-policy-1.0.46.tgz",
    "integrity": "sha512-T1dvsf3+/Od+//mBrV2FxUyyq9Nw9EgPbSEikvy1j/rVDBztPf5LL76JyNQR355vkjnNtlIwCa4UksXZo2S12A==",
    "license": "MIT",
    "dependencies": {
@@ -4619,7 +4619,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_order-settings": {
    "version": "1.0.37",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-settings/-/@wix/auto_sdk_restaurants_order-settings-1.0.37.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_order-settings/-/auto_sdk_restaurants_order-settings-1.0.37.tgz",
    "integrity": "sha512-eLkWv81SyCoQhx2+JozpZXNirrhGm+LiRFw3H6Fyz2QCbcfz561K2iwLCmGAnnH+CJkp9kuRtXK7oDNKADeCQA==",
    "license": "MIT",
    "dependencies": {
@@ -4630,7 +4630,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_orders": {
    "version": "1.0.58",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_orders/-/@wix/auto_sdk_restaurants_orders-1.0.58.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_orders/-/auto_sdk_restaurants_orders-1.0.58.tgz",
    "integrity": "sha512-c934r6LuARhyWsoPvgjaJXcjv9S1iG935DknMhGmqyUsvIUUrFjNhPDAIr/GkWqM3zogwmBMKV/rbUvtGbHIwg==",
    "license": "MIT",
    "dependencies": {
@@ -4641,7 +4641,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_pos-tpa": {
    "version": "1.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_pos-tpa/-/@wix/auto_sdk_restaurants_pos-tpa-1.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_pos-tpa/-/auto_sdk_restaurants_pos-tpa-1.0.41.tgz",
    "integrity": "sha512-H46gCch4IWlqBuPuSCfBqMtITh1WWdyu55WLK8tnIp5aJ8HaP0J4POJkUwQ4i9HoUc1xCTSL+mEgVF0wGhI95g==",
    "license": "MIT",
    "dependencies": {
@@ -4652,7 +4652,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_recipients": {
    "version": "1.0.31",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_recipients/-/@wix/auto_sdk_restaurants_recipients-1.0.31.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_recipients/-/auto_sdk_restaurants_recipients-1.0.31.tgz",
    "integrity": "sha512-rbipvHfR75VTiHnQ1pteKGRh0JKNJpenPmsp5zeGMlfjQZf7B0bEQX2tujKLETefd8h37Khe/nX5zis/Zi904A==",
    "license": "MIT",
    "dependencies": {
@@ -4663,7 +4663,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_restaurant-locations": {
    "version": "1.0.39",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_restaurant-locations/-/@wix/auto_sdk_restaurants_restaurant-locations-1.0.39.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_restaurant-locations/-/auto_sdk_restaurants_restaurant-locations-1.0.39.tgz",
    "integrity": "sha512-iYXRZdBjTbXmUhm9wZhujW7ZHWAJCmUnLgI3WQWsd1NiNePnOZKG5vsTMlP5yrC99jnoFzSttKTTR0RU61J6cQ==",
    "license": "MIT",
    "dependencies": {
@@ -4674,7 +4674,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_sections": {
    "version": "1.0.72",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_sections/-/@wix/auto_sdk_restaurants_sections-1.0.72.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_sections/-/auto_sdk_restaurants_sections-1.0.72.tgz",
    "integrity": "sha512-JZtyIAsuXroWQB3BgdRL83bajDvd+u8I8MqAQ3AujIMAxRMSCacNFgNRWaLA1fF7PLGqGpF8IwkrB7s8uU23dg==",
    "license": "MIT",
    "dependencies": {
@@ -4685,7 +4685,7 @@
   },
   "node_modules/@wix/auto_sdk_restaurants_service-fees": {
    "version": "1.0.56",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_service-fees/-/@wix/auto_sdk_restaurants_service-fees-1.0.56.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_restaurants_service-fees/-/auto_sdk_restaurants_service-fees-1.0.56.tgz",
    "integrity": "sha512-6VXLQdw+vSIX4+KwLj5ozaG0ZPAjBAO4ji/poDBSBwEahVfy7rc8xGsK0ve8m+IZevlJJF5E39kfBiCRkXyu0Q==",
    "license": "MIT",
    "dependencies": {
@@ -4696,7 +4696,7 @@
   },
   "node_modules/@wix/auto_sdk_table-reservations_experiences": {
    "version": "1.0.56",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_experiences/-/@wix/auto_sdk_table-reservations_experiences-1.0.56.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_experiences/-/auto_sdk_table-reservations_experiences-1.0.56.tgz",
    "integrity": "sha512-pssKfV7OPsmBw6VMosnO3fxfmDTDsIdgAvtNM3rGuiKRJw8bu3bA5qhYyxTNZKTd8RauxWRwGXV0Y2+2U6qw0g==",
    "license": "MIT",
    "dependencies": {
@@ -4707,7 +4707,7 @@
   },
   "node_modules/@wix/auto_sdk_table-reservations_reservation-locations": {
    "version": "1.0.101",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservation-locations/-/@wix/auto_sdk_table-reservations_reservation-locations-1.0.101.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservation-locations/-/auto_sdk_table-reservations_reservation-locations-1.0.101.tgz",
    "integrity": "sha512-b078MnHxosuT/coJu9C60InI/vO+oIBuaCftWA3NZBY8o7lY81pHSz7vYAvsMAVLAczpwdeTxvcexYIMAJK/4Q==",
    "license": "MIT",
    "dependencies": {
@@ -4718,7 +4718,7 @@
   },
   "node_modules/@wix/auto_sdk_table-reservations_reservations": {
    "version": "1.0.76",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservations/-/@wix/auto_sdk_table-reservations_reservations-1.0.76.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_reservations/-/auto_sdk_table-reservations_reservations-1.0.76.tgz",
    "integrity": "sha512-ss2WDMyCiZpUC1j0mKStAyZsnp8+Z8Dy0dSGGjfLgvutl3QeqtZBN8EPsjx0FmiVzcijipbptFuLszOyWvjEvA==",
    "license": "MIT",
    "dependencies": {
@@ -4729,7 +4729,7 @@
   },
   "node_modules/@wix/auto_sdk_table-reservations_time-slots": {
    "version": "1.0.48",
-   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_time-slots/-/@wix/auto_sdk_table-reservations_time-slots-1.0.48.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_table-reservations_time-slots/-/auto_sdk_table-reservations_time-slots-1.0.48.tgz",
    "integrity": "sha512-41i83EI2tdPD1vBZ3uIOSMNv9WAAfMNdlHYhcQxjSF1WfF6tIZIuRx64UIPqMYtY4D9waDHCwyrlD+kmPJ0iJQ==",
    "license": "MIT",
    "dependencies": {
@@ -4740,7 +4740,7 @@
   },
   "node_modules/@wix/cli": {
    "version": "1.1.239",
-   "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
    "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
    "dev": true,
    "dependencies": {
@@ -4759,7 +4759,7 @@
   },
   "node_modules/@wix/communication-channel": {
    "version": "1.0.10",
-   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
    "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4769,13 +4769,13 @@
   },
   "node_modules/@wix/consent-policy-manager": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
    "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
    "license": "MIT"
   },
   "node_modules/@wix/credits-types": {
    "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
    "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4784,7 +4784,7 @@
   },
   "node_modules/@wix/dashboard": {
    "version": "1.3.47",
-   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
    "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4823,7 +4823,7 @@
   },
   "node_modules/@wix/ecom": {
    "version": "1.0.2454",
-   "resolved": "https://registry.npmjs.org/@wix/ecom/-/@wix/ecom-1.0.2454.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/ecom/-/ecom-1.0.2454.tgz",
    "integrity": "sha512-fjkJZf+utwGk6db2W7/WUo/UiAiYzODeaJOkqSDoGVL4rt6j6u1YQRRtWoCSc1nixIZengHYs1amJp7+SZnEww==",
    "license": "MIT",
    "dependencies": {
@@ -4890,7 +4890,7 @@
   },
   "node_modules/@wix/ecom_app-extensions": {
    "version": "1.0.107",
-   "resolved": "https://registry.npmjs.org/@wix/ecom_app-extensions/-/@wix/ecom_app-extensions-1.0.107.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/ecom_app-extensions/-/ecom_app-extensions-1.0.107.tgz",
    "integrity": "sha512-oAUv1VGGFCth/G7YxkMlvJCv1RjPJ02QgcMWGJFwuorfgCZHEinoA3F8QKaQ97FaF+k7Nup00OMLYJl/TBpCwA==",
    "license": "MIT",
    "dependencies": {
@@ -4901,7 +4901,7 @@
   },
   "node_modules/@wix/editor": {
    "version": "1.786.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.786.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.786.0.tgz",
    "integrity": "sha512-QCxvot772xJimacGSxj/b043g3K5cc2hBjeRQ/004U9qCXYF26iLR+s/aX2YkQ3OlHtu/6fTn7k7Bn+VnHlzbg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4917,7 +4917,7 @@
   },
   "node_modules/@wix/editor-application": {
    "version": "1.474.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.474.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.474.0.tgz",
    "integrity": "sha512-ZqNCEf8U/XuKKkKFXj7YTZ9/vKaBzyhutR+mrVDbuFBkN07orSCH35aquhdyJrKmh98Dp6hmEW4CLXks4raTOw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4929,7 +4929,7 @@
   },
   "node_modules/@wix/editor-platform-contexts": {
    "version": "1.161.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.161.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.161.0.tgz",
    "integrity": "sha512-/lP2wXy7SZHd8vclfzHQa4AWRxa3fOdzv1qoLsWn9t1+fkXap936p/3zQZdlcsKyUBZ0T0CC2wDQ4UrmfiiOeg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4941,7 +4941,7 @@
   },
   "node_modules/@wix/editor-platform-environment-api": {
    "version": "1.162.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.162.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.162.0.tgz",
    "integrity": "sha512-1FAuptFBKIxF5z5J+doTspltncafO5yTQdirzPS2Mp6vLEjzYk54nfEuddqRuu+qbPHM3rPyQDbgRwEdmyPYyQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -4955,7 +4955,7 @@
   },
   "node_modules/@wix/editor-platform-transport": {
    "version": "1.15.0",
-   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
    "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
    "license": "UNLICENSED"
   },
@@ -4982,7 +4982,7 @@
   },
   "node_modules/@wix/error-handler-core": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
    "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
    "license": "MIT",
    "dependencies": {
@@ -4992,7 +4992,7 @@
   },
   "node_modules/@wix/error-handler-types": {
    "version": "1.20.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
    "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
    "license": "MIT",
    "dependencies": {
@@ -5001,7 +5001,7 @@
   },
   "node_modules/@wix/essentials": {
    "version": "1.0.14",
-   "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
    "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
    "license": "MIT",
    "dependencies": {
@@ -5021,7 +5021,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -5054,7 +5054,7 @@
   },
   "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -5064,7 +5064,7 @@
   },
   "node_modules/@wix/feedback-loop-structure": {
    "version": "1.34.0",
-   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
    "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
    "license": "MIT",
    "dependencies": {
@@ -5095,7 +5095,7 @@
   },
   "node_modules/@wix/headless-ecom": {
    "version": "0.0.41",
-   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.41.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/headless-ecom-0.0.41.tgz",
    "integrity": "sha512-YYZZtCLvY+2vcS0FxSJuuro8aWF8jnINHQRafxYwkZXQNvPMbewKpx1MF97/UiSaGyeSCJyZZoOTdSldEo7Vtw==",
    "license": "MIT",
    "dependencies": {
@@ -5114,7 +5114,7 @@
   },
   "node_modules/@wix/headless-localization-utils": {
    "version": "1.0.15",
-   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
    "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
    "license": "MIT",
    "dependencies": {
@@ -5124,7 +5124,7 @@
   },
   "node_modules/@wix/headless-media": {
    "version": "0.0.21",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.21.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.21.tgz",
    "integrity": "sha512-7o9ctPfQsQwfLwLCjs4RDO9Ns900Hv+BNVc301tShulKeitxgMKTrFqUxCsCuSQqqgQYaOhm5hDB+994LtBozg==",
    "license": "MIT",
    "dependencies": {
@@ -5135,7 +5135,7 @@
   },
   "node_modules/@wix/headless-node": {
    "version": "1.44.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
    "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5146,7 +5146,7 @@
   },
   "node_modules/@wix/headless-restaurants-menus": {
    "version": "0.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-menus/-/@wix/headless-restaurants-menus-0.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-menus/-/headless-restaurants-menus-0.0.24.tgz",
    "integrity": "sha512-dCL/fZiIz8A7b8xUDriPvYJLMvnr8Om9BgSlLjtqM1u9iBZutvBXz0gfwY0QboZL8BeW0JcSl4g48mwYoBU4AA==",
    "license": "MIT",
    "dependencies": {
@@ -5167,7 +5167,7 @@
   },
   "node_modules/@wix/headless-restaurants-menus/node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -5178,7 +5178,7 @@
   },
   "node_modules/@wix/headless-restaurants-menus/node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -5190,7 +5190,7 @@
   },
   "node_modules/@wix/headless-restaurants-olo": {
    "version": "0.0.50",
-   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-olo/-/@wix/headless-restaurants-olo-0.0.50.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-olo/-/headless-restaurants-olo-0.0.50.tgz",
    "integrity": "sha512-Qq/rqgayRIAjohkDl+quHo8mOqQxyD3WZaGEfQT3KaqT6zP9jt5yHS2fliL+YvzIwJg9DPDhksHO8T8MFqcOlA==",
    "license": "MIT",
    "dependencies": {
@@ -5215,7 +5215,7 @@
   },
   "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-components": {
    "version": "0.0.36",
-   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/@wix/headless-components-0.0.36.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.36.tgz",
    "integrity": "sha512-PKq1vsXKdSUf/sIpPkQHgfqATkO/e67PgkKtcS3p4MZYQo7IRatY0KE3JaYzy92XStptJtOWEP/iBpXCYQOtNw==",
    "license": "MIT",
    "dependencies": {
@@ -5229,7 +5229,7 @@
   },
   "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-media": {
    "version": "0.0.20",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.20.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.20.tgz",
    "integrity": "sha512-hJkAjNcr2ttfCogHlzDSbyjBfMbIFqu4CjPh+7oXcnQWHti+VDn1hpT3BsFGjdTVb6WyXNTrCWSOAWwbg2/ghw==",
    "license": "MIT",
    "dependencies": {
@@ -5240,7 +5240,7 @@
   },
   "node_modules/@wix/headless-restaurants-olo/node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -5252,7 +5252,7 @@
   },
   "node_modules/@wix/headless-restaurants-table-reservations": {
    "version": "0.0.19",
-   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-table-reservations/-/@wix/headless-restaurants-table-reservations-0.0.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-restaurants-table-reservations/-/headless-restaurants-table-reservations-0.0.19.tgz",
    "integrity": "sha512-WZO49sd2Bd9FBq3FDTdFSTZkGMalvyDBZi7dPOJLiXA56dBDuALqBd5w/J6IglnjO9E0qeeoGCCTlB4vF3c9Ww==",
    "license": "MIT",
    "dependencies": {
@@ -5272,7 +5272,7 @@
   },
   "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/error-handler": {
    "version": "1.68.0",
-   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
    "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
    "license": "MIT",
    "dependencies": {
@@ -5323,7 +5323,7 @@
   },
   "node_modules/@wix/headless-restaurants-table-reservations/node_modules/@wix/headless-utils": {
    "version": "0.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.8.tgz",
    "integrity": "sha512-BcLXiNXc4p5O9PRbfqk/3C9OIELjelB0C3qkYQu9oQDa8QZtQ06/ZRHAviM+DD7+jOgAw1larc+58Zq/54xBKw==",
    "license": "MIT",
    "dependencies": {
@@ -5345,7 +5345,7 @@
   },
   "node_modules/@wix/headless-site": {
    "version": "1.37.0",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
    "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5356,7 +5356,7 @@
   },
   "node_modules/@wix/headless-site-assets": {
    "version": "1.0.13",
-   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
    "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
    "license": "MIT",
    "dependencies": {
@@ -5378,7 +5378,7 @@
   },
   "node_modules/@wix/identity": {
    "version": "1.0.230",
-   "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
    "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
    "license": "MIT",
    "dependencies": {
@@ -5391,7 +5391,7 @@
   },
   "node_modules/@wix/image-kit": {
    "version": "1.125.0",
-   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
    "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
    "license": "MIT",
    "dependencies": {
@@ -5401,13 +5401,13 @@
   },
   "node_modules/@wix/l10n": {
    "version": "1.207.0",
-   "resolved": "https://registry.npmjs.org/@wix/l10n/-/@wix/l10n-1.207.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/l10n/-/l10n-1.207.0.tgz",
    "integrity": "sha512-af9QAcXDixaj3dRnYy2bA1NU09RV5uBd8uUf746DpZJhAoPlTzK7XDmgHo/PG6X8x7y2HwdN43h2NGrLPBIxtw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/media": {
    "version": "1.0.272",
-   "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.272.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.272.tgz",
    "integrity": "sha512-1s5wUltm+aQA/+g9BeH8qhYpFyF8UJPmgF+zpaWyRalQnSK6GMFOVhS1L7hOWMQCpGdZyZUpAtzvcsDL2fobew==",
    "license": "MIT",
    "dependencies": {
@@ -5420,7 +5420,7 @@
   },
   "node_modules/@wix/media/node_modules/@wix/headless-media": {
    "version": "0.0.25",
-   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
    "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
    "license": "MIT",
    "dependencies": {
@@ -5440,7 +5440,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama": {
    "version": "0.10.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
    "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5450,7 +5450,7 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5459,13 +5459,13 @@
   },
   "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host": {
    "version": "0.1.27",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
    "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
    "dependencies": {
     "@wix/monitoring": "1.0.0",
@@ -5477,7 +5477,7 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5486,13 +5486,13 @@
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
    "version": "1.29.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
    "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5503,7 +5503,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry": {
    "version": "0.26.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
    "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5514,7 +5514,7 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
    "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5523,19 +5523,19 @@
   },
   "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
    "version": "0.17.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
    "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common": {
    "version": "1.13.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
    "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/monitoring-common-sentry": {
    "version": "0.2.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
    "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
    "license": "UNLICENSED"
   },
@@ -5547,7 +5547,7 @@
   },
   "node_modules/@wix/monitoring-velo": {
    "version": "1.31.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
    "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5558,7 +5558,7 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
    "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
    "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5567,13 +5567,13 @@
   },
   "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
    "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
    "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/multilingual-manager": {
    "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
    "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
    "license": "MIT",
    "dependencies": {
@@ -5583,13 +5583,13 @@
   },
   "node_modules/@wix/public-editor-platform-errors": {
    "version": "1.9.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
    "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
    "license": "UNLICENSED"
   },
   "node_modules/@wix/public-editor-platform-events": {
    "version": "1.395.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.395.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.395.0.tgz",
    "integrity": "sha512-lYWWbPZcDWC5qWrRXY3M64eRMLlFxIS2rW8PNUwYJocu/wqOhmjaLYqvtpDeD9CvQsjQr87d85T/xd2/YkKf8g==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5598,7 +5598,7 @@
   },
   "node_modules/@wix/public-editor-platform-interfaces": {
    "version": "1.104.0",
-   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.104.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.104.0.tgz",
    "integrity": "sha512-1VZo+E4yYTXLH8s1fXOAzhoN4LW+AR1e0ayCHcl7vSmXwtppqdp6XvJF5cx29Z5KbVg4nlwZi2QhGXk5stEr6Q==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5608,13 +5608,13 @@
   },
   "node_modules/@wix/react-component-schema": {
    "version": "1.8.0",
-   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
    "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
    "license": "ISC"
   },
   "node_modules/@wix/redirects": {
    "version": "1.0.125",
-   "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
    "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
    "license": "MIT",
    "dependencies": {
@@ -5623,7 +5623,7 @@
   },
   "node_modules/@wix/restaurants": {
    "version": "1.0.525",
-   "resolved": "https://registry.npmjs.org/@wix/restaurants/-/@wix/restaurants-1.0.525.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/restaurants/-/restaurants-1.0.525.tgz",
    "integrity": "sha512-1VT3mJRBrFTD2eqBRz2TIfd7WiF7aCc3bBdj5xiCIopCBaQUXR2fXmT3f3vLwbFH3f7VHEcARSuG6PXTiJArbQ==",
    "license": "MIT",
    "dependencies": {
@@ -5658,7 +5658,7 @@
   },
   "node_modules/@wix/restaurants_app-extensions": {
    "version": "1.0.43",
-   "resolved": "https://registry.npmjs.org/@wix/restaurants_app-extensions/-/@wix/restaurants_app-extensions-1.0.43.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/restaurants_app-extensions/-/restaurants_app-extensions-1.0.43.tgz",
    "integrity": "sha512-rYMxXAJYppaW6Gy4TUSQmxUfon0V+ztkvEq50qGUZ5y8y29+UE8QKO44Jgi0NWjPqpOONBjiXBAq1zQZHGRTrw==",
    "license": "MIT",
    "dependencies": {
@@ -5669,7 +5669,7 @@
   },
   "node_modules/@wix/sdk": {
    "version": "1.21.16",
-   "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
    "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
    "license": "MIT",
    "dependencies": {
@@ -5694,7 +5694,7 @@
   },
   "node_modules/@wix/sdk-react-context": {
    "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
    "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
    "license": "UNLICENSED",
    "peerDependencies": {
@@ -5703,7 +5703,7 @@
   },
   "node_modules/@wix/sdk-runtime": {
    "version": "1.0.24",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
    "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
    "license": "MIT",
    "dependencies": {
@@ -5713,7 +5713,7 @@
   },
   "node_modules/@wix/sdk-types": {
    "version": "1.17.11",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
    "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
    "license": "MIT",
    "dependencies": {
@@ -5724,7 +5724,7 @@
   },
   "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
    "version": "1.0.22",
-   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
    "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
    "license": "MIT",
    "dependencies": {
@@ -5734,7 +5734,7 @@
   },
   "node_modules/@wix/services-definitions": {
    "version": "1.0.5",
-   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
    "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
    "dependencies": {
     "type-fest": "^4.41.0"
@@ -5742,7 +5742,7 @@
   },
   "node_modules/@wix/services-manager": {
    "version": "1.0.7",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
    "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
    "dependencies": {
     "@preact/signals-core": "^1.12.1",
@@ -5752,7 +5752,7 @@
   },
   "node_modules/@wix/services-manager-react": {
    "version": "1.0.8",
-   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
    "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
    "license": "MIT",
    "dependencies": {
@@ -5769,7 +5769,7 @@
   },
   "node_modules/@wix/site": {
    "version": "1.66.0",
-   "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
    "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5783,7 +5783,7 @@
   },
   "node_modules/@wix/table-reservations": {
    "version": "1.0.397",
-   "resolved": "https://registry.npmjs.org/@wix/table-reservations/-/@wix/table-reservations-1.0.397.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations/-/table-reservations-1.0.397.tgz",
    "integrity": "sha512-BPZpU6mlWYZOxrtT7CBOaxCkFRDiAnGT48em2AWWZMWg5r6b9bQG2SnAUhMCGRiP/yfb2m/sWFWA/nSc5Ly//Q==",
    "license": "MIT",
    "dependencies": {
@@ -5797,7 +5797,7 @@
   },
   "node_modules/@wix/table-reservations_app-extensions": {
    "version": "1.0.38",
-   "resolved": "https://registry.npmjs.org/@wix/table-reservations_app-extensions/-/@wix/table-reservations_app-extensions-1.0.38.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations_app-extensions/-/table-reservations_app-extensions-1.0.38.tgz",
    "integrity": "sha512-ImYorQmqy4jyLcNnWPTEYkVHN2C1rBPbMQ0AAW9bSMJtq+B7GODpcIil2fQL2J/vQBmkZ7ebKCLt/8FC8ALTmQ==",
    "license": "MIT",
    "dependencies": {
@@ -5808,7 +5808,7 @@
   },
   "node_modules/@wix/table-reservations-lib": {
    "version": "1.304.0",
-   "resolved": "https://registry.npmjs.org/@wix/table-reservations-lib/-/@wix/table-reservations-lib-1.304.0.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/table-reservations-lib/-/table-reservations-lib-1.304.0.tgz",
    "integrity": "sha512-NA877KvFrdx0F6/IaklkkAYWC0VyFbvP1kQwnyz1uUf1PuC+sQvhlB2foQKnALjjr8CiFHYAVC7bXsNiW1yVDQ==",
    "license": "UNLICENSED",
    "dependencies": {
@@ -5833,7 +5833,7 @@
   },
   "node_modules/@wix/workspace": {
    "version": "1.3.19",
-   "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
    "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
    "license": "UNLICENSED",
    "dependencies": {

--- a/skills/wix-headless-fast/references/storefront/lock/astro/package-lock.json
+++ b/skills/wix-headless-fast/references/storefront/lock/astro/package-lock.json
@@ -1,12247 +1,12247 @@
 {
-  "name": "wix-astro-blank",
-  "version": "0.0.1",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "wix-astro-blank",
-      "version": "0.0.1",
-      "dependencies": {
-        "@tailwindcss/vite": "^4.1.7",
-        "@wix/astro": "^2.39.0",
-        "@wix/astro-pages": "^2.0.4",
-        "@wix/categories": "^1.0.220",
-        "@wix/dashboard": "^1.3.43",
-        "@wix/ecom": "^1.0.2451",
-        "@wix/essentials": "^1.0.6",
-        "@wix/redirects": "^1.0.125",
-        "@wix/sdk": "^1.21.5",
-        "@wix/seo": "^1.0.79",
-        "@wix/stores": "^1.0.888",
-        "astro": "^5.8.0",
-        "tailwindcss": "^4.1.7",
-        "typescript": "^5.8.3"
-      },
-      "devDependencies": {
-        "@astrojs/react": "^4.3.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.1",
-        "@wix/astro-wix-hosting-adapter": "^2.0.0",
-        "@wix/cli": "^1.1.92",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
-      }
-    },
-    "node_modules/@astrojs/cloudflare": {
-      "version": "12.6.13",
-      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
-      "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/underscore-redirects": "1.0.0",
-        "@cloudflare/workers-types": "^4.20260116.0",
-        "tinyglobby": "^0.2.15",
-        "vite": "^6.4.1",
-        "wrangler": "4.59.2"
-      },
-      "peerDependencies": {
-        "astro": "^5.7.0"
-      }
-    },
-    "node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
-      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
-      "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/prism": "3.3.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/@astrojs/prism": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prismjs": "^1.30.0"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      }
-    },
-    "node_modules/@astrojs/react": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
-      "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitejs/plugin-react": "^4.7.0",
-        "ultrahtml": "^1.6.0",
-        "vite": "^6.4.1"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
-        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
-        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
-        "dlv": "^1.1.3",
-        "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
-        "which-pm-runs": "^1.1.0"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
-      }
-    },
-    "node_modules/@astrojs/underscore-redirects": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
-      "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
-      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@babel/types": "^7.29.8",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
-      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.8"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.8",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.8",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.8",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
-      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@capsizecss/unpack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
-      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "fontkitten": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
-      "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.24",
-        "workerd": "^1.20251221.0"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
-      "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
-      "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
-      "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
-      "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
-      "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
-      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/icu-skeleton-parser": "1.8.16",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
-      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
-      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^22.20 || ^24.12 || >=25"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oslojs/encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
-      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
-    },
-    "node_modules/@poppinss/colors": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
-      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^4.1.5"
-      }
-    },
-    "node_modules/@poppinss/colors/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@poppinss/dumper": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
-      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@sindresorhus/is": "^7.0.2",
-        "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/@poppinss/exception": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
-      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@preact/signals-core": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
-      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@preact/signals-react": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
-      "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-core": "^1.14.4",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "node_modules/@radix-ui/number": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
-      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
-      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
-      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
-      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
-      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
-      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
-      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
-      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-effect-event": "0.0.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
-      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
-      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
-      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-rect": "1.1.4",
-        "@radix-ui/react-use-size": "1.1.4",
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
-      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
-      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
-      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-slot": "1.3.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
-      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-is-hydrated": "0.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
-      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/number": "1.1.3",
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.19",
-        "@radix-ui/react-focus-guards": "1.1.6",
-        "@radix-ui/react-focus-scope": "1.1.16",
-        "@radix-ui/react-id": "1.1.4",
-        "@radix-ui/react-popper": "1.3.7",
-        "@radix-ui/react-portal": "1.1.17",
-        "@radix-ui/react-presence": "1.1.10",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-slot": "1.3.3",
-        "@radix-ui/react-use-callback-ref": "1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-previous": "1.1.4",
-        "@radix-ui/react-visually-hidden": "1.2.11",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
-      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/number": "1.1.3",
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-collection": "1.1.15",
-        "@radix-ui/react-compose-refs": "1.1.5",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6",
-        "@radix-ui/react-use-layout-effect": "1.1.4",
-        "@radix-ui/react-use-previous": "1.1.4",
-        "@radix-ui/react-use-size": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
-      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
-      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
-      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-context": "1.2.2",
-        "@radix-ui/react-direction": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.10",
-        "@radix-ui/react-roving-focus": "1.1.19",
-        "@radix-ui/react-toggle": "1.1.18",
-        "@radix-ui/react-use-controllable-state": "1.2.6"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
-      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
-      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-use-effect-event": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
-      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
-      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
-      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
-      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
-      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/rect": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
-      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
-      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/rect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
-      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
-      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
-      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
-      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
-      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
-      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
-      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
-      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
-      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
-      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
-      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
-      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
-      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
-      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
-      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
-      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
-      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
-      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
-      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
-      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
-      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
-      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
-      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
-      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
-      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@speed-highlight/core": {
-      "version": "1.2.24",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
-      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
-      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.24.1",
-        "jiti": "^2.7.0",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.3"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
-      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.3",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
-        "@tailwindcss/oxide-darwin-x64": "4.3.3",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
-      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
-      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
-      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
-      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
-      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
-      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
-      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
-      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
-      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
-      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.11.1",
-        "@emnapi/runtime": "^1.11.1",
-        "@emnapi/wasi-threads": "^1.2.2",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
-      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
-      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
-      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.3.3",
-        "@tailwindcss/oxide": "4.3.3",
-        "tailwindcss": "4.3.3"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/hast": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
-      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/nlcst": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
-      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "license": "ISC"
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@wix/agent-skills": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
-      "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wix/analytics": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@wix/analytics/-/@wix/analytics-1.19.0.tgz",
-      "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
-      "license": "MIT"
-    },
-    "node_modules/@wix/app-extensions": {
-      "version": "1.0.133",
-      "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/@wix/app-extensions-1.0.133.tgz",
-      "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
-    },
-    "node_modules/@wix/app-management": {
-      "version": "1.0.158",
-      "resolved": "https://registry.npmjs.org/@wix/app-management/-/@wix/app-management-1.0.158.tgz",
-      "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_app-management_app-instances": "1.0.48",
-        "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
-        "@wix/auto_sdk_app-management_app-plans": "1.0.37",
-        "@wix/auto_sdk_app-management_bi-events": "1.0.37",
-        "@wix/auto_sdk_app-management_billing": "1.0.45",
-        "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
-        "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
-        "@wix/auto_sdk_app-management_external-billing": "1.0.32"
-      }
-    },
-    "node_modules/@wix/astro": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/astro/-/@wix/astro-2.68.0.tgz",
-      "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
-      "dependencies": {
-        "@wix/app-management": "^1.0.149",
-        "@wix/auth-management": "^1.0.71",
-        "@wix/dashboard": "^1.3.43",
-        "@wix/editor": "^1.772.0",
-        "@wix/essentials": "^1.0.14",
-        "@wix/headless-localization-utils": "^1.0.13",
-        "@wix/headless-node": "^1.43.0",
-        "@wix/headless-site": "^1.31.0",
-        "@wix/headless-site-assets": "^1.0.13",
-        "@wix/multilingual-manager": "^1.5.0",
-        "@wix/react-component-schema": "^1.4.0",
-        "@wix/sdk": "^1.21.3",
-        "@wix/sdk-runtime": "^1.0.0",
-        "@wix/sdk-types": "^1.17.1",
-        "@wix/site": "^1.66.0"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      }
-    },
-    "node_modules/@wix/astro-pages": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/@wix/astro-pages-2.0.4.tgz",
-      "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
-      "peerDependencies": {
-        "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@wix/astro-wix-hosting-adapter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/@wix/astro-wix-hosting-adapter-2.0.0.tgz",
-      "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
-      "dev": true,
-      "dependencies": {
-        "@astrojs/cloudflare": "^12.6.10"
-      },
-      "peerDependencies": {
-        "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@wix/auth-management": {
-      "version": "1.0.91",
-      "resolved": "https://registry.npmjs.org/@wix/auth-management/-/@wix/auth-management-1.0.91.tgz",
-      "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
-      }
-    },
-    "node_modules/@wix/authentication": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wix/authentication/-/@wix/authentication-1.16.0.tgz",
-      "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.15",
-        "@wix/sdk-types": "^1.17.9"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-instances": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/@wix/auto_sdk_app-management_app-instances-1.0.48.tgz",
-      "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-permissions": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/@wix/auto_sdk_app-management_app-permissions-1.0.46.tgz",
-      "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_app-plans": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/@wix/auto_sdk_app-management_app-plans-1.0.37.tgz",
-      "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_bi-events": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/@wix/auto_sdk_app-management_bi-events-1.0.37.tgz",
-      "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_billing": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/@wix/auto_sdk_app-management_billing-1.0.45.tgz",
-      "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_custom-charges": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/@wix/auto_sdk_app-management_custom-charges-1.0.35.tgz",
-      "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/@wix/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
-      "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_app-management_external-billing": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/@wix/auto_sdk_app-management_external-billing-1.0.32.tgz",
-      "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/@wix/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
-      "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_bookings_availability-calendar": {
-      "version": "1.0.196",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-calendar/-/@wix/auto_sdk_bookings_availability-calendar-1.0.196.tgz",
-      "integrity": "sha512-EXtTMMkqJhj0hOdAykz719KXTLnzwTURl/P+uJrKHyZoE8j9ovzJKv20ATr5IbOWHA3tje9oTLivqMMqxqU99w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_categories_categories": {
-      "version": "1.0.142",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_categories_categories/-/@wix/auto_sdk_categories_categories-1.0.142.tgz",
-      "integrity": "sha512-QQvhbwt1Ms9ZDBt21fv+IimfDiUPHRAOafpRXb/Z08M/V6uz6mL1FOZ/qcfK5RKaeaMfRs/fa2eUEvV95z7mHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_abandoned-checkouts": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_abandoned-checkouts/-/@wix/auto_sdk_ecom_abandoned-checkouts-1.0.83.tgz",
-      "integrity": "sha512-k7mo7MuxcFgwyq6aUrBEaVjsDOkSceXb0jDSKYRFMsysivlQ3H5Io+ZOvFJ2NlBJT4Kq3OStXj4hyvIEFuJNzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_additional-fees": {
-      "version": "1.0.49",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_additional-fees/-/@wix/auto_sdk_ecom_additional-fees-1.0.49.tgz",
-      "integrity": "sha512-ouF6gC/hZQXIiQM3HN/88Svf/TUEmHpDRyEGCSGNiG+DDb7WMQ5lgo+elnrZ5xsrK8nh3ir9wCcZf4Et511wuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_back-in-stock-notifications": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-notifications/-/@wix/auto_sdk_ecom_back-in-stock-notifications-1.0.63.tgz",
-      "integrity": "sha512-9enqO6pwJU114uhnaa4v0f2qj8VWYexYHUutP86qxmadNVi0ekEQUrif5VonByPRgIgGTFlGwIPP5BD4L0BeoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_back-in-stock-settings": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-settings/-/@wix/auto_sdk_ecom_back-in-stock-settings-1.0.42.tgz",
-      "integrity": "sha512-YKRGIjbKqhtXnfSrGjqPSwqLDCjt2Se9q11ro0vI+9zoyyfWmsRIR4oYt1quZ/m7w8Qz79auLt1z80WRFJehOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_cart": {
-      "version": "1.0.174",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart/-/@wix/auto_sdk_ecom_cart-1.0.174.tgz",
-      "integrity": "sha512-bng9lfcWQ0XJ1Nr0SKe2v7yen9SprlZRHRuQ+iXe27VJWjmFhGcUGj7xqCtbLj9zTQ91DBU916eYIo9YBM5WRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
-      "version": "1.0.192",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/@wix/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
-      "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_catalog": {
-      "version": "1.0.64",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_catalog/-/@wix/auto_sdk_ecom_catalog-1.0.64.tgz",
-      "integrity": "sha512-fKmFDucjlRKPCiLiTseBSTVGTQQyvn6Hap9gLzkF/+IFsKCg515Z+pSs2ds8os8D3V4DZCUkOfYJenzleJw01Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_checkout": {
-      "version": "1.0.168",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/@wix/auto_sdk_ecom_checkout-1.0.168.tgz",
-      "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_checkout-content": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-content/-/@wix/auto_sdk_ecom_checkout-content-1.0.37.tgz",
-      "integrity": "sha512-RrG3rzJBFGTCQR1hG9RX9/p9z07dfqNHjDtZs9DZUbHlsgqZlo8mJ6H28Th2tUlc7LaFBJ90l+3/qlJwSCzL/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_checkout-settings": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-settings/-/@wix/auto_sdk_ecom_checkout-settings-1.0.73.tgz",
-      "integrity": "sha512-2j8Z3dbhox4Hs0n0VmUUcEyreOX02OYkPyRk9MTGI51L6i4Bd5rWWxaqn74boDURcgQjF9JTxAlXXQvfvDC0eA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_checkout-templates": {
-      "version": "1.0.150",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-templates/-/@wix/auto_sdk_ecom_checkout-templates-1.0.150.tgz",
-      "integrity": "sha512-jomZhO1xhmmHX/FYaijYI8+g8b05rSn+X2bGIpVFGsjynZCj0lXyxcMKJxANk+t6D11pxf4oIoF8o45EpzkVBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_contact-tax-details": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_contact-tax-details/-/@wix/auto_sdk_ecom_contact-tax-details-1.0.3.tgz",
-      "integrity": "sha512-kx7Q+0QWzc0TCqPINuhLjXuFacrkxl1Vc3hmF/ZtqiTpHZ4xoegAaHOhiQ20l7mNXbgAWajn1bVVNS/ZNHxD1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_currencies": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_currencies/-/@wix/auto_sdk_ecom_currencies-1.0.35.tgz",
-      "integrity": "sha512-gfCYsiJ4zsDbm9PGxhi/paZEW8lJZdUnIEAPneRU9lfvGK+6QbM5TRJd74Fwcgsp8K82O15DPfzlZ0tH9Y02kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_current-cart": {
-      "version": "1.0.184",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/@wix/auto_sdk_ecom_current-cart-1.0.184.tgz",
-      "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_current-cart-v-2": {
-      "version": "1.0.193",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart-v-2/-/@wix/auto_sdk_ecom_current-cart-v-2-1.0.193.tgz",
-      "integrity": "sha512-H9v8Jsmm+TXPSZ/WlQD9Gz/lLJIKzZIQHW/FOB/VfOBC20yufghAhZl9g05YgBWoBydtmNePS/wOQGzVwJ1nVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_custom-triggers": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_custom-triggers/-/@wix/auto_sdk_ecom_custom-triggers-1.0.40.tgz",
-      "integrity": "sha512-4pbt7WOMuMSQIEre/Do0LmcF3RdSVvE6Z3538pTg9jCvg6R+uBb/mycBNu/Za3iJNrcsYmv62Zq6p8y+BuHdbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_delivery-profile": {
-      "version": "1.0.440",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-profile/-/@wix/auto_sdk_ecom_delivery-profile-1.0.440.tgz",
-      "integrity": "sha512-KZA+tN85AR65oUvmsVr0WTOBLkwYq18piO+8QE5ug5XxLSLLnwC7WUBqGDbm5N6GWxW1L2cJu8eIIqBzPxPY+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_delivery-solutions": {
-      "version": "1.0.62",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-solutions/-/@wix/auto_sdk_ecom_delivery-solutions-1.0.62.tgz",
-      "integrity": "sha512-YuLWOYsSSrfhZ/RpKa/67Qel8O9Ft1Qz8VebclOuAB1JrAV25zsMVh3Ks8yJeBPdOfawlcL4ECGbMi4t6v9b4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_discount-rules": {
-      "version": "1.0.115",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discount-rules/-/@wix/auto_sdk_ecom_discount-rules-1.0.115.tgz",
-      "integrity": "sha512-K0TMVir6a7o5pSvetPebJELwuVrhMiPwhyC6dtnTmdHNYwmMVpGZlkloJowNcra9kCiPm1iGKRSrvSu4SxtjmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_discounts": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts/-/@wix/auto_sdk_ecom_discounts-1.0.34.tgz",
-      "integrity": "sha512-UBSaqNnZrivhDAhrDYmGceibwe0sYCd+RQEbAOPn/8ZlXKnS9R6VCVjxvmgMqrnQ9Cpyht8WGS/df61g2ID8Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_discounts-custom-trigger": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts-custom-trigger/-/@wix/auto_sdk_ecom_discounts-custom-trigger-1.0.45.tgz",
-      "integrity": "sha512-ykH8JVbiXukiHCtikksv5NjrjLec+8I9M6kf8RrwGekgD1NXX73hvij4XV8tJp8Pxm14OTPocGmTl/vPA00/gA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_draft-orders": {
-      "version": "1.0.171",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-orders/-/@wix/auto_sdk_ecom_draft-orders-1.0.171.tgz",
-      "integrity": "sha512-DZkSx3spJDmXsDxf0EhQg30EjNJoEuaixlJGPcXJn43mQTtFeb0pI4s3hlikS1ZsXsJPdyefhYcPn6d8/jq9Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_draft-subscription-contracts": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-subscription-contracts/-/@wix/auto_sdk_ecom_draft-subscription-contracts-1.0.7.tgz",
-      "integrity": "sha512-IqP/MoK8T0YlDvcmrH9OkZrvaUMKnPyky1/+aXZ4qM4IQH1AiVi6S34vU/BwOlwMC37EMaJWVnaZ82j986xS/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_ecommerce-settings": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_ecommerce-settings/-/@wix/auto_sdk_ecom_ecommerce-settings-1.0.33.tgz",
-      "integrity": "sha512-2Wy6YrZV488ENvXmy9lIUYW65qSJ7KkgLYVZeH211EESGXqpKYHjSeMafopBpN+ycz3huzwYtyhoTqVQ577uwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_gift-vouchers": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers/-/@wix/auto_sdk_ecom_gift-vouchers-1.0.45.tgz",
-      "integrity": "sha512-z+n1zAZ/EHFP1fKjRNXNDNbUsx/G/sy5KFJES2+l/Ipzgsu/m/9smBzjtJlKndf0MMCxeSQk6sU2pa92pEt0fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_gift-vouchers-provider": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers-provider/-/@wix/auto_sdk_ecom_gift-vouchers-provider-1.0.35.tgz",
-      "integrity": "sha512-57/A3DK88Awz8fgmfkEc51tPEsCfJgzkQCYrCUsgaHPyJZ2froVF+UfDvBDPqlFCJhbmI4ZAtYWhXUXzsxezfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_inventory": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_inventory/-/@wix/auto_sdk_ecom_inventory-1.0.24.tgz",
-      "integrity": "sha512-gvhjYT5NtAcsfSuvth7Y3JNsKajAPJswdot7Vtvojx+tOAQLgdCtvBdS+CY27Ms1HRcVUjqGSUg1czu4IKaZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_local-delivery-options": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_local-delivery-options/-/@wix/auto_sdk_ecom_local-delivery-options-1.0.53.tgz",
-      "integrity": "sha512-9Bw2w1MNgMaQNNmNNegDWn4YHuycjJMzBH3CObEZuSrpGk0pBz/oHJyUAGFLcfrNu3QHSMfqqHUk78T1wXi7bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_manual-tax-mappings": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_manual-tax-mappings/-/@wix/auto_sdk_ecom_manual-tax-mappings-1.0.43.tgz",
-      "integrity": "sha512-5lOIYwVHFoiHMTumdGO/Hz8EBMUUHaolJ2cBhopfQE4KM0g4iWQad8tmQxNAo229azQB3LySnFm3O0dQSA/fSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_memberships": {
-      "version": "1.0.66",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_memberships/-/@wix/auto_sdk_ecom_memberships-1.0.66.tgz",
-      "integrity": "sha512-oSjsAhJOk/a7v5+Pfd3AYLx43sdU6knnc8kiGRuZdeZg4Mu1mhqLXsmhfdLo/dvILqbgf/bEkLwLQ6Gg/yxmOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_order-billing": {
-      "version": "1.0.104",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-billing/-/@wix/auto_sdk_ecom_order-billing-1.0.104.tgz",
-      "integrity": "sha512-mhC2hVZb65oPwc0/y4gthsSgnWqiaanNrog9qAFj7NxS9Gz3QC1hw0GbXzog814paZlB/QETm5jKu1FxzXweMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_order-fulfillments": {
-      "version": "1.0.62",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-fulfillments/-/@wix/auto_sdk_ecom_order-fulfillments-1.0.62.tgz",
-      "integrity": "sha512-Rsjbrq6aeXlQXQD42HH4es5a+1R9hePBca0I3sb+/XsPnszB+GvaCyUwsX8a/UpimHciqN+aQ07p1yMKN8M+rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_order-invoices": {
-      "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-invoices/-/@wix/auto_sdk_ecom_order-invoices-1.0.52.tgz",
-      "integrity": "sha512-htA5vi/lACC20BF4dfnxZ8GaY9viaemZi4oQQqf8FOIHuItlMzoscwF21viybu/XKzghXfZqi/vX+jJBWXdTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_order-payment-requests": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-payment-requests/-/@wix/auto_sdk_ecom_order-payment-requests-1.0.67.tgz",
-      "integrity": "sha512-zqVQlZztMspEG2TguG+hmw8yFVqsipjdyxudraOwxqTcpHTA71ay+35EDHRGsH36WvORHNGM1DHj8D6PyojKJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_order-transactions": {
-      "version": "1.0.104",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-transactions/-/@wix/auto_sdk_ecom_order-transactions-1.0.104.tgz",
-      "integrity": "sha512-vZwoWGPWgG273L4omJLBTItvqBWiqCqUQgPOpIKaU6PnbA5R8xib5VdjQ853zqjnAZFlrkPztWNLiFn7AnqlXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_orders": {
-      "version": "1.0.286",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders/-/@wix/auto_sdk_ecom_orders-1.0.286.tgz",
-      "integrity": "sha512-YJVe5RjcF+heHig9Bai64O/SbhaRVeO5qc6K2trN8dQDD7RMJiZndRNgDzo0+sGxggDsnd3jLpH4a0AZcVmkgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_orders-settings": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders-settings/-/@wix/auto_sdk_ecom_orders-settings-1.0.55.tgz",
-      "integrity": "sha512-RY+rDh307GkVr8aEnHri+N3EgW0wzKc4gKRJw2/RcjAGDX8QY9JDb7C8ep2vhgm/FcMXA3csxddV/TyPeZ0LGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_payment-settings": {
-      "version": "1.0.143",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_payment-settings/-/@wix/auto_sdk_ecom_payment-settings-1.0.143.tgz",
-      "integrity": "sha512-9LOI5E1p5aZZ5sC2k4q6T+uZ4Ylp2bYuVeOdj/4quXfT45OqPotAH+66ET5vhzPhaRSY3VfuAC5EnwHrdDH0PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_pickup-locations": {
-      "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_pickup-locations/-/@wix/auto_sdk_ecom_pickup-locations-1.0.52.tgz",
-      "integrity": "sha512-E4+UEDHHNU4jV7KsyoJR++tTw9cqcROOBltG8CNJCAhQCnDbqxK3gfOdK9gYvgPrAWNoJ1Jzq2bCmTaK7Ru/QA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_recommendations": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations/-/@wix/auto_sdk_ecom_recommendations-1.0.47.tgz",
-      "integrity": "sha512-kIX4fnm/IYDMdV7BJMK8eUx05lP0hm/0v8PvviCKlhG/0LtLQ9SrusRZn8pZOEyG2Lp+7RAYkS3F/t4SRBAdTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_recommendations-provider": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations-provider/-/@wix/auto_sdk_ecom_recommendations-provider-1.0.33.tgz",
-      "integrity": "sha512-x00UHSPpdXDt/bKwRx9fhspPKbOWH74cHuzSJRj7+7rp5hAAySBepNvbY+V4YKtq1W2wZ3au+b0fSBQ2BDdOPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_shipping-options": {
-      "version": "1.0.230",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-options/-/@wix/auto_sdk_ecom_shipping-options-1.0.230.tgz",
-      "integrity": "sha512-PqlZiJqSKHde7yZbom0KhndP6Pe+UsdzUx0C2EH2XBszXSv1FKymBNVEw2+PaI0JxDfZ2E4WpWWaGHuIm9E2dA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_shipping-rates": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-rates/-/@wix/auto_sdk_ecom_shipping-rates-1.0.39.tgz",
-      "integrity": "sha512-WzM3aB28G/XeaBjaXWYAAEXP5niKQprw2Cchpd4jHOPC1atWy91lox8Vvi080WZQUdOWuw9eUfGpci9D+/jTLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_shippo-configurations": {
-      "version": "1.0.71",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shippo-configurations/-/@wix/auto_sdk_ecom_shippo-configurations-1.0.71.tgz",
-      "integrity": "sha512-h7kJJpsPYQTMQKelbeECsEDLZM6VLEb37FBE//Nmiap1ff+PUcFFZ0DsHuXktsWkoa3oQp4JBuCWbqojvy6dOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_subscription-contracts": {
-      "version": "1.0.125",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_subscription-contracts/-/@wix/auto_sdk_ecom_subscription-contracts-1.0.125.tgz",
-      "integrity": "sha512-elR3LIlzu/dM1eBBc8Jbklni/lD3QL4eeEuHp470g4QF9TXq/a1e4cJ9qzqC1EUm8L+y5VsWZXI1G8Q8rwuI3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-calculation": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation/-/@wix/auto_sdk_ecom_tax-calculation-1.0.54.tgz",
-      "integrity": "sha512-wkXEshZoXgBm8LtxX/38iJ9tdnzRTpBKtY0PpvMmhp/AHt4z8nFSKPhLJHo35U3XJSLxBnt7meiVWnZY+0v9Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-calculation-provider": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation-provider/-/@wix/auto_sdk_ecom_tax-calculation-provider-1.0.31.tgz",
-      "integrity": "sha512-X8WgM60a+qMqKOHwH3kdvJMEB+mCnrnFRZbVSLjigAqwL5YcVYBltAovI8viR05LLQd6s0MOqntjew/pDPzZeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-exempt-groups": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-exempt-groups/-/@wix/auto_sdk_ecom_tax-exempt-groups-1.0.4.tgz",
-      "integrity": "sha512-yk7U1z5enPiVxeNVFH05lr7UtCM5xn0IAXDW7pswkknrdAOk0axrjc279CY5jTHaZTmEgqyEv0/39ZZTycDCkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-groups": {
-      "version": "1.0.64",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-groups/-/@wix/auto_sdk_ecom_tax-groups-1.0.64.tgz",
-      "integrity": "sha512-df8Zise8uEfHFgj7tDvTTcT7DRn+771j6eI4tWqL6fPIQGPN0rURY7kGQehBi3jnDHLOohI5ksg7hlKKsjCQzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-regions": {
-      "version": "1.0.61",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-regions/-/@wix/auto_sdk_ecom_tax-regions-1.0.61.tgz",
-      "integrity": "sha512-o2Gmc89SlO5pQuOngj+l8y+vm7HQJ0qxuEJzqdJwx0siRIwRqb8hkmT0+HXn+zM1e0Ntc9kMxHHabYf2OtqCmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tax-settings": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-settings/-/@wix/auto_sdk_ecom_tax-settings-1.0.2.tgz",
-      "integrity": "sha512-8+566igMSdW6dOK9RHRmoatin7w6U+H10ren7YqlNixf3qJBazSyv2CdMwFvf1MFSFSY319u3VgkW64OPWrQKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tip-settings": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tip-settings/-/@wix/auto_sdk_ecom_tip-settings-1.0.54.tgz",
-      "integrity": "sha512-4N1l/X0KTIXOzkbCVO/oYuDnApCpz/MToDg0IEbfjeEnm1SX/gk1DkXnSjuGv6ttOEusekyL1WdOXwL5qKvQmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tippable-staff": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tippable-staff/-/@wix/auto_sdk_ecom_tippable-staff-1.0.40.tgz",
-      "integrity": "sha512-FvIEtLdx3qbMSvQcr5czVDjzP7BvV9c69FquHuvrBOVotq6xjEiqs9+durHHHcqNpWgs/DjVIeT+GZ2rwWrozw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_tips": {
-      "version": "1.0.62",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tips/-/@wix/auto_sdk_ecom_tips-1.0.62.tgz",
-      "integrity": "sha512-zPUDIRSXEdghPH7G049nzNsyB+5JYeiOLtwUelQasibHwln1sb/rG7R5xP9ifIVuy6u7kzwN7Oisuk8NDrNyCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_totals-calculator": {
-      "version": "1.0.115",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_totals-calculator/-/@wix/auto_sdk_ecom_totals-calculator-1.0.115.tgz",
-      "integrity": "sha512-N1rp4LtZSfTooN3J/3OmfMpcbrWIIHkskSm7NYo74TmnJFLpE5sAUyAMGbCwamZjYFXKVWdCJnWMjn8PgQq3Pg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_validations": {
-      "version": "1.0.56",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_validations/-/@wix/auto_sdk_ecom_validations-1.0.56.tgz",
-      "integrity": "sha512-UUbTbVI5qTYkJYg+DBtJN2dAGJqYuZ1FyFlTEI5sgqxRHeFlalKxWppAGG0stlk5E2Tweb52/OLb3UvMQ7zLVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_ecom_wishlists": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_wishlists/-/@wix/auto_sdk_ecom_wishlists-1.0.2.tgz",
-      "integrity": "sha512-W1VkbP9U40aHpk1eu27Z9PoFFgWO1FuTUhpm346jlHBK//9kL8Zktwbag9P6Taxp3/CeILsqsriAvJtb1LkE9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/@wix/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
-      "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_authentication": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/@wix/auto_sdk_identity_authentication-1.0.57.tgz",
-      "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_oauth": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/@wix/auto_sdk_identity_oauth-1.0.53.tgz",
-      "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_recovery": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/@wix/auto_sdk_identity_recovery-1.0.46.tgz",
-      "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/@wix/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
-      "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_identity_verification": {
-      "version": "1.0.48",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/@wix/auto_sdk_identity_verification-1.0.48.tgz",
-      "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/@wix/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
-      "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/@wix/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
-      "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_files": {
-      "version": "1.0.96",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/@wix/auto_sdk_media_files-1.0.96.tgz",
-      "integrity": "sha512-KrPyTF319c/EKKbVA+89xPXhQ1MBl5ShR41OPmiFhRyhbILWe7dRIn/5dgBhopsKj5mBw50SuA5bXeHrntv8Yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_media_folders": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/@wix/auto_sdk_media_folders-1.0.57.tgz",
-      "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_redirects_redirects": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/@wix/auto_sdk_redirects_redirects-1.0.53.tgz",
-      "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/@wix/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
-      "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_llms-txt": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/@wix/auto_sdk_seo_llms-txt-1.0.0.tgz",
-      "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_redirects": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/@wix/auto_sdk_seo_redirects-1.0.2.tgz",
-      "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_robots-txt": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/@wix/auto_sdk_seo_robots-txt-1.0.21.tgz",
-      "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.12",
-        "@wix/sdk-types": "^1.17.7",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-patterns": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/@wix/auto_sdk_seo_seo-patterns-1.0.8.tgz",
-      "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/@wix/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
-      "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_seo-tags": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/@wix/auto_sdk_seo_seo-tags-1.0.28.tgz",
-      "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/@wix/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
-      "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_abandoned-carts": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_abandoned-carts/-/@wix/auto_sdk_stores_abandoned-carts-1.0.42.tgz",
-      "integrity": "sha512-DXG4pLTEaBP8pdzIWpidlJ44lkk93BuUew0iXB/nq6JbgDOu0O+GNgglPzrBC8oGxEhsrfzBMGkWkT68cH8hVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_brands-v-3": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_brands-v-3/-/@wix/auto_sdk_stores_brands-v-3-1.0.80.tgz",
-      "integrity": "sha512-bCqh6Kl2lU7j3JySC9kvQEbQc2+LncKkuyoc3F0gx+ei9w9Z3eQay6V0Q4w0oCWaRkYpC0NNvvRoUeAWsk5TKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_catalog-imports-v-3": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_catalog-imports-v-3/-/@wix/auto_sdk_stores_catalog-imports-v-3-1.0.84.tgz",
-      "integrity": "sha512-TvWARid8/679NGicnuGBnE/p0thZWeFvDr6TNel60rR2ZouO8RoS8w78j3sbUqbY/2WRRrUcb/9CAZNBEbbBEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_catalog-versioning": {
-      "version": "1.0.77",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_catalog-versioning/-/@wix/auto_sdk_stores_catalog-versioning-1.0.77.tgz",
-      "integrity": "sha512-nLuNFPnBp6lHIy44LblKO0pPAYXUjhANqdad0rTfEZu0niUrKKXgYbI8WayQU/OVHPqZrC8xRcpk9cAe8LUgpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_collections": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_collections/-/@wix/auto_sdk_stores_collections-1.0.47.tgz",
-      "integrity": "sha512-SFYl7ns3VziT1P0aZuJwNtmLlbTlpx38YGBI1mbMOgDhOBhRyt59CKo50fSmKntdFwoqHF90j+zOlnbxc/UmeA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_customizations-v-3": {
-      "version": "1.0.92",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_customizations-v-3/-/@wix/auto_sdk_stores_customizations-v-3-1.0.92.tgz",
-      "integrity": "sha512-y1ObDGG/pDGMmGgelb6bUgY1EFp0nQcUHVq1PnECrxpIQXv0LhJ/frASd5xot0Lb1aONWGZAuia9QEvzJKKhaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_info-sections-v-3": {
-      "version": "1.0.107",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_info-sections-v-3/-/@wix/auto_sdk_stores_info-sections-v-3-1.0.107.tgz",
-      "integrity": "sha512-wShiCSDNuLPks0VIjsckf45jaBe6imoI+7x3/6/dFdm1ufMYRDg70aqzzgUeWMp6FVeEhqZWBiEEJKdo0LnuMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_inventory": {
-      "version": "1.0.74",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_inventory/-/@wix/auto_sdk_stores_inventory-1.0.74.tgz",
-      "integrity": "sha512-m4taisJPIynd2hCEGnY501cxbOcmPyfOcTNtjmXaVtN2xQswaa1BA6CYIpk+wgG32N5MtTRILrbW3EQmg9e2mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_inventory-items-v-3": {
-      "version": "1.0.91",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_inventory-items-v-3/-/@wix/auto_sdk_stores_inventory-items-v-3-1.0.91.tgz",
-      "integrity": "sha512-FytMefbR/xy/bzEI4HGl0Dp2rtahrnynIh4sdbiVzeaU7n5ZT9jI/DdYABsNjokPu7oe3dAzobPQQiETMpfBXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_product-groups-v-3": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_product-groups-v-3/-/@wix/auto_sdk_stores_product-groups-v-3-1.0.6.tgz",
-      "integrity": "sha512-QIynglDeH1Z9dICpJCJU2MJlMqoBjrKnjwXSbpNDBZy5HLbvE8/MHzKoOzWzLPwzyU2qXVelNQ6D3UCnDFpHvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_products": {
-      "version": "1.0.104",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_products/-/@wix/auto_sdk_stores_products-1.0.104.tgz",
-      "integrity": "sha512-mV6sm1jEAgkjRZN9jdWTVKch4ajoeBMZwxuUW9Fe07vAN0bY9rjWLQ4h74bmHTVaCF8NR7qKjRtmqLJjpaQJbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_products-v-3": {
-      "version": "1.0.217",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_products-v-3/-/@wix/auto_sdk_stores_products-v-3-1.0.217.tgz",
-      "integrity": "sha512-MSiOiCvpHZ9NkirqvbudxS4lzQZQWSTAjVggXGWeQYJdduW6todFIBcxU9fPt4CKsI+q7X/FQ6NrctqCsTiEgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_promotions-v-3": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_promotions-v-3/-/@wix/auto_sdk_stores_promotions-v-3-1.0.2.tgz",
-      "integrity": "sha512-GB1n5II3IEyOjvqdQGGCsUdW0Ra5btXbwTYLt8xgef2qJHTh3tNObfmXU/FhtXpKDOaOxnuvn/m3XN5A3kk4Ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_read-only-variants-v-3": {
-      "version": "1.0.136",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_read-only-variants-v-3/-/@wix/auto_sdk_stores_read-only-variants-v-3-1.0.136.tgz",
-      "integrity": "sha512-SrpfRui07Nm3fZugfFnHWCz271BMLa7LIScFp/34KBOVMPIc2G7BVL4AfJ8X2se5ha9zPpEd5udvZAfmC1MDKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_ribbons-v-3": {
-      "version": "1.0.59",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_ribbons-v-3/-/@wix/auto_sdk_stores_ribbons-v-3-1.0.59.tgz",
-      "integrity": "sha512-TpDBVN+w86AzQIy+ZkaVulnrJrJ/uvJDL2YvuCIfd/mfqUupzBCj+sOcBMAommLTb5HIPr0tmY6ThyX6dSKrYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_stores-locations-v-3": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_stores-locations-v-3/-/@wix/auto_sdk_stores_stores-locations-v-3-1.0.55.tgz",
-      "integrity": "sha512-tmTvTGRMV6x+Z1jKAKBP+dPdXJYpgNgJWMTU9Of0TARuHAdPkLWWFIkuba5n4lpX226HekceI+z+SadCotR2Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_subscription-options": {
-      "version": "1.0.69",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_subscription-options/-/@wix/auto_sdk_stores_subscription-options-1.0.69.tgz",
-      "integrity": "sha512-SOyFaEZxAMZ6wRQLjWnaUMr/JdiElT44EPT/1VQ5zWtupiqFKN5RfOXsMwm1mG0mCC4gZbd+edBXBg+AkYqqDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/auto_sdk_stores_wishlist": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_wishlist/-/@wix/auto_sdk_stores_wishlist-1.0.38.tgz",
-      "integrity": "sha512-kdGETiwtnATkKXTTHUQ1wJZN8jsv6Nyaiyl/BD/k4CV0bKWXpvDiXyp1TeKH/TyEedMUw52UF5XoECr38bzQsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.19",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/categories": {
-      "version": "1.0.220",
-      "resolved": "https://registry.npmjs.org/@wix/categories/-/@wix/categories-1.0.220.tgz",
-      "integrity": "sha512-8W3Gu/0dIo/gEPzHWzvs/8tqfTfBUUlI00TL73OeRftdzC82hUWtXc2B0VlX70ine7pFmzVqqIoqLxfRvVgSOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_categories_categories": "1.0.142"
-      }
-    },
-    "node_modules/@wix/cli": {
-      "version": "1.1.239",
-      "resolved": "https://registry.npmjs.org/@wix/cli/-/@wix/cli-1.1.239.tgz",
-      "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
-      "dev": true,
-      "dependencies": {
-        "@wix/agent-skills": "^1.1.0",
-        "node-gyp": "^8.4.1"
-      },
-      "bin": {
-        "wix": "bin/wix.cjs"
-      },
-      "engines": {
-        "node": ">= 20.11.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@wix/communication-channel": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/@wix/communication-channel-1.0.10.tgz",
-      "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "comlink": "4.3.0"
-      }
-    },
-    "node_modules/@wix/consent-policy-manager": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/@wix/consent-policy-manager-1.15.0.tgz",
-      "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
-      "license": "MIT"
-    },
-    "node_modules/@wix/credits-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wix/credits-types/-/@wix/credits-types-1.0.3.tgz",
-      "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      }
-    },
-    "node_modules/@wix/dashboard": {
-      "version": "1.3.47",
-      "resolved": "https://registry.npmjs.org/@wix/dashboard/-/@wix/dashboard-1.3.47.tgz",
-      "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/communication-channel": "1.0.10",
-        "@wix/feedback-loop-structure": "^1.34.0",
-        "@wix/media": "^1.0.249",
-        "@wix/monitoring-browser-sdk-host": "^0.1.27",
-        "@wix/sdk-runtime": "^0.3.62",
-        "@wix/sdk-types": "^1.17.8",
-        "@wix/workspace": "^1.3.14",
-        "zustand": "^4.5.0"
-      },
-      "peerDependencies": {
-        "@wix/sdk": ">=1.12.4",
-        "react": "^16.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@wix/sdk": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
-      "version": "0.3.62",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
-      "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "^1.13.41"
-      }
-    },
-    "node_modules/@wix/ecom": {
-      "version": "1.0.2454",
-      "resolved": "https://registry.npmjs.org/@wix/ecom/-/@wix/ecom-1.0.2454.tgz",
-      "integrity": "sha512-fjkJZf+utwGk6db2W7/WUo/UiAiYzODeaJOkqSDoGVL4rt6j6u1YQRRtWoCSc1nixIZengHYs1amJp7+SZnEww==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_ecom_abandoned-checkouts": "1.0.83",
-        "@wix/auto_sdk_ecom_additional-fees": "1.0.49",
-        "@wix/auto_sdk_ecom_back-in-stock-notifications": "1.0.63",
-        "@wix/auto_sdk_ecom_back-in-stock-settings": "1.0.42",
-        "@wix/auto_sdk_ecom_cart": "1.0.174",
-        "@wix/auto_sdk_ecom_cart-v-2": "1.0.192",
-        "@wix/auto_sdk_ecom_catalog": "1.0.64",
-        "@wix/auto_sdk_ecom_checkout": "1.0.168",
-        "@wix/auto_sdk_ecom_checkout-content": "1.0.37",
-        "@wix/auto_sdk_ecom_checkout-settings": "1.0.73",
-        "@wix/auto_sdk_ecom_checkout-templates": "1.0.150",
-        "@wix/auto_sdk_ecom_contact-tax-details": "1.0.3",
-        "@wix/auto_sdk_ecom_currencies": "1.0.35",
-        "@wix/auto_sdk_ecom_current-cart": "1.0.184",
-        "@wix/auto_sdk_ecom_current-cart-v-2": "1.0.193",
-        "@wix/auto_sdk_ecom_custom-triggers": "1.0.40",
-        "@wix/auto_sdk_ecom_delivery-profile": "1.0.440",
-        "@wix/auto_sdk_ecom_delivery-solutions": "1.0.62",
-        "@wix/auto_sdk_ecom_discount-rules": "1.0.115",
-        "@wix/auto_sdk_ecom_discounts": "1.0.34",
-        "@wix/auto_sdk_ecom_discounts-custom-trigger": "1.0.45",
-        "@wix/auto_sdk_ecom_draft-orders": "1.0.171",
-        "@wix/auto_sdk_ecom_draft-subscription-contracts": "1.0.7",
-        "@wix/auto_sdk_ecom_ecommerce-settings": "1.0.33",
-        "@wix/auto_sdk_ecom_gift-vouchers": "1.0.45",
-        "@wix/auto_sdk_ecom_gift-vouchers-provider": "1.0.35",
-        "@wix/auto_sdk_ecom_inventory": "1.0.24",
-        "@wix/auto_sdk_ecom_local-delivery-options": "1.0.53",
-        "@wix/auto_sdk_ecom_manual-tax-mappings": "1.0.43",
-        "@wix/auto_sdk_ecom_memberships": "1.0.66",
-        "@wix/auto_sdk_ecom_order-billing": "1.0.104",
-        "@wix/auto_sdk_ecom_order-fulfillments": "1.0.62",
-        "@wix/auto_sdk_ecom_order-invoices": "1.0.52",
-        "@wix/auto_sdk_ecom_order-payment-requests": "1.0.67",
-        "@wix/auto_sdk_ecom_order-transactions": "1.0.104",
-        "@wix/auto_sdk_ecom_orders": "1.0.286",
-        "@wix/auto_sdk_ecom_orders-settings": "1.0.55",
-        "@wix/auto_sdk_ecom_payment-settings": "1.0.143",
-        "@wix/auto_sdk_ecom_pickup-locations": "1.0.52",
-        "@wix/auto_sdk_ecom_recommendations": "1.0.47",
-        "@wix/auto_sdk_ecom_recommendations-provider": "1.0.33",
-        "@wix/auto_sdk_ecom_shipping-options": "1.0.230",
-        "@wix/auto_sdk_ecom_shipping-rates": "1.0.39",
-        "@wix/auto_sdk_ecom_shippo-configurations": "1.0.71",
-        "@wix/auto_sdk_ecom_subscription-contracts": "1.0.125",
-        "@wix/auto_sdk_ecom_tax-calculation": "1.0.54",
-        "@wix/auto_sdk_ecom_tax-calculation-provider": "1.0.31",
-        "@wix/auto_sdk_ecom_tax-exempt-groups": "1.0.4",
-        "@wix/auto_sdk_ecom_tax-groups": "1.0.64",
-        "@wix/auto_sdk_ecom_tax-regions": "1.0.61",
-        "@wix/auto_sdk_ecom_tax-settings": "1.0.2",
-        "@wix/auto_sdk_ecom_tip-settings": "1.0.54",
-        "@wix/auto_sdk_ecom_tippable-staff": "1.0.40",
-        "@wix/auto_sdk_ecom_tips": "1.0.62",
-        "@wix/auto_sdk_ecom_totals-calculator": "1.0.115",
-        "@wix/auto_sdk_ecom_validations": "1.0.56",
-        "@wix/auto_sdk_ecom_wishlists": "1.0.2",
-        "@wix/ecom_app-extensions": "1.0.107",
-        "@wix/headless-ecom": "0.0.41"
-      }
-    },
-    "node_modules/@wix/ecom_app-extensions": {
-      "version": "1.0.107",
-      "resolved": "https://registry.npmjs.org/@wix/ecom_app-extensions/-/@wix/ecom_app-extensions-1.0.107.tgz",
-      "integrity": "sha512-oAUv1VGGFCth/G7YxkMlvJCv1RjPJ02QgcMWGJFwuorfgCZHEinoA3F8QKaQ97FaF+k7Nup00OMLYJl/TBpCwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/editor": {
-      "version": "1.785.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor/-/@wix/editor-1.785.0.tgz",
-      "integrity": "sha512-2gjp52CPDm0NyHmOeSshY8JB8d9cZSim+wLhEtywvonapYmhMUYpk3apg5Y6Nq9EkkQKV78h3VBldbG89bA6zQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/editor-platform-environment-api": "1.161.0",
-        "@wix/monitoring-browser-sdk-host": "^0.1.25",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0",
-        "@wix/sdk-runtime": "^0.7.0",
-        "@wix/sdk-types": "^1.17.11",
-        "@wix/workspace": "^1.3.18"
-      }
-    },
-    "node_modules/@wix/editor-application": {
-      "version": "1.473.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-application/-/@wix/editor-application-1.473.0.tgz",
-      "integrity": "sha512-uMfBLWBF/XBcw5uZcn9Uwng+iQEfm+dWI34DfSgWuy52FrpnFrCiIxZpO/bKMK0lBGzvy6WGIVj9Sbzrd6iLjg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-contexts": {
-      "version": "1.160.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/@wix/editor-platform-contexts-1.160.0.tgz",
-      "integrity": "sha512-5nBLeqPsWELDJECxcXVbsTm+uTI8W15e46Mi8wvm8i7SM87RfsOB0BY5kIIP33rfMFyBrZS2NJiRAGO9IzadZQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-platform-transport": "1.15.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-environment-api": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/@wix/editor-platform-environment-api-1.161.0.tgz",
-      "integrity": "sha512-hjUr8xmqDij0bKCKp2VPCfajz8Wj2JAeDL2ez9pcgtoPhtuPixaSRzrTNegK8Kk+p6sitLlhPxtOEi6FCsBtlw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/editor-application": "1.473.0",
-        "@wix/editor-platform-contexts": "1.160.0",
-        "@wix/editor-platform-transport": "1.15.0",
-        "@wix/public-editor-platform-errors": "1.9.0",
-        "@wix/public-editor-platform-events": "1.394.0",
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/editor-platform-transport": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/@wix/editor-platform-transport-1.15.0.tgz",
-      "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
-      "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.14.0"
-      }
-    },
-    "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
-      "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler-types": "^1.19.0",
-        "@wix/monitoring-types": "^0.12.0",
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/error-handler-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/@wix/error-handler-core-1.20.0.tgz",
-      "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-types": "1.20.0"
-      }
-    },
-    "node_modules/@wix/error-handler-types": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/@wix/error-handler-types-1.20.0.tgz",
-      "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      }
-    },
-    "node_modules/@wix/essentials": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@wix/essentials/-/@wix/essentials-1.0.14.tgz",
-      "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler": "^1.67.0",
-        "@wix/monitoring": "^0.21.0",
-        "@wix/multilingual-manager": "^1.2.0",
-        "@wix/sdk-runtime": "1.0.22",
-        "@wix/sdk-types": "1.17.11",
-        "i18next": "^25.6.3",
-        "i18next-icu": "^2.4.1",
-        "intl-messageformat": "^10.7.18",
-        "react-i18next": "^16.1.2"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
-      "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-core": "1.20.0",
-        "events": "^3.3.0",
-        "http-status-codes": "^2.3.0",
-        "uuid": "^11.0.3"
-      },
-      "peerDependencies": {
-        "@wix/fe-essentials": "^1.233.0",
-        "i18next": ">=19.9.2",
-        "i18next-icu": ">=2.3.0",
-        "intl-messageformat": ">=7.8.4"
-      },
-      "peerDependenciesMeta": {
-        "@wix/fe-essentials": {
-          "optional": true
-        },
-        "i18next": {
-          "optional": true
-        },
-        "i18next-icu": {
-          "optional": true
-        },
-        "intl-messageformat": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
-      "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/feedback-loop-structure": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/@wix/feedback-loop-structure-1.34.0.tgz",
-      "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@wix/headless-components": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
-      "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-select": "^2.2.6",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-toggle-group": "^1.1.11",
-        "@wix/headless-utils": "0.0.0"
-      }
-    },
-    "node_modules/@wix/headless-ecom": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.41.tgz",
-      "integrity": "sha512-YYZZtCLvY+2vcS0FxSJuuro8aWF8jnINHQRafxYwkZXQNvPMbewKpx1MF97/UiSaGyeSCJyZZoOTdSldEo7Vtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.1.0",
-        "@wix/auto_sdk_ecom_checkout": "^1.0.61",
-        "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
-        "@wix/headless-media": "0.0.21",
-        "@wix/redirects": "^1.0.0",
-        "@wix/sdk": "^1.15.24",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@wix/headless-components": "^0.0.0"
-      }
-    },
-    "node_modules/@wix/headless-localization-utils": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/@wix/headless-localization-utils-1.0.15.tgz",
-      "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/headless-node": "^1.42.0",
-        "@wix/headless-site-assets": "^1.0.9"
-      }
-    },
-    "node_modules/@wix/headless-media": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.21.tgz",
-      "integrity": "sha512-7o9ctPfQsQwfLwLCjs4RDO9Ns900Hv+BNVc301tShulKeitxgMKTrFqUxCsCuSQqqgQYaOhm5hDB+994LtBozg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk": "^1.17.1",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/headless-node": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-node/-/@wix/headless-node-1.44.0.tgz",
-      "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/monitoring-velo": "^1.31.0",
-        "@wix/sdk-runtime": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/headless-seo": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/@wix/headless-seo-0.0.16.tgz",
-      "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/seo": "^1.0.14",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/headless-site": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-site/-/@wix/headless-site-1.37.0.tgz",
-      "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/monitoring-velo": "^1.31.0",
-        "@wix/sdk-runtime": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/headless-site-assets": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/@wix/headless-site-assets-1.0.13.tgz",
-      "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
-      }
-    },
-    "node_modules/@wix/headless-stores": {
-      "version": "0.0.119",
-      "resolved": "https://registry.npmjs.org/@wix/headless-stores/-/@wix/headless-stores-0.0.119.tgz",
-      "integrity": "sha512-PcXXK0FyXffYKMqp8CHRGTnNZgOQftLaxMGDuA8bWY7WT05uzIsxceWK33xDRhzXFPz/lEWB/YvwQ1+vIy2XcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.2.3",
-        "@wix/auto_sdk_bookings_availability-calendar": "^1.0.155",
-        "@wix/auto_sdk_categories_categories": "^1.0.62",
-        "@wix/ecom": "^1.0.1744",
-        "@wix/essentials": "^0.1.24",
-        "@wix/headless-ecom": "0.0.45",
-        "@wix/headless-media": "0.0.25",
-        "@wix/headless-utils": "0.0.12",
-        "@wix/redirects": "^1.0.83",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3",
-        "@wix/site": "^1.40.0",
-        "@wix/stores": "^1.0.650"
-      },
-      "peerDependencies": {
-        "@wix/headless-components": "^0.0.0"
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/error-handler": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/@wix/error-handler/-/@wix/error-handler-1.68.0.tgz",
-      "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@wix/error-handler-core": "1.20.0",
-        "events": "^3.3.0",
-        "http-status-codes": "^2.3.0",
-        "uuid": "^11.0.3"
-      },
-      "peerDependencies": {
-        "@wix/fe-essentials": "^1.233.0",
-        "i18next": ">=19.9.2",
-        "i18next-icu": ">=2.3.0",
-        "intl-messageformat": ">=7.8.4"
-      },
-      "peerDependenciesMeta": {
-        "@wix/fe-essentials": {
-          "optional": true
-        },
-        "i18next": {
-          "optional": true
-        },
-        "i18next-icu": {
-          "optional": true
-        },
-        "intl-messageformat": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/essentials": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
-      "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler": "^1.67.0",
-        "@wix/monitoring": "^0.21.0",
-        "@wix/sdk-runtime": "^0.3.62",
-        "@wix/sdk-types": "^1.13.41",
-        "i18next": "^25.3.2",
-        "i18next-icu": "^2.3.0",
-        "intl-messageformat": "^10.7.16"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/headless-ecom": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/@wix/headless-ecom-0.0.45.tgz",
-      "integrity": "sha512-CRbvUajeMijIitfPMCgOEPLJtBe8ry5ePD4PF9wTiUjFrHR+Ybz0u8wd9zomnH910zLFWdBcfIBqxFboBIP8aw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.1.0",
-        "@wix/auto_sdk_ecom_checkout": "^1.0.61",
-        "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
-        "@wix/headless-media": "0.0.25",
-        "@wix/redirects": "^1.0.0",
-        "@wix/sdk": "^1.15.24",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@wix/headless-components": "^0.0.0"
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/headless-media": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
-      "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk": "^1.17.1",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/headless-utils": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/@wix/headless-utils-0.0.12.tgz",
-      "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@wix/headless-stores/node_modules/@wix/sdk-runtime": {
-      "version": "0.3.62",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
-      "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "^1.13.41"
-      }
-    },
-    "node_modules/@wix/headless-utils": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
-      "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@wix/identity": {
-      "version": "1.0.230",
-      "resolved": "https://registry.npmjs.org/@wix/identity/-/@wix/identity-1.0.230.tgz",
-      "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_identity_authentication": "1.0.57",
-        "@wix/auto_sdk_identity_oauth": "1.0.53",
-        "@wix/auto_sdk_identity_recovery": "1.0.46",
-        "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
-        "@wix/auto_sdk_identity_verification": "1.0.48"
-      }
-    },
-    "node_modules/@wix/image-kit": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@wix/image-kit/-/@wix/image-kit-1.125.0.tgz",
-      "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@wix/media": {
-      "version": "1.0.271",
-      "resolved": "https://registry.npmjs.org/@wix/media/-/@wix/media-1.0.271.tgz",
-      "integrity": "sha512-Ci/qsi/qouoC9NqIwwgiEvcRxk9xJugivsk59wPRDb0h/kQDAs9Jc8R06bgBPAC8ja3+frRMnBXTrVo2+bmaqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
-        "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
-        "@wix/auto_sdk_media_files": "1.0.96",
-        "@wix/auto_sdk_media_folders": "1.0.57",
-        "@wix/headless-media": "^0.0.25"
-      }
-    },
-    "node_modules/@wix/media/node_modules/@wix/headless-media": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@wix/headless-media/-/@wix/headless-media-0.0.25.tgz",
-      "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk": "^1.17.1",
-        "@wix/services-definitions": "^1.0.1",
-        "@wix/services-manager-react": "^1.0.3"
-      }
-    },
-    "node_modules/@wix/monitoring": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
-      "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.12.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/@wix/monitoring-browser-panorama-0.10.0.tgz",
-      "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common-sentry": "0.2.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/@wix/monitoring-browser-sdk-host-0.1.27.tgz",
-      "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-browser-panorama": "0.10.0",
-        "@wix/monitoring-browser-sentry": "0.26.0",
-        "@wix/monitoring-types": "0.17.0",
-        "@wix/monitoring-velo": "1.29.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.29.0.tgz",
-      "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common": "1.13.0",
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/@wix/monitoring-browser-sentry-0.26.0.tgz",
-      "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.0.0",
-        "@wix/monitoring-common-sentry": "0.2.0",
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.0.0.tgz",
-      "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "0.17.0"
-      }
-    },
-    "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-0.17.0.tgz",
-      "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-common": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/@wix/monitoring-common-1.13.0.tgz",
-      "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-common-sentry": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/@wix/monitoring-common-sentry-0.2.0.tgz",
-      "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
-      "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/monitoring-velo": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/@wix/monitoring-velo-1.31.0.tgz",
-      "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring": "1.1.0",
-        "@wix/monitoring-common": "1.13.0",
-        "@wix/monitoring-types": "1.0.0"
-      }
-    },
-    "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring/-/@wix/monitoring-1.1.0.tgz",
-      "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/monitoring-types": "1.0.0"
-      }
-    },
-    "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/@wix/monitoring-types-1.0.0.tgz",
-      "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/multilingual-manager": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/@wix/multilingual-manager-1.11.0.tgz",
-      "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/headless-localization-utils": "^1.0.11",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@wix/public-editor-platform-errors": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/@wix/public-editor-platform-errors-1.9.0.tgz",
-      "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/public-editor-platform-events": {
-      "version": "1.394.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/@wix/public-editor-platform-events-1.394.0.tgz",
-      "integrity": "sha512-yHxIbhSpHZE8CIPoYonUrkNVDzDRYT36Ssb3HIJ8b1OZRhdtcjF1HNP+okdTVW+mBBiyXjGFNqfe1LWM0R6GDg==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/public-editor-platform-interfaces": "1.103.0"
-      }
-    },
-    "node_modules/@wix/public-editor-platform-interfaces": {
-      "version": "1.103.0",
-      "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/@wix/public-editor-platform-interfaces-1.103.0.tgz",
-      "integrity": "sha512-iWupfV581sAgrCd8UyWrlakRNHhjfEeH0tluwVBbD+OEoybKs58c4xLEAw2N4A+VzzRVcwOIk+b6hdF4wI6wjw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@wix/app-extensions": "^1.0.131",
-        "@wix/sdk-types": "^1.17.11"
-      }
-    },
-    "node_modules/@wix/react-component-schema": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/@wix/react-component-schema-1.8.0.tgz",
-      "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
-      "license": "ISC"
-    },
-    "node_modules/@wix/redirects": {
-      "version": "1.0.125",
-      "resolved": "https://registry.npmjs.org/@wix/redirects/-/@wix/redirects-1.0.125.tgz",
-      "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_redirects_redirects": "1.0.53"
-      }
-    },
-    "node_modules/@wix/sdk": {
-      "version": "1.21.16",
-      "resolved": "https://registry.npmjs.org/@wix/sdk/-/@wix/sdk-1.21.16.tgz",
-      "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/identity": "^1.0.204",
-        "@wix/image-kit": "^1.114.0",
-        "@wix/redirects": "^1.0.70",
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-runtime": "1.0.22",
-        "@wix/sdk-types": "1.17.11",
-        "jose": "^5.10.0",
-        "type-fest": "^4.41.0"
-      },
-      "optionalDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@wix/sdk-context": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
-      "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
-      "license": "UNLICENSED"
-    },
-    "node_modules/@wix/sdk-react-context": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/@wix/sdk-react-context-1.0.2.tgz",
-      "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
-      "license": "UNLICENSED",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@wix/sdk-runtime": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.24.tgz",
-      "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/sdk-types": {
-      "version": "1.17.11",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/@wix/sdk-types-1.17.11.tgz",
-      "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/error-handler-types": "^1.19.0",
-        "@wix/monitoring-types": "^0.12.0",
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/@wix/sdk-runtime-1.0.22.tgz",
-      "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-context": "0.0.1",
-        "@wix/sdk-types": "1.17.11"
-      }
-    },
-    "node_modules/@wix/seo": {
-      "version": "1.0.79",
-      "resolved": "https://registry.npmjs.org/@wix/seo/-/@wix/seo-1.0.79.tgz",
-      "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
-        "@wix/auto_sdk_seo_llms-txt": "1.0.0",
-        "@wix/auto_sdk_seo_redirects": "1.0.2",
-        "@wix/auto_sdk_seo_robots-txt": "1.0.21",
-        "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
-        "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
-        "@wix/auto_sdk_seo_seo-tags": "1.0.28",
-        "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
-        "@wix/headless-seo": "^0.0.16"
-      }
-    },
-    "node_modules/@wix/services-definitions": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/@wix/services-definitions-1.0.5.tgz",
-      "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
-      "dependencies": {
-        "type-fest": "^4.41.0"
-      }
-    },
-    "node_modules/@wix/services-manager": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@wix/services-manager/-/@wix/services-manager-1.0.7.tgz",
-      "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
-      "peer": true,
-      "dependencies": {
-        "@preact/signals-core": "^1.12.1",
-        "@wix/sdk-context": "0.0.1",
-        "@wix/services-definitions": "1.0.5"
-      }
-    },
-    "node_modules/@wix/services-manager-react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/@wix/services-manager-react-1.0.8.tgz",
-      "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-react": "^3.6.1",
-        "@wix/sdk-react-context": "1.0.2",
-        "@wix/services-definitions": "1.0.5"
-      },
-      "peerDependencies": {
-        "@wix/services-manager": "^1.0.0",
-        "react": "^16.14.0 || 17.x || 18.x || 19.x",
-        "react-dom": "^18.3.1",
-        "use-sync-external-store": "^1.0.0"
-      }
-    },
-    "node_modules/@wix/site": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@wix/site/-/@wix/site-1.66.0.tgz",
-      "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/analytics": "1.19.0",
-        "@wix/authentication": "1.16.0",
-        "@wix/consent-policy-manager": "1.15.0",
-        "@wix/multilingual-manager": "1.11.0",
-        "@wix/sdk-types": "^1.13.2"
-      }
-    },
-    "node_modules/@wix/stores": {
-      "version": "1.0.889",
-      "resolved": "https://registry.npmjs.org/@wix/stores/-/@wix/stores-1.0.889.tgz",
-      "integrity": "sha512-H+gn+6YEriDRt5fAuCtiT87fAEiD8PycOLfqV8ayAu8ncOka9ckatZkZO7IAx3BAKk3YGP+3i4ephPOvjlu+lg==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/auto_sdk_stores_abandoned-carts": "1.0.42",
-        "@wix/auto_sdk_stores_brands-v-3": "1.0.80",
-        "@wix/auto_sdk_stores_catalog-imports-v-3": "1.0.84",
-        "@wix/auto_sdk_stores_catalog-versioning": "1.0.77",
-        "@wix/auto_sdk_stores_collections": "1.0.47",
-        "@wix/auto_sdk_stores_customizations-v-3": "1.0.92",
-        "@wix/auto_sdk_stores_info-sections-v-3": "1.0.107",
-        "@wix/auto_sdk_stores_inventory": "1.0.74",
-        "@wix/auto_sdk_stores_inventory-items-v-3": "1.0.91",
-        "@wix/auto_sdk_stores_product-groups-v-3": "1.0.6",
-        "@wix/auto_sdk_stores_products": "1.0.104",
-        "@wix/auto_sdk_stores_products-v-3": "1.0.217",
-        "@wix/auto_sdk_stores_promotions-v-3": "1.0.2",
-        "@wix/auto_sdk_stores_read-only-variants-v-3": "1.0.136",
-        "@wix/auto_sdk_stores_ribbons-v-3": "1.0.59",
-        "@wix/auto_sdk_stores_stores-locations-v-3": "1.0.55",
-        "@wix/auto_sdk_stores_subscription-options": "1.0.69",
-        "@wix/auto_sdk_stores_wishlist": "1.0.38",
-        "@wix/headless-stores": "^0.0.119",
-        "@wix/stores_app-extensions": "1.0.54"
-      }
-    },
-    "node_modules/@wix/stores_app-extensions": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@wix/stores_app-extensions/-/@wix/stores_app-extensions-1.0.54.tgz",
-      "integrity": "sha512-m+/iwpsySTwqOmeloE6/aW1aiqAjiadoCLw+t0Je8kN5jIzFhytodnJlEjQVHzAB+3DYCK586+B96qTrkwSynQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11",
-        "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@wix/workspace": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/@wix/workspace/-/@wix/workspace-1.3.19.tgz",
-      "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@wix/credits-types": "^1.0.3",
-        "@wix/sdk-runtime": "^1.0.24",
-        "@wix/sdk-types": "^1.17.11"
-      },
-      "peerDependencies": {
-        "@wix/sdk": "^1.21.3"
-      }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/array-iterate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
-      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/astro": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
-      "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/compiler": "^2.13.0",
-        "@astrojs/internal-helpers": "0.7.6",
-        "@astrojs/markdown-remark": "6.3.11",
-        "@astrojs/telemetry": "3.3.0",
-        "@capsizecss/unpack": "^4.0.0",
-        "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.3.0",
-        "acorn": "^8.15.0",
-        "aria-query": "^5.3.2",
-        "axobject-query": "^4.1.0",
-        "boxen": "8.0.1",
-        "ci-info": "^4.3.1",
-        "clsx": "^2.1.1",
-        "common-ancestor-path": "^1.0.1",
-        "cookie": "^1.1.1",
-        "cssesc": "^3.0.0",
-        "debug": "^4.4.3",
-        "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.6.2",
-        "diff": "^8.0.3",
-        "dlv": "^1.1.3",
-        "dset": "^3.1.4",
-        "es-module-lexer": "^1.7.0",
-        "esbuild": "^0.27.3",
-        "estree-walker": "^3.0.3",
-        "flattie": "^1.1.1",
-        "fontace": "~0.4.0",
-        "github-slugger": "^2.0.0",
-        "html-escaper": "3.0.3",
-        "http-cache-semantics": "^4.2.0",
-        "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.1",
-        "magic-string": "^0.30.21",
-        "magicast": "^0.5.1",
-        "mrmime": "^2.0.1",
-        "neotraverse": "^0.6.18",
-        "p-limit": "^6.2.0",
-        "p-queue": "^8.1.1",
-        "package-manager-detector": "^1.6.0",
-        "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
-        "prompts": "^2.4.2",
-        "rehype": "^13.0.2",
-        "semver": "^7.7.3",
-        "shiki": "^3.21.0",
-        "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tsconfck": "^3.1.6",
-        "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.3",
-        "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.17.4",
-        "vfile": "^6.0.3",
-        "vite": "^6.4.1",
-        "vitefu": "^1.1.1",
-        "xxhash-wasm": "^1.1.0",
-        "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.2.3",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.25.1",
-        "zod-to-ts": "^1.2.0"
-      },
-      "bin": {
-        "astro": "astro.js"
-      },
-      "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/astrodotbuild"
-      },
-      "optionalDependencies": {
-        "sharp": "^0.34.0"
-      }
-    },
-    "node_modules/astro/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/astro/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/astro/node_modules/unstorage": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
-      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^3.1.3",
-        "chokidar": "^5.0.0",
-        "destr": "^2.0.5",
-        "h3": "^1.15.10",
-        "lru-cache": "^11.2.7",
-        "node-fetch-native": "^1.6.7",
-        "ofetch": "^1.5.1",
-        "ufo": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@azure/app-configuration": "^1.8.0",
-        "@azure/cosmos": "^4.2.0",
-        "@azure/data-tables": "^13.3.0",
-        "@azure/identity": "^4.6.0",
-        "@azure/keyvault-secrets": "^4.9.0",
-        "@azure/storage-blob": "^12.26.0",
-        "@capacitor/preferences": "^6 || ^7 || ^8",
-        "@deno/kv": ">=0.9.0",
-        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
-        "@planetscale/database": "^1.19.0",
-        "@upstash/redis": "^1.34.3",
-        "@vercel/blob": ">=0.27.1",
-        "@vercel/functions": "^2.2.12 || ^3.0.0",
-        "@vercel/kv": "^1 || ^2 || ^3",
-        "aws4fetch": "^1.0.20",
-        "db0": ">=0.2.1",
-        "idb-keyval": "^6.2.1",
-        "ioredis": "^5.4.2",
-        "uploadthing": "^7.4.4"
-      },
-      "peerDependenciesMeta": {
-        "@azure/app-configuration": {
-          "optional": true
-        },
-        "@azure/cosmos": {
-          "optional": true
-        },
-        "@azure/data-tables": {
-          "optional": true
-        },
-        "@azure/identity": {
-          "optional": true
-        },
-        "@azure/keyvault-secrets": {
-          "optional": true
-        },
-        "@azure/storage-blob": {
-          "optional": true
-        },
-        "@capacitor/preferences": {
-          "optional": true
-        },
-        "@deno/kv": {
-          "optional": true
-        },
-        "@netlify/blobs": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/blob": {
-          "optional": true
-        },
-        "@vercel/functions": {
-          "optional": true
-        },
-        "@vercel/kv": {
-          "optional": true
-        },
-        "aws4fetch": {
-          "optional": true
-        },
-        "db0": {
-          "optional": true
-        },
-        "idb-keyval": {
-          "optional": true
-        },
-        "ioredis": {
-          "optional": true
-        },
-        "uploadthing": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/astro/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/astro/node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/bail": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.11.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/blake3-wasm": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
-    },
-    "node_modules/boxen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^8.0.0",
-        "chalk": "^5.3.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^7.2.0",
-        "type-fest": "^4.21.0",
-        "widest-line": "^5.0.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/camelcase": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/comlink": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
-      "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-      "license": "ISC"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cookie-es": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
-      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
-      "license": "MIT"
-    },
-    "node_modules/crossws": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
-    },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "license": "MIT"
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/destr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/deterministic-object-hash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/devalue": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
-      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
-      "license": "MIT"
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.405",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
-      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.24.5",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
-      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/error-stack-parser-es": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
-      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/flattie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
-      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fontace": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
-      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
-      "license": "MIT",
-      "dependencies": {
-        "fontkitten": "^1.0.2"
-      }
-    },
-    "node_modules/fontkitten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
-      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-inflate": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/graphql": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
-      "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
-      }
-    },
-    "node_modules/h3": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
-      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie-es": "^1.2.3",
-        "crossws": "^0.3.5",
-        "defu": "^6.1.6",
-        "destr": "^2.0.5",
-        "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.4",
-        "radix3": "^1.1.2",
-        "ufo": "^1.6.3",
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "hast-util-to-parse5": "^8.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "parse5": "^7.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-text": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unist-util-find-after": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "license": "MIT"
-    },
-    "node_modules/html-parse-stringify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
-      "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "license": "MIT"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://www.locize.com/i18next"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.locize.com"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/i18next-icu": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
-      "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "intl-messageformat": ">=10.3.3 <12.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/intl-messageformat": {
-      "version": "10.7.18",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
-      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/iron-webcrypto": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
-      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/brc-dd"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
-      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mdast-util-definitions": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
-      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/micromark": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-destination": "^2.0.0",
-        "micromark-factory-label": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-title": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-html-tag-name": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/miniflare": {
-      "version": "4.20260114.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
-      "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.14.0",
-        "workerd": "1.20260114.0",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10",
-        "zod": "^3.25.76"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
-    "node_modules/miniflare/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/nlcst-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
-      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "license": "MIT"
-    },
-    "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-mock-http": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
-      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
-      "license": "MIT"
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
-      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/ofetch": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
-      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
-      "license": "MIT",
-      "dependencies": {
-        "destr": "^2.0.5",
-        "node-fetch-native": "^1.6.7",
-        "ufo": "^1.6.1"
-      }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "license": "MIT"
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/oniguruma-parser": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
-      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
-      "license": "MIT"
-    },
-    "node_modules/oniguruma-to-es": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
-      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
-      "license": "MIT",
-      "dependencies": {
-        "oniguruma-parser": "^0.12.2",
-        "regex": "^6.1.0",
-        "regex-recursion": "^6.0.2"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-manager-detector": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-      "license": "MIT"
-    },
-    "node_modules/parse-latin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
-      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "@types/unist": "^3.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unist-util-modify-children": "^4.0.0",
-        "unist-util-visit-children": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/piccolore": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
-      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
-      "license": "ISC"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/property-information": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
-      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/radix3": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
-      "license": "MIT"
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-i18next": {
-      "version": "16.6.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "html-parse-stringify": "^3.0.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "i18next": ">= 25.10.9",
-        "react": ">= 16.8.0",
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
-      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "license": "MIT"
-    },
-    "node_modules/rehype": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "rehype-parse": "^9.0.0",
-        "rehype-stringify": "^10.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-raw": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-raw": "^9.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-stringify": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-gfm": "^3.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-smartypants": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
-      "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
-      "license": "MIT",
-      "dependencies": {
-        "retext": "^9.0.0",
-        "retext-smartypants": "^6.0.0",
-        "unified": "^11.0.4",
-        "unist-util-visit": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
-      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "retext-latin": "^4.0.0",
-        "retext-stringify": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-latin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
-      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "parse-latin": "^7.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-smartypants": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
-      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-stringify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
-      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nlcst": "^2.0.0",
-        "nlcst-to-string": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.62.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
-      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.9"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
-        "@rollup/rollup-android-arm-eabi": "4.62.4",
-        "@rollup/rollup-android-arm64": "4.62.4",
-        "@rollup/rollup-darwin-arm64": "4.62.4",
-        "@rollup/rollup-darwin-x64": "4.62.4",
-        "@rollup/rollup-freebsd-arm64": "4.62.4",
-        "@rollup/rollup-freebsd-x64": "4.62.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
-        "@rollup/rollup-linux-arm64-musl": "4.62.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
-        "@rollup/rollup-linux-loong64-musl": "4.62.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-gnu": "4.62.4",
-        "@rollup/rollup-linux-x64-musl": "4.62.4",
-        "@rollup/rollup-openbsd-x64": "4.62.4",
-        "@rollup/rollup-openharmony-arm64": "4.62.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
-        "@rollup/rollup-win32-x64-gnu": "4.62.4",
-        "@rollup/rollup-win32-x64-msvc": "4.62.4",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/sax": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
-      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "license": "MIT"
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/smol-toml": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
-      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^11.1.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
-      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trough": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-      "license": "MIT"
-    },
-    "node_modules/ultrahtml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
-      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
-      "license": "MIT"
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/unenv": {
-      "version": "2.0.0-rc.24",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
-      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/unified": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "bail": "^2.0.0",
-        "devlop": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unifont": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
-      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.1.0",
-        "ohash": "^2.0.11",
-        "undici": "^8.0.0"
-      }
-    },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/unist-util-find-after": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-modify-children": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
-      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "array-iterate": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-children": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
-      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
-      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vite": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
-      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/vitefu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
-      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
-      "license": "MIT",
-      "workspaces": [
-        "tests/deps/*",
-        "tests/projects/*",
-        "tests/projects/workspace/packages/*"
-      ],
-      "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/workerd": {
-      "version": "1.20260114.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
-      "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260114.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
-        "@cloudflare/workerd-linux-64": "1.20260114.0",
-        "@cloudflare/workerd-linux-arm64": "1.20260114.0",
-        "@cloudflare/workerd-windows-64": "1.20260114.0"
-      }
-    },
-    "node_modules/wrangler": {
-      "version": "4.59.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
-      "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.10.0",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.0",
-        "miniflare": "4.20260114.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260114.0"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260114.0"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xxhash-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-      "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yocto-spinner": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-      "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.19"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
-      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/youch": {
-      "version": "4.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
-      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/colors": "^4.1.5",
-        "@poppinss/dumper": "^0.6.4",
-        "@speed-highlight/core": "^1.2.7",
-        "cookie": "^1.0.2",
-        "youch-core": "^0.3.3"
-      }
-    },
-    "node_modules/youch-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
-      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/exception": "^1.2.2",
-        "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
+ "name": "wix-astro-blank",
+ "version": "0.0.1",
+ "lockfileVersion": 3,
+ "requires": true,
+ "packages": {
+  "": {
+   "name": "wix-astro-blank",
+   "version": "0.0.1",
+   "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "@wix/astro": "^2.39.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/categories": "^1.0.220",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/ecom": "^1.0.2451",
+    "@wix/essentials": "^1.0.6",
+    "@wix/redirects": "^1.0.125",
+    "@wix/sdk": "^1.21.5",
+    "@wix/seo": "^1.0.79",
+    "@wix/stores": "^1.0.888",
+    "astro": "^5.8.0",
+    "tailwindcss": "^4.1.7",
+    "typescript": "^5.8.3"
+   },
+   "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
+    "@wix/cli": "^1.1.92",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+   }
+  },
+  "node_modules/@astrojs/cloudflare": {
+   "version": "12.6.13",
+   "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.13.tgz",
+   "integrity": "sha512-oKaCyiovyQr183r9U93787Ju1zwk+rRMgPnLTwCLckHmOUK7sltA1Gp4LSGt8oNMgqQS6jR7uRdfQ/NPul37QA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/underscore-redirects": "1.0.0",
+    "@cloudflare/workers-types": "^4.20260116.0",
+    "tinyglobby": "^0.2.15",
+    "vite": "^6.4.1",
+    "wrangler": "4.59.2"
+   },
+   "peerDependencies": {
+    "astro": "^5.7.0"
+   }
+  },
+  "node_modules/@astrojs/compiler": {
+   "version": "2.13.1",
+   "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+   "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/internal-helpers": {
+   "version": "0.7.6",
+   "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+   "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+   "license": "MIT"
+  },
+  "node_modules/@astrojs/markdown-remark": {
+   "version": "6.3.11",
+   "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+   "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/prism": "3.3.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-text": "^4.0.2",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "mdast-util-definitions": "^6.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-smartypants": "^3.0.2",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "unified": "^11.0.5",
+    "unist-util-remove-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.2",
+    "vfile": "^6.0.3"
+   }
+  },
+  "node_modules/@astrojs/prism": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+   "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+   "license": "MIT",
+   "dependencies": {
+    "prismjs": "^1.30.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/react": {
+   "version": "4.4.2",
+   "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-4.4.2.tgz",
+   "integrity": "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@vitejs/plugin-react": "^4.7.0",
+    "ultrahtml": "^1.6.0",
+    "vite": "^6.4.1"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   },
+   "peerDependencies": {
+    "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+    "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/@astrojs/telemetry": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+   "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "ci-info": "^4.2.0",
+    "debug": "^4.4.0",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "is-docker": "^3.0.0",
+    "is-wsl": "^3.1.0",
+    "which-pm-runs": "^1.1.0"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+   }
+  },
+  "node_modules/@astrojs/underscore-redirects": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+   "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@babel/code-frame": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+   "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "js-tokens": "^4.0.0",
+    "picocolors": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/compat-data": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+   "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/core": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+   "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.7",
+    "@babel/helper-compilation-targets": "^7.29.7",
+    "@babel/helper-module-transforms": "^7.29.7",
+    "@babel/helpers": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/template": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "@jridgewell/remapping": "^2.3.5",
+    "convert-source-map": "^2.0.0",
+    "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.2",
+    "json5": "^2.2.3",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/babel"
+   }
+  },
+  "node_modules/@babel/generator": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+   "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.8",
+    "@babel/types": "^7.29.8",
+    "@jridgewell/gen-mapping": "^0.3.12",
+    "@jridgewell/trace-mapping": "^0.3.28",
+    "jsesc": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-compilation-targets": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+   "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/compat-data": "^7.29.7",
+    "@babel/helper-validator-option": "^7.29.7",
+    "browserslist": "^4.24.0",
+    "lru-cache": "^5.1.1",
+    "semver": "^6.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-globals": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+   "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-imports": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+   "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-module-transforms": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+   "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-module-imports": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7",
+    "@babel/traverse": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0"
+   }
+  },
+  "node_modules/@babel/helper-plugin-utils": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+   "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-string-parser": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+   "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-identifier": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+   "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helper-validator-option": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+   "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/helpers": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+   "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/parser": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+   "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.29.8"
+   },
+   "bin": {
+    "parser": "bin/babel-parser.js"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-self": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+   "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/plugin-transform-react-jsx-source": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+   "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   },
+   "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+   }
+  },
+  "node_modules/@babel/runtime": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+   "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/template": {
+   "version": "7.29.7",
+   "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+   "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/traverse": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+   "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/code-frame": "^7.29.7",
+    "@babel/generator": "^7.29.8",
+    "@babel/helper-globals": "^7.29.7",
+    "@babel/parser": "^7.29.8",
+    "@babel/template": "^7.29.7",
+    "@babel/types": "^7.29.8",
+    "debug": "^4.3.1"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@babel/types": {
+   "version": "7.29.8",
+   "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+   "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/helper-string-parser": "^7.29.7",
+    "@babel/helper-validator-identifier": "^7.29.7"
+   },
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/@capsizecss/unpack": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+   "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@cloudflare/kv-asset-handler": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+   "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/@cloudflare/unenv-preset": {
+   "version": "2.10.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.10.0.tgz",
+   "integrity": "sha512-/uII4vLQXhzCAZzEVeYAjFLBNg2nqTJ1JGzd2lRF6ItYe6U2zVoYGfeKpGx/EkBF6euiU+cyBXgMdtJih+nQ6g==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "peerDependencies": {
+    "unenv": "2.0.0-rc.24",
+    "workerd": "^1.20251221.0"
+   },
+   "peerDependenciesMeta": {
+    "workerd": {
+     "optional": true
     }
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260114.0.tgz",
+   "integrity": "sha512-HNlsRkfNgardCig2P/5bp/dqDECsZ4+NU5XewqArWxMseqt3C5daSuptI620s4pn7Wr0ZKg7jVLH0PDEBkA+aA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-darwin-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-qyE1UdFnAlxzb+uCfN/d9c8icch7XRiH49/DjoqEa+bCDihTuRS7GL1RmhVIqHJhb3pX3DzxmKgQZBDBL83Inw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260114.0.tgz",
+   "integrity": "sha512-Z0BLvAj/JPOabzads2ddDEfgExWTlD22pnwsuNbPwZAGTSZeQa3Y47eGUWyHk+rSGngknk++S7zHTGbKuG7RRg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-linux-arm64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260114.0.tgz",
+   "integrity": "sha512-kPUmEtUxUWlr9PQ64kuhdK0qyo8idPe5IIXUgi7xCD7mDd6EOe5J7ugDpbfvfbYKEjx4DpLvN2t45izyI/Sodw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workerd-windows-64": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260114.0.tgz",
+   "integrity": "sha512-MJnKgm6i1jZGyt2ZHQYCnRlpFTEZcK2rv9y7asS3KdVEXaDgGF8kOns5u6YL6/+eMogfZuHRjfDS+UqRTUYIFA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/@cloudflare/workers-types": {
+   "version": "4.20260702.1",
+   "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+   "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0"
+  },
+  "node_modules/@cspotcode/source-map-support": {
+   "version": "0.8.1",
+   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.9"
+   },
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.9",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.0.3",
+    "@jridgewell/sourcemap-codec": "^1.4.10"
+   }
+  },
+  "node_modules/@emnapi/runtime": {
+   "version": "1.11.3",
+   "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+   "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+   "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+   "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+   "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/android-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+   "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+   "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+   "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+   "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+   "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+   "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+   "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+   "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+   "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+   "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+   "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+   "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/linux-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+   "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+   "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+   "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+   "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+   "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+   "cpu": [
+    "x64"
+   ],
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+   "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+   "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@esbuild/win32-x64": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+   "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@floating-ui/core": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+   "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/dom": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+   "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/core": "^1.8.0",
+    "@floating-ui/utils": "^0.2.12"
+   }
+  },
+  "node_modules/@floating-ui/react-dom": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+   "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/dom": "^1.8.0"
+   },
+   "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+   }
+  },
+  "node_modules/@floating-ui/utils": {
+   "version": "0.2.12",
+   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+   "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@formatjs/ecma402-abstract": {
+   "version": "2.3.6",
+   "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+   "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/intl-localematcher": "0.6.2",
+    "decimal.js": "^10.4.3",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/fast-memoize": {
+   "version": "2.2.7",
+   "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+   "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-messageformat-parser": {
+   "version": "2.11.4",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+   "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/icu-skeleton-parser": "1.8.16",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/icu-skeleton-parser": {
+   "version": "1.8.16",
+   "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+   "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@formatjs/intl-localematcher": {
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+   "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/@gar/promisify": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+   "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@img/colour": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+   "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/@img/sharp-darwin-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+   "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-darwin-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+   "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-darwin-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+   "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-darwin-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+   "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+   "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+   "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-ppc64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+   "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-riscv64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+   "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-s390x": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+   "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linux-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+   "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+   "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+   "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+   "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+   "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-ppc64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+   "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-ppc64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-riscv64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+   "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-riscv64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-s390x": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+   "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-s390x": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linux-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+   "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+   "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-linuxmusl-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+   "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+   }
+  },
+  "node_modules/@img/sharp-wasm32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+   "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+   "cpu": [
+    "wasm32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/runtime": "^1.7.0"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-arm64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+   "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-ia32": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+   "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@img/sharp-win32-x64": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+   "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "Apache-2.0 AND LGPL-3.0-or-later",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   }
+  },
+  "node_modules/@jridgewell/gen-mapping": {
+   "version": "0.3.13",
+   "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+   "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/remapping": {
+   "version": "2.3.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+   "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
+    "@jridgewell/trace-mapping": "^0.3.24"
+   }
+  },
+  "node_modules/@jridgewell/resolve-uri": {
+   "version": "3.1.2",
+   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/@jridgewell/sourcemap-codec": {
+   "version": "1.5.5",
+   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+   "license": "MIT"
+  },
+  "node_modules/@jridgewell/trace-mapping": {
+   "version": "0.3.31",
+   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+   "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.0",
+    "@jridgewell/sourcemap-codec": "^1.4.14"
+   }
+  },
+  "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+   "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": "^22.20 || ^24.12 || >=25"
+   }
+  },
+  "node_modules/@npmcli/fs": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+   "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@gar/promisify": "^1.0.1",
+    "semver": "^7.3.5"
+   }
+  },
+  "node_modules/@npmcli/fs/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@npmcli/move-file": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+   "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+   "deprecated": "This functionality has been moved to @npmcli/fs",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/@oslojs/encoding": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+   "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+   "license": "MIT"
+  },
+  "node_modules/@poppinss/colors": {
+   "version": "4.1.6",
+   "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+   "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^4.1.5"
+   }
+  },
+  "node_modules/@poppinss/colors/node_modules/kleur": {
+   "version": "4.1.5",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+   "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@poppinss/dumper": {
+   "version": "0.6.5",
+   "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+   "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@sindresorhus/is": "^7.0.2",
+    "supports-color": "^10.0.0"
+   }
+  },
+  "node_modules/@poppinss/exception": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+   "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@preact/signals-core": {
+   "version": "1.14.4",
+   "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+   "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@preact/signals-react": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.12.0.tgz",
+   "integrity": "sha512-o3zBSekC/RPcsHOYTLagjw6JX0ih5eMMFZE0AICEeuk7p3MrYOyEXxM7bmT1Uqi0jPy2pbuDQZTFXYe55IAFVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-core": "^1.14.4",
+    "use-sync-external-store": "^1.2.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   },
+   "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
+   }
+  },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+   "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+   "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+   "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+   "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+   "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+   "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+   "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+   "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-effect-event": "0.0.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+   "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+   "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+   "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+   "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-rect": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4",
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.17",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+   "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+   "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+   "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "1.3.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+   "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-is-hydrated": "0.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+   "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-dismissable-layer": "1.1.19",
+    "@radix-ui/react-focus-guards": "1.1.6",
+    "@radix-ui/react-focus-scope": "1.1.16",
+    "@radix-ui/react-id": "1.1.4",
+    "@radix-ui/react-popper": "1.3.7",
+    "@radix-ui/react-portal": "1.1.17",
+    "@radix-ui/react-presence": "1.1.10",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-slot": "1.3.3",
+    "@radix-ui/react-use-callback-ref": "1.1.4",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-visually-hidden": "1.2.11",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.7.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.4.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+   "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/number": "1.1.3",
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-collection": "1.1.15",
+    "@radix-ui/react-compose-refs": "1.1.5",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6",
+    "@radix-ui/react-use-layout-effect": "1.1.4",
+    "@radix-ui/react-use-previous": "1.1.4",
+    "@radix-ui/react-use-size": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+   "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.5"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+   "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.19",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+   "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-context": "1.2.2",
+    "@radix-ui/react-direction": "1.1.4",
+    "@radix-ui/react-primitive": "2.1.10",
+    "@radix-ui/react-roving-focus": "1.1.19",
+    "@radix-ui/react-toggle": "1.1.18",
+    "@radix-ui/react-use-controllable-state": "1.2.6"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+   "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+   "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.7",
+    "@radix-ui/react-use-effect-event": "0.0.5",
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+   "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+   "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+   "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+   "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+   "license": "MIT",
+   "peer": true,
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+   "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/rect": "1.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.4",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+   "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.4"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+   "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+   "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/@rolldown/pluginutils": {
+   "version": "1.0.0-beta.27",
+   "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+   "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@rollup/pluginutils": {
+   "version": "5.4.0",
+   "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+   "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0",
+    "estree-walker": "^2.0.2",
+    "picomatch": "^4.0.2"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   },
+   "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+   },
+   "peerDependenciesMeta": {
+    "rollup": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+   "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+   "license": "MIT"
+  },
+  "node_modules/@rollup/rollup-android-arm-eabi": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+   "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-android-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+   "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+   "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-darwin-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+   "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+   "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-freebsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+   "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+   "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+   "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+   "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-arm64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+   "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+   "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-loong64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+   "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+   "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-ppc64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+   "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+   "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-riscv64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+   "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-s390x-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+   "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-linux-x64-musl": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+   "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ]
+  },
+  "node_modules/@rollup/rollup-openbsd-x64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+   "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ]
+  },
+  "node_modules/@rollup/rollup-openharmony-arm64": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+   "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-arm64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+   "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-ia32-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+   "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-gnu": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+   "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@rollup/rollup-win32-x64-msvc": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+   "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ]
+  },
+  "node_modules/@shikijs/core": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+   "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4",
+    "hast-util-to-html": "^9.0.5"
+   }
+  },
+  "node_modules/@shikijs/engine-javascript": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+   "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "oniguruma-to-es": "^4.3.4"
+   }
+  },
+  "node_modules/@shikijs/engine-oniguruma": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+   "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2"
+   }
+  },
+  "node_modules/@shikijs/langs": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+   "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/themes": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+   "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/types": "3.23.0"
+   }
+  },
+  "node_modules/@shikijs/types": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+   "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/@shikijs/vscode-textmate": {
+   "version": "10.0.2",
+   "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+   "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+   "license": "MIT"
+  },
+  "node_modules/@sindresorhus/is": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+   "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sindresorhus/is?sponsor=1"
+   }
+  },
+  "node_modules/@speed-highlight/core": {
+   "version": "1.2.24",
+   "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+   "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+   "dev": true,
+   "license": "CC0-1.0"
+  },
+  "node_modules/@tailwindcss/node": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+   "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "enhanced-resolve": "^5.24.1",
+    "jiti": "^2.7.0",
+    "lightningcss": "1.32.0",
+    "magic-string": "^0.30.21",
+    "source-map-js": "^1.2.1",
+    "tailwindcss": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+   "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20"
+   },
+   "optionalDependencies": {
+    "@tailwindcss/oxide-android-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+    "@tailwindcss/oxide-darwin-x64": "4.3.3",
+    "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+    "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+    "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+    "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+    "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-android-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+   "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-arm64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+   "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-darwin-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+   "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-freebsd-x64": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+   "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+   "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+   "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+   "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+   "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+   "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+   "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+   "bundleDependencies": [
+    "@napi-rs/wasm-runtime",
+    "@emnapi/core",
+    "@emnapi/runtime",
+    "@tybys/wasm-util",
+    "@emnapi/wasi-threads",
+    "tslib"
+   ],
+   "cpu": [
+    "wasm32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/wasi-threads": "^1.2.2",
+    "@napi-rs/wasm-runtime": "^1.1.4",
+    "@tybys/wasm-util": "^0.10.2",
+    "tslib": "^2.8.1"
+   },
+   "engines": {
+    "node": ">=14.0.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@emnapi/wasi-threads": "1.2.2",
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+   "version": "1.11.1",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+   "version": "1.2.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+   "version": "1.1.4",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "@tybys/wasm-util": "^0.10.1"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/Brooooooklyn"
+   },
+   "peerDependencies": {
+    "@emnapi/core": "^1.7.1",
+    "@emnapi/runtime": "^1.7.1"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+   "version": "0.10.2",
+   "inBundle": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "tslib": "^2.4.0"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+   "version": "2.8.1",
+   "inBundle": true,
+   "license": "0BSD",
+   "optional": true
+  },
+  "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+   "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+   "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 20"
+   }
+  },
+  "node_modules/@tailwindcss/vite": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+   "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+   "license": "MIT",
+   "dependencies": {
+    "@tailwindcss/node": "4.3.3",
+    "@tailwindcss/oxide": "4.3.3",
+    "tailwindcss": "4.3.3"
+   },
+   "peerDependencies": {
+    "vite": "^5.2.0 || ^6 || ^7 || ^8"
+   }
+  },
+  "node_modules/@tootallnate/once": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+   "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/@types/babel__core": {
+   "version": "7.20.5",
+   "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+   "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.20.7",
+    "@babel/types": "^7.20.7",
+    "@types/babel__generator": "*",
+    "@types/babel__template": "*",
+    "@types/babel__traverse": "*"
+   }
+  },
+  "node_modules/@types/babel__generator": {
+   "version": "7.27.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+   "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__template": {
+   "version": "7.4.4",
+   "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+   "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0"
+   }
+  },
+  "node_modules/@types/babel__traverse": {
+   "version": "7.28.0",
+   "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+   "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/types": "^7.28.2"
+   }
+  },
+  "node_modules/@types/debug": {
+   "version": "4.1.13",
+   "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+   "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/ms": "*"
+   }
+  },
+  "node_modules/@types/estree": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+   "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+   "license": "MIT"
+  },
+  "node_modules/@types/hast": {
+   "version": "3.0.5",
+   "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+   "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/mdast": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+   "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/ms": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+   "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+   "license": "MIT"
+  },
+  "node_modules/@types/nlcst": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+   "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "*"
+   }
+  },
+  "node_modules/@types/prop-types": {
+   "version": "15.7.15",
+   "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+   "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/react": {
+   "version": "18.3.31",
+   "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+   "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+   "devOptional": true,
+   "license": "MIT",
+   "dependencies": {
+    "@types/prop-types": "*",
+    "csstype": "^3.2.2"
+   }
+  },
+  "node_modules/@types/react-dom": {
+   "version": "18.3.7",
+   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+   "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+   "devOptional": true,
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "^18.0.0"
+   }
+  },
+  "node_modules/@types/unist": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+   "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+   "license": "MIT"
+  },
+  "node_modules/@ungap/structured-clone": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+   "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+   "license": "ISC"
+  },
+  "node_modules/@vitejs/plugin-react": {
+   "version": "4.7.0",
+   "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+   "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@rolldown/pluginutils": "1.0.0-beta.27",
+    "@types/babel__core": "^7.20.5",
+    "react-refresh": "^0.17.0"
+   },
+   "engines": {
+    "node": "^14.18.0 || >=16.0.0"
+   },
+   "peerDependencies": {
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+   }
+  },
+  "node_modules/@wix/agent-skills": {
+   "version": "1.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/agent-skills/-/agent-skills-1.17.0.tgz",
+   "integrity": "sha512-q15Rh7ugmXBqFk5kc/3dirXiT7cX0Adbrcmjc+H0/Z7EKfvj7d+CaFsTidbvhNlXJoIGviR06AeYQxGK/PPEjg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@wix/analytics": {
+   "version": "1.19.0",
+   "resolved": "https://registry.npmjs.org/@wix/analytics/-/analytics-1.19.0.tgz",
+   "integrity": "sha512-WlF1fNoXMOcHzu2ORLosmTytnOEQGvwVvF0TjmUiscxnLOin0HQVZOvonggj+J2sS1/uyhyNaKxzhsROoIF1AQ==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/app-extensions": {
+   "version": "1.0.133",
+   "resolved": "https://registry.npmjs.org/@wix/app-extensions/-/app-extensions-1.0.133.tgz",
+   "integrity": "sha512-ZOxd0Rp5ZsTdrPaTWNKCAdY2wTkdvqoHCpEE+JgIrppSdzceh1uK87OlD0/uIG9xKgJbpuZnxAR9I90ITVcUrw=="
+  },
+  "node_modules/@wix/app-management": {
+   "version": "1.0.158",
+   "resolved": "https://registry.npmjs.org/@wix/app-management/-/app-management-1.0.158.tgz",
+   "integrity": "sha512-yREM/RXfD6HEF+dWagB5XDcQpbJYE7kClANK58FDvZa3MpPi0yRUBL3jRALpUUZyzKWQo44M2tBj/kZKLp5uDQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_app-management_app-instances": "1.0.48",
+    "@wix/auto_sdk_app-management_app-permissions": "1.0.46",
+    "@wix/auto_sdk_app-management_app-plans": "1.0.37",
+    "@wix/auto_sdk_app-management_bi-events": "1.0.37",
+    "@wix/auto_sdk_app-management_billing": "1.0.45",
+    "@wix/auto_sdk_app-management_custom-charges": "1.0.35",
+    "@wix/auto_sdk_app-management_embedded-scripts": "1.0.35",
+    "@wix/auto_sdk_app-management_external-billing": "1.0.32"
+   }
+  },
+  "node_modules/@wix/astro": {
+   "version": "2.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro/-/astro-2.68.0.tgz",
+   "integrity": "sha512-iCOLHbUTWyv4S0ioDuamYsdFzV8eQXND4lzgBHojbiGIwSWrU5iuGwXNk5+Kv9iOO82OFFDHZSdz0ZE8iRfLSg==",
+   "dependencies": {
+    "@wix/app-management": "^1.0.149",
+    "@wix/auth-management": "^1.0.71",
+    "@wix/dashboard": "^1.3.43",
+    "@wix/editor": "^1.772.0",
+    "@wix/essentials": "^1.0.14",
+    "@wix/headless-localization-utils": "^1.0.13",
+    "@wix/headless-node": "^1.43.0",
+    "@wix/headless-site": "^1.31.0",
+    "@wix/headless-site-assets": "^1.0.13",
+    "@wix/multilingual-manager": "^1.5.0",
+    "@wix/react-component-schema": "^1.4.0",
+    "@wix/sdk": "^1.21.3",
+    "@wix/sdk-runtime": "^1.0.0",
+    "@wix/sdk-types": "^1.17.1",
+    "@wix/site": "^1.66.0"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+   }
+  },
+  "node_modules/@wix/astro-pages": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/astro-pages/-/astro-pages-2.0.4.tgz",
+   "integrity": "sha512-LsvdBfbjWMUnVNp8Qk1Pjmbzc6dSVsKMV+nTkI4fiNR2STQ52RFi3iL8BN6lYrpGvGql6F5zhJWWr5/CZ7DSEA==",
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/astro-wix-hosting-adapter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/astro-wix-hosting-adapter/-/astro-wix-hosting-adapter-2.0.0.tgz",
+   "integrity": "sha512-Jvo5mBapWiKJHrLm5fZJDcOirdO8LaprQlP40FC03bUujValiCmKRmlQtrulpa3CsGbHSaabRPfMow2tTgp4Mw==",
+   "dev": true,
+   "dependencies": {
+    "@astrojs/cloudflare": "^12.6.10"
+   },
+   "peerDependencies": {
+    "astro": "^5.0.0"
+   }
+  },
+  "node_modules/@wix/auth-management": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auth-management/-/auth-management-1.0.91.tgz",
+   "integrity": "sha512-FyuDxFs5Ber4FK0d8cN3H0PaRQseMmb28SH8z1hEXB2QdAsJ9MPMDJpE5Hzxd+yXcoVCjF099iM2Bkol5UloPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_auth-management_o-auth-apps": "1.0.53"
+   }
+  },
+  "node_modules/@wix/authentication": {
+   "version": "1.16.0",
+   "resolved": "https://registry.npmjs.org/@wix/authentication/-/authentication-1.16.0.tgz",
+   "integrity": "sha512-P4z9Nzgp+gmIEtfs58LgPBzychMoKZwCawPRQ41/NGBALvCi/pxngRP7TLeyo91Rvq1o0ZjISKAwUv8lx/Wxjw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.15",
+    "@wix/sdk-types": "^1.17.9"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-instances": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-instances/-/auto_sdk_app-management_app-instances-1.0.48.tgz",
+   "integrity": "sha512-dYOdTh0iozexsiTsRmD5F3+YHmuFI3GgRnYS1ut1SBlJXBazQSZ65uKTqyYJpS2bk4LmNFfUaHSFX2hD7gHqNQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-permissions": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-permissions/-/auto_sdk_app-management_app-permissions-1.0.46.tgz",
+   "integrity": "sha512-tb/+tI6F9gJPnh+Bcp8Fc7GCQvf1JD+T3SYILgvOSB9r6aJtTsBNbxf0QtC/Geo/fmPd3L4snk3Q65Gu4dCZ0g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_app-plans": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_app-plans/-/auto_sdk_app-management_app-plans-1.0.37.tgz",
+   "integrity": "sha512-qCXTpownkSlHQFKltWtPwX/oqFFaplWB7wxMjVtbyRfGKHGuIgGdc+qB9tqrlUfigTSOPRd8qsQ8JTpb2Jq74Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_bi-events": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_bi-events/-/auto_sdk_app-management_bi-events-1.0.37.tgz",
+   "integrity": "sha512-NMDiYJnc+rC9igs+c3tAIkO8VXLfUTu/jL0PyL55Ntg2NLYAKK/FFxCABLh0kXOOoukfbNycHbZaa0SNG9JqKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_billing": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_billing/-/auto_sdk_app-management_billing-1.0.45.tgz",
+   "integrity": "sha512-H2zVRJMwMFXbOh2AlZuHQADjw+80onvjmQpxF4o36a0CNpNxWbgvevZvotaynzEJkWOk0ht8oDDXRFJ8OqZTYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_custom-charges": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_custom-charges/-/auto_sdk_app-management_custom-charges-1.0.35.tgz",
+   "integrity": "sha512-wmrYbGvrbmrcK099SpwXc1nvVmZTVndzjlEj7BIao9+YL24Lpcoto+AcVjZEDOyn/7/ATkfTQ57JYyERr6ZHZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_embedded-scripts": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_embedded-scripts/-/auto_sdk_app-management_embedded-scripts-1.0.35.tgz",
+   "integrity": "sha512-9TpWy7fl9FbPucDo36U9flkPUCagpk9zNgwjdEcj/7K3HSqQsxPC2iP4k6LhqeYvgRJNK/8xQpmoWQNdhvJB0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_app-management_external-billing": {
+   "version": "1.0.32",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_app-management_external-billing/-/auto_sdk_app-management_external-billing-1.0.32.tgz",
+   "integrity": "sha512-iyx6zFsBtf4lWrsCgX/9yqdIKHP2KFfOlV9TBQM5oPzqVOt6km0otsLQGnvyMHNREw0A8j9Pl9JCKTvi/QvFkg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_auth-management_o-auth-apps": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_auth-management_o-auth-apps/-/auto_sdk_auth-management_o-auth-apps-1.0.53.tgz",
+   "integrity": "sha512-2tOE3GoOzHmUpKEJmBac/OziHhJOxIL5bSSt38c1FuGy3qlfiRkqQ3KbpIiXw8BH0LGw0N91XkUpxjlvMfdBow==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_bookings_availability-calendar": {
+   "version": "1.0.196",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_bookings_availability-calendar/-/auto_sdk_bookings_availability-calendar-1.0.196.tgz",
+   "integrity": "sha512-EXtTMMkqJhj0hOdAykz719KXTLnzwTURl/P+uJrKHyZoE8j9ovzJKv20ATr5IbOWHA3tje9oTLivqMMqxqU99w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_categories_categories": {
+   "version": "1.0.142",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_categories_categories/-/auto_sdk_categories_categories-1.0.142.tgz",
+   "integrity": "sha512-QQvhbwt1Ms9ZDBt21fv+IimfDiUPHRAOafpRXb/Z08M/V6uz6mL1FOZ/qcfK5RKaeaMfRs/fa2eUEvV95z7mHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_abandoned-checkouts": {
+   "version": "1.0.83",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_abandoned-checkouts/-/auto_sdk_ecom_abandoned-checkouts-1.0.83.tgz",
+   "integrity": "sha512-k7mo7MuxcFgwyq6aUrBEaVjsDOkSceXb0jDSKYRFMsysivlQ3H5Io+ZOvFJ2NlBJT4Kq3OStXj4hyvIEFuJNzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_additional-fees": {
+   "version": "1.0.49",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_additional-fees/-/auto_sdk_ecom_additional-fees-1.0.49.tgz",
+   "integrity": "sha512-ouF6gC/hZQXIiQM3HN/88Svf/TUEmHpDRyEGCSGNiG+DDb7WMQ5lgo+elnrZ5xsrK8nh3ir9wCcZf4Et511wuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_back-in-stock-notifications": {
+   "version": "1.0.63",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-notifications/-/auto_sdk_ecom_back-in-stock-notifications-1.0.63.tgz",
+   "integrity": "sha512-9enqO6pwJU114uhnaa4v0f2qj8VWYexYHUutP86qxmadNVi0ekEQUrif5VonByPRgIgGTFlGwIPP5BD4L0BeoA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_back-in-stock-settings": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_back-in-stock-settings/-/auto_sdk_ecom_back-in-stock-settings-1.0.42.tgz",
+   "integrity": "sha512-YKRGIjbKqhtXnfSrGjqPSwqLDCjt2Se9q11ro0vI+9zoyyfWmsRIR4oYt1quZ/m7w8Qz79auLt1z80WRFJehOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_cart": {
+   "version": "1.0.174",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart/-/auto_sdk_ecom_cart-1.0.174.tgz",
+   "integrity": "sha512-bng9lfcWQ0XJ1Nr0SKe2v7yen9SprlZRHRuQ+iXe27VJWjmFhGcUGj7xqCtbLj9zTQ91DBU916eYIo9YBM5WRw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_cart-v-2": {
+   "version": "1.0.192",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_cart-v-2/-/auto_sdk_ecom_cart-v-2-1.0.192.tgz",
+   "integrity": "sha512-QOLUV+vEFBwAh86208NIZngr4SpU+k8m8XebxgQGZRGdKN1ahr2sY/a59jO/rOhD/BY1kDUqJwfxJD75DWYcLA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_catalog": {
+   "version": "1.0.64",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_catalog/-/auto_sdk_ecom_catalog-1.0.64.tgz",
+   "integrity": "sha512-fKmFDucjlRKPCiLiTseBSTVGTQQyvn6Hap9gLzkF/+IFsKCg515Z+pSs2ds8os8D3V4DZCUkOfYJenzleJw01Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout": {
+   "version": "1.0.168",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout/-/auto_sdk_ecom_checkout-1.0.168.tgz",
+   "integrity": "sha512-LPZtbYSs45czMTir9CYeUZpiwLLUL/SG0To8sDCo18FzoQheXUMpGhcpGI9X57Q5hbUk3VBAhsjcyONCV4FtHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-content": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-content/-/auto_sdk_ecom_checkout-content-1.0.37.tgz",
+   "integrity": "sha512-RrG3rzJBFGTCQR1hG9RX9/p9z07dfqNHjDtZs9DZUbHlsgqZlo8mJ6H28Th2tUlc7LaFBJ90l+3/qlJwSCzL/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-settings": {
+   "version": "1.0.73",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-settings/-/auto_sdk_ecom_checkout-settings-1.0.73.tgz",
+   "integrity": "sha512-2j8Z3dbhox4Hs0n0VmUUcEyreOX02OYkPyRk9MTGI51L6i4Bd5rWWxaqn74boDURcgQjF9JTxAlXXQvfvDC0eA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_checkout-templates": {
+   "version": "1.0.150",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_checkout-templates/-/auto_sdk_ecom_checkout-templates-1.0.150.tgz",
+   "integrity": "sha512-jomZhO1xhmmHX/FYaijYI8+g8b05rSn+X2bGIpVFGsjynZCj0lXyxcMKJxANk+t6D11pxf4oIoF8o45EpzkVBg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_contact-tax-details": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_contact-tax-details/-/auto_sdk_ecom_contact-tax-details-1.0.3.tgz",
+   "integrity": "sha512-kx7Q+0QWzc0TCqPINuhLjXuFacrkxl1Vc3hmF/ZtqiTpHZ4xoegAaHOhiQ20l7mNXbgAWajn1bVVNS/ZNHxD1g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_currencies": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_currencies/-/auto_sdk_ecom_currencies-1.0.35.tgz",
+   "integrity": "sha512-gfCYsiJ4zsDbm9PGxhi/paZEW8lJZdUnIEAPneRU9lfvGK+6QbM5TRJd74Fwcgsp8K82O15DPfzlZ0tH9Y02kQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart": {
+   "version": "1.0.184",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart/-/auto_sdk_ecom_current-cart-1.0.184.tgz",
+   "integrity": "sha512-S8Jwd21+yyEhvZko68FYTXPiWeXGDO0R3L5e90WDkbkvTfVyleaRJzqcIHWFyBnY+cmNH+30DygVdWyCRc3dIg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_current-cart-v-2": {
+   "version": "1.0.193",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_current-cart-v-2/-/auto_sdk_ecom_current-cart-v-2-1.0.193.tgz",
+   "integrity": "sha512-H9v8Jsmm+TXPSZ/WlQD9Gz/lLJIKzZIQHW/FOB/VfOBC20yufghAhZl9g05YgBWoBydtmNePS/wOQGzVwJ1nVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_custom-triggers": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_custom-triggers/-/auto_sdk_ecom_custom-triggers-1.0.40.tgz",
+   "integrity": "sha512-4pbt7WOMuMSQIEre/Do0LmcF3RdSVvE6Z3538pTg9jCvg6R+uBb/mycBNu/Za3iJNrcsYmv62Zq6p8y+BuHdbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_delivery-profile": {
+   "version": "1.0.440",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-profile/-/auto_sdk_ecom_delivery-profile-1.0.440.tgz",
+   "integrity": "sha512-KZA+tN85AR65oUvmsVr0WTOBLkwYq18piO+8QE5ug5XxLSLLnwC7WUBqGDbm5N6GWxW1L2cJu8eIIqBzPxPY+A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_delivery-solutions": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_delivery-solutions/-/auto_sdk_ecom_delivery-solutions-1.0.62.tgz",
+   "integrity": "sha512-YuLWOYsSSrfhZ/RpKa/67Qel8O9Ft1Qz8VebclOuAB1JrAV25zsMVh3Ks8yJeBPdOfawlcL4ECGbMi4t6v9b4A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discount-rules": {
+   "version": "1.0.115",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discount-rules/-/auto_sdk_ecom_discount-rules-1.0.115.tgz",
+   "integrity": "sha512-K0TMVir6a7o5pSvetPebJELwuVrhMiPwhyC6dtnTmdHNYwmMVpGZlkloJowNcra9kCiPm1iGKRSrvSu4SxtjmQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discounts": {
+   "version": "1.0.34",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts/-/auto_sdk_ecom_discounts-1.0.34.tgz",
+   "integrity": "sha512-UBSaqNnZrivhDAhrDYmGceibwe0sYCd+RQEbAOPn/8ZlXKnS9R6VCVjxvmgMqrnQ9Cpyht8WGS/df61g2ID8Sg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_discounts-custom-trigger": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_discounts-custom-trigger/-/auto_sdk_ecom_discounts-custom-trigger-1.0.45.tgz",
+   "integrity": "sha512-ykH8JVbiXukiHCtikksv5NjrjLec+8I9M6kf8RrwGekgD1NXX73hvij4XV8tJp8Pxm14OTPocGmTl/vPA00/gA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_draft-orders": {
+   "version": "1.0.171",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-orders/-/auto_sdk_ecom_draft-orders-1.0.171.tgz",
+   "integrity": "sha512-DZkSx3spJDmXsDxf0EhQg30EjNJoEuaixlJGPcXJn43mQTtFeb0pI4s3hlikS1ZsXsJPdyefhYcPn6d8/jq9Eg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_draft-subscription-contracts": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_draft-subscription-contracts/-/auto_sdk_ecom_draft-subscription-contracts-1.0.7.tgz",
+   "integrity": "sha512-IqP/MoK8T0YlDvcmrH9OkZrvaUMKnPyky1/+aXZ4qM4IQH1AiVi6S34vU/BwOlwMC37EMaJWVnaZ82j986xS/Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_ecommerce-settings": {
+   "version": "1.0.33",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_ecommerce-settings/-/auto_sdk_ecom_ecommerce-settings-1.0.33.tgz",
+   "integrity": "sha512-2Wy6YrZV488ENvXmy9lIUYW65qSJ7KkgLYVZeH211EESGXqpKYHjSeMafopBpN+ycz3huzwYtyhoTqVQ577uwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_gift-vouchers": {
+   "version": "1.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers/-/auto_sdk_ecom_gift-vouchers-1.0.45.tgz",
+   "integrity": "sha512-z+n1zAZ/EHFP1fKjRNXNDNbUsx/G/sy5KFJES2+l/Ipzgsu/m/9smBzjtJlKndf0MMCxeSQk6sU2pa92pEt0fQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_gift-vouchers-provider": {
+   "version": "1.0.35",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_gift-vouchers-provider/-/auto_sdk_ecom_gift-vouchers-provider-1.0.35.tgz",
+   "integrity": "sha512-57/A3DK88Awz8fgmfkEc51tPEsCfJgzkQCYrCUsgaHPyJZ2froVF+UfDvBDPqlFCJhbmI4ZAtYWhXUXzsxezfg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_inventory": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_inventory/-/auto_sdk_ecom_inventory-1.0.24.tgz",
+   "integrity": "sha512-gvhjYT5NtAcsfSuvth7Y3JNsKajAPJswdot7Vtvojx+tOAQLgdCtvBdS+CY27Ms1HRcVUjqGSUg1czu4IKaZUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_local-delivery-options": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_local-delivery-options/-/auto_sdk_ecom_local-delivery-options-1.0.53.tgz",
+   "integrity": "sha512-9Bw2w1MNgMaQNNmNNegDWn4YHuycjJMzBH3CObEZuSrpGk0pBz/oHJyUAGFLcfrNu3QHSMfqqHUk78T1wXi7bg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_manual-tax-mappings": {
+   "version": "1.0.43",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_manual-tax-mappings/-/auto_sdk_ecom_manual-tax-mappings-1.0.43.tgz",
+   "integrity": "sha512-5lOIYwVHFoiHMTumdGO/Hz8EBMUUHaolJ2cBhopfQE4KM0g4iWQad8tmQxNAo229azQB3LySnFm3O0dQSA/fSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_memberships": {
+   "version": "1.0.66",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_memberships/-/auto_sdk_ecom_memberships-1.0.66.tgz",
+   "integrity": "sha512-oSjsAhJOk/a7v5+Pfd3AYLx43sdU6knnc8kiGRuZdeZg4Mu1mhqLXsmhfdLo/dvILqbgf/bEkLwLQ6Gg/yxmOQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-billing": {
+   "version": "1.0.104",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-billing/-/auto_sdk_ecom_order-billing-1.0.104.tgz",
+   "integrity": "sha512-mhC2hVZb65oPwc0/y4gthsSgnWqiaanNrog9qAFj7NxS9Gz3QC1hw0GbXzog814paZlB/QETm5jKu1FxzXweMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-fulfillments": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-fulfillments/-/auto_sdk_ecom_order-fulfillments-1.0.62.tgz",
+   "integrity": "sha512-Rsjbrq6aeXlQXQD42HH4es5a+1R9hePBca0I3sb+/XsPnszB+GvaCyUwsX8a/UpimHciqN+aQ07p1yMKN8M+rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-invoices": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-invoices/-/auto_sdk_ecom_order-invoices-1.0.52.tgz",
+   "integrity": "sha512-htA5vi/lACC20BF4dfnxZ8GaY9viaemZi4oQQqf8FOIHuItlMzoscwF21viybu/XKzghXfZqi/vX+jJBWXdTZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-payment-requests": {
+   "version": "1.0.67",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-payment-requests/-/auto_sdk_ecom_order-payment-requests-1.0.67.tgz",
+   "integrity": "sha512-zqVQlZztMspEG2TguG+hmw8yFVqsipjdyxudraOwxqTcpHTA71ay+35EDHRGsH36WvORHNGM1DHj8D6PyojKJQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_order-transactions": {
+   "version": "1.0.104",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_order-transactions/-/auto_sdk_ecom_order-transactions-1.0.104.tgz",
+   "integrity": "sha512-vZwoWGPWgG273L4omJLBTItvqBWiqCqUQgPOpIKaU6PnbA5R8xib5VdjQ853zqjnAZFlrkPztWNLiFn7AnqlXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_orders": {
+   "version": "1.0.286",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders/-/auto_sdk_ecom_orders-1.0.286.tgz",
+   "integrity": "sha512-YJVe5RjcF+heHig9Bai64O/SbhaRVeO5qc6K2trN8dQDD7RMJiZndRNgDzo0+sGxggDsnd3jLpH4a0AZcVmkgg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_orders-settings": {
+   "version": "1.0.55",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_orders-settings/-/auto_sdk_ecom_orders-settings-1.0.55.tgz",
+   "integrity": "sha512-RY+rDh307GkVr8aEnHri+N3EgW0wzKc4gKRJw2/RcjAGDX8QY9JDb7C8ep2vhgm/FcMXA3csxddV/TyPeZ0LGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_payment-settings": {
+   "version": "1.0.143",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_payment-settings/-/auto_sdk_ecom_payment-settings-1.0.143.tgz",
+   "integrity": "sha512-9LOI5E1p5aZZ5sC2k4q6T+uZ4Ylp2bYuVeOdj/4quXfT45OqPotAH+66ET5vhzPhaRSY3VfuAC5EnwHrdDH0PA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_pickup-locations": {
+   "version": "1.0.52",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_pickup-locations/-/auto_sdk_ecom_pickup-locations-1.0.52.tgz",
+   "integrity": "sha512-E4+UEDHHNU4jV7KsyoJR++tTw9cqcROOBltG8CNJCAhQCnDbqxK3gfOdK9gYvgPrAWNoJ1Jzq2bCmTaK7Ru/QA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_recommendations": {
+   "version": "1.0.47",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations/-/auto_sdk_ecom_recommendations-1.0.47.tgz",
+   "integrity": "sha512-kIX4fnm/IYDMdV7BJMK8eUx05lP0hm/0v8PvviCKlhG/0LtLQ9SrusRZn8pZOEyG2Lp+7RAYkS3F/t4SRBAdTg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_recommendations-provider": {
+   "version": "1.0.33",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_recommendations-provider/-/auto_sdk_ecom_recommendations-provider-1.0.33.tgz",
+   "integrity": "sha512-x00UHSPpdXDt/bKwRx9fhspPKbOWH74cHuzSJRj7+7rp5hAAySBepNvbY+V4YKtq1W2wZ3au+b0fSBQ2BDdOPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shipping-options": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-options/-/auto_sdk_ecom_shipping-options-1.0.230.tgz",
+   "integrity": "sha512-PqlZiJqSKHde7yZbom0KhndP6Pe+UsdzUx0C2EH2XBszXSv1FKymBNVEw2+PaI0JxDfZ2E4WpWWaGHuIm9E2dA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shipping-rates": {
+   "version": "1.0.39",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shipping-rates/-/auto_sdk_ecom_shipping-rates-1.0.39.tgz",
+   "integrity": "sha512-WzM3aB28G/XeaBjaXWYAAEXP5niKQprw2Cchpd4jHOPC1atWy91lox8Vvi080WZQUdOWuw9eUfGpci9D+/jTLw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_shippo-configurations": {
+   "version": "1.0.71",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_shippo-configurations/-/auto_sdk_ecom_shippo-configurations-1.0.71.tgz",
+   "integrity": "sha512-h7kJJpsPYQTMQKelbeECsEDLZM6VLEb37FBE//Nmiap1ff+PUcFFZ0DsHuXktsWkoa3oQp4JBuCWbqojvy6dOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_subscription-contracts": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_subscription-contracts/-/auto_sdk_ecom_subscription-contracts-1.0.125.tgz",
+   "integrity": "sha512-elR3LIlzu/dM1eBBc8Jbklni/lD3QL4eeEuHp470g4QF9TXq/a1e4cJ9qzqC1EUm8L+y5VsWZXI1G8Q8rwuI3w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-calculation": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation/-/auto_sdk_ecom_tax-calculation-1.0.54.tgz",
+   "integrity": "sha512-wkXEshZoXgBm8LtxX/38iJ9tdnzRTpBKtY0PpvMmhp/AHt4z8nFSKPhLJHo35U3XJSLxBnt7meiVWnZY+0v9Fw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-calculation-provider": {
+   "version": "1.0.31",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-calculation-provider/-/auto_sdk_ecom_tax-calculation-provider-1.0.31.tgz",
+   "integrity": "sha512-X8WgM60a+qMqKOHwH3kdvJMEB+mCnrnFRZbVSLjigAqwL5YcVYBltAovI8viR05LLQd6s0MOqntjew/pDPzZeQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-exempt-groups": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-exempt-groups/-/auto_sdk_ecom_tax-exempt-groups-1.0.4.tgz",
+   "integrity": "sha512-yk7U1z5enPiVxeNVFH05lr7UtCM5xn0IAXDW7pswkknrdAOk0axrjc279CY5jTHaZTmEgqyEv0/39ZZTycDCkA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-groups": {
+   "version": "1.0.64",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-groups/-/auto_sdk_ecom_tax-groups-1.0.64.tgz",
+   "integrity": "sha512-df8Zise8uEfHFgj7tDvTTcT7DRn+771j6eI4tWqL6fPIQGPN0rURY7kGQehBi3jnDHLOohI5ksg7hlKKsjCQzw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-regions": {
+   "version": "1.0.61",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-regions/-/auto_sdk_ecom_tax-regions-1.0.61.tgz",
+   "integrity": "sha512-o2Gmc89SlO5pQuOngj+l8y+vm7HQJ0qxuEJzqdJwx0siRIwRqb8hkmT0+HXn+zM1e0Ntc9kMxHHabYf2OtqCmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tax-settings": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tax-settings/-/auto_sdk_ecom_tax-settings-1.0.2.tgz",
+   "integrity": "sha512-8+566igMSdW6dOK9RHRmoatin7w6U+H10ren7YqlNixf3qJBazSyv2CdMwFvf1MFSFSY319u3VgkW64OPWrQKg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tip-settings": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tip-settings/-/auto_sdk_ecom_tip-settings-1.0.54.tgz",
+   "integrity": "sha512-4N1l/X0KTIXOzkbCVO/oYuDnApCpz/MToDg0IEbfjeEnm1SX/gk1DkXnSjuGv6ttOEusekyL1WdOXwL5qKvQmw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tippable-staff": {
+   "version": "1.0.40",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tippable-staff/-/auto_sdk_ecom_tippable-staff-1.0.40.tgz",
+   "integrity": "sha512-FvIEtLdx3qbMSvQcr5czVDjzP7BvV9c69FquHuvrBOVotq6xjEiqs9+durHHHcqNpWgs/DjVIeT+GZ2rwWrozw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_tips": {
+   "version": "1.0.62",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_tips/-/auto_sdk_ecom_tips-1.0.62.tgz",
+   "integrity": "sha512-zPUDIRSXEdghPH7G049nzNsyB+5JYeiOLtwUelQasibHwln1sb/rG7R5xP9ifIVuy6u7kzwN7Oisuk8NDrNyCg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_totals-calculator": {
+   "version": "1.0.115",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_totals-calculator/-/auto_sdk_ecom_totals-calculator-1.0.115.tgz",
+   "integrity": "sha512-N1rp4LtZSfTooN3J/3OmfMpcbrWIIHkskSm7NYo74TmnJFLpE5sAUyAMGbCwamZjYFXKVWdCJnWMjn8PgQq3Pg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_validations": {
+   "version": "1.0.56",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_validations/-/auto_sdk_ecom_validations-1.0.56.tgz",
+   "integrity": "sha512-UUbTbVI5qTYkJYg+DBtJN2dAGJqYuZ1FyFlTEI5sgqxRHeFlalKxWppAGG0stlk5E2Tweb52/OLb3UvMQ7zLVg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_ecom_wishlists": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_ecom_wishlists/-/auto_sdk_ecom_wishlists-1.0.2.tgz",
+   "integrity": "sha512-W1VkbP9U40aHpk1eu27Z9PoFFgWO1FuTUhpm346jlHBK//9kL8Zktwbag9P6Taxp3/CeILsqsriAvJtb1LkE9Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_headless-site-assets_scripts": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_headless-site-assets_scripts/-/auto_sdk_headless-site-assets_scripts-1.0.13.tgz",
+   "integrity": "sha512-4ISEZzeYsi0TAX9Te6zZWcsKM+if0LjcTG8dHXO766t3yE1Elo+8jHP+IrUU/tl5I2hNsG1ri8E5uRdojpXH/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_authentication": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_authentication/-/auto_sdk_identity_authentication-1.0.57.tgz",
+   "integrity": "sha512-34i1pQYO+jAs9cjNkK4qA4AAGo/ap/Q0RrUlwErNRBKFiRdlx7LNrR8YHF9ZNvhJ4xy4Ix4ywsq+Yfl9AK9rHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_oauth": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_oauth/-/auto_sdk_identity_oauth-1.0.53.tgz",
+   "integrity": "sha512-OleN6D0WU8ZCwuCMjgaRVHmjZUSf0F0OIi3ezjI/xSpAu9rcAASWsq6DeQ5wY4fJe+0XEwU8XH9REDdGTdNZjA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_recovery": {
+   "version": "1.0.46",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_recovery/-/auto_sdk_identity_recovery-1.0.46.tgz",
+   "integrity": "sha512-59YLuj1qEZC6XMM44gsUFXKToWwUnqUDADhS1F3EE729obJGVavobJloCuFxX/J/3RJ7dix4I1/H6wq49+u0SA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_sign-on-policy": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_sign-on-policy/-/auto_sdk_identity_sign-on-policy-1.0.1.tgz",
+   "integrity": "sha512-zaKMWvgrNISS6bNnOCvlfqepnp6JtDG6Ggnd+QgyLAEAQw63hQDjtyKtMT5ptihOt7EBW9FkMQAFnb4gDrlnPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_identity_verification": {
+   "version": "1.0.48",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_identity_verification/-/auto_sdk_identity_verification-1.0.48.tgz",
+   "integrity": "sha512-HWhPvgZHaw8FHAB6Whr55NrS3elB6NADI6GjRjCANMDXIxErcRbLQvY4EwKgB5C9AEFRrG5ERXnfd50Ztg/u+g==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-categories": {
+   "version": "1.0.37",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-categories/-/auto_sdk_media_enterprise-media-categories-1.0.37.tgz",
+   "integrity": "sha512-H2Epij/OL5tRIr2wa+gG/efZYKTXIEzmKhY2Fk/CJdZtOSiMRO1vAPSnDXX60wLn6bFGcooLumeTfnOat2gZ8w==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_enterprise-media-items": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_enterprise-media-items/-/auto_sdk_media_enterprise-media-items-1.0.38.tgz",
+   "integrity": "sha512-QnU7i1VtXwbn9D6zsNOrTXbXNybKZY6ymid+VQ75s1vknHlFfcEt+BhvVwp/yFah/fPLnQJ+zy16n0Wtge57IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_files": {
+   "version": "1.0.96",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_files/-/auto_sdk_media_files-1.0.96.tgz",
+   "integrity": "sha512-KrPyTF319c/EKKbVA+89xPXhQ1MBl5ShR41OPmiFhRyhbILWe7dRIn/5dgBhopsKj5mBw50SuA5bXeHrntv8Yw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_media_folders": {
+   "version": "1.0.57",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_media_folders/-/auto_sdk_media_folders-1.0.57.tgz",
+   "integrity": "sha512-0D5L5hLvC3uCZuyN+0zjntbdi/6cHJFNidOn5YKOJi6Ql9NI+PQkYjRIGNebJNPETZtNAPAUgCN/WLm+fjJbew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_redirects_redirects": {
+   "version": "1.0.53",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_redirects_redirects/-/auto_sdk_redirects_redirects-1.0.53.tgz",
+   "integrity": "sha512-qznx4OUgasP7MZ/YPhcNQPVg40FhGHIAXMsCo0cK18yefTLgLH6tKpJn9NlD0MonVsJi6HEcW4NUogN4clRBxA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_item-seo-tags": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_item-seo-tags/-/auto_sdk_seo_item-seo-tags-1.0.12.tgz",
+   "integrity": "sha512-MCYZCzRFcO3Ru8DO1uX7ghovKY6t1MLBstllXx1fGpcZNu+0lKAo+9EUnYUE5cn4ObyccQt7SHf8+U70qsciUg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_llms-txt": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_llms-txt/-/auto_sdk_seo_llms-txt-1.0.0.tgz",
+   "integrity": "sha512-yFfD0GJIY2GB9/V4ky9kXSj8bypy13URXanmvFi5fg5LxbwvCmz5asRaaLzVIfZSL7zOuHAXz74gdHTjaGHohA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_redirects": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_redirects/-/auto_sdk_seo_redirects-1.0.2.tgz",
+   "integrity": "sha512-h324S0Cbpc7hN57oBXG0cSbQETrPVbIPnZqe9sfWXbWtfJLIix1yrbLlbFR/aofDAH9hAujZC66XTECOoZn6GA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_robots-txt": {
+   "version": "1.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_robots-txt/-/auto_sdk_seo_robots-txt-1.0.21.tgz",
+   "integrity": "sha512-zkBCMODAKdOTlb37tIj1NUVXdyoMFnFloVBkQ8CtmNGkrAsRULnKestok7WiYv1ROUZKeZ3+zMPNE0uV+LzKhQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.12",
+    "@wix/sdk-types": "^1.17.7",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-patterns": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-patterns/-/auto_sdk_seo_seo-patterns-1.0.8.tgz",
+   "integrity": "sha512-gIg6a6WeE883zMvZOFzFK5tQA/uzkh3O4aOSsESYkOr0yXh9/trNAh89tT3NCBYPBZQ0csBPd2zDrT+doXLrXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-sitemap-entries": {
+   "version": "1.0.20",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-sitemap-entries/-/auto_sdk_seo_seo-sitemap-entries-1.0.20.tgz",
+   "integrity": "sha512-QvDO54PPxIzXBcP/6kR1j1mK7l7FxAM29vVAWXmdFl21EsauWQ1TBydmk5AerdlnzjKeY/hS6kf88sA5dkpaPQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_seo-tags": {
+   "version": "1.0.28",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_seo-tags/-/auto_sdk_seo_seo-tags-1.0.28.tgz",
+   "integrity": "sha512-oL7NZQi8ri8lXHw6ewZ12HGOCSX8ULdMzK0NaEr8HgjYQd4TBX+MN/xhteGgAi1V25/87lAddf/XqEZUNs4ibQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_seo_site-seo-tags": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_seo_site-seo-tags/-/auto_sdk_seo_site-seo-tags-1.0.8.tgz",
+   "integrity": "sha512-B4R9n615GQ/mYtA1atsi0ZHlzWikzgXoL6ZMA4eTbkm+FV+CrmDXqmLckkr3wWvvgdwr7VExZTTpC1628WQ5sw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_abandoned-carts": {
+   "version": "1.0.42",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_abandoned-carts/-/auto_sdk_stores_abandoned-carts-1.0.42.tgz",
+   "integrity": "sha512-DXG4pLTEaBP8pdzIWpidlJ44lkk93BuUew0iXB/nq6JbgDOu0O+GNgglPzrBC8oGxEhsrfzBMGkWkT68cH8hVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_brands-v-3": {
+   "version": "1.0.80",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_brands-v-3/-/auto_sdk_stores_brands-v-3-1.0.80.tgz",
+   "integrity": "sha512-bCqh6Kl2lU7j3JySC9kvQEbQc2+LncKkuyoc3F0gx+ei9w9Z3eQay6V0Q4w0oCWaRkYpC0NNvvRoUeAWsk5TKA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_catalog-imports-v-3": {
+   "version": "1.0.84",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_catalog-imports-v-3/-/auto_sdk_stores_catalog-imports-v-3-1.0.84.tgz",
+   "integrity": "sha512-TvWARid8/679NGicnuGBnE/p0thZWeFvDr6TNel60rR2ZouO8RoS8w78j3sbUqbY/2WRRrUcb/9CAZNBEbbBEg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_catalog-versioning": {
+   "version": "1.0.77",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_catalog-versioning/-/auto_sdk_stores_catalog-versioning-1.0.77.tgz",
+   "integrity": "sha512-nLuNFPnBp6lHIy44LblKO0pPAYXUjhANqdad0rTfEZu0niUrKKXgYbI8WayQU/OVHPqZrC8xRcpk9cAe8LUgpg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_collections": {
+   "version": "1.0.47",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_collections/-/auto_sdk_stores_collections-1.0.47.tgz",
+   "integrity": "sha512-SFYl7ns3VziT1P0aZuJwNtmLlbTlpx38YGBI1mbMOgDhOBhRyt59CKo50fSmKntdFwoqHF90j+zOlnbxc/UmeA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_customizations-v-3": {
+   "version": "1.0.92",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_customizations-v-3/-/auto_sdk_stores_customizations-v-3-1.0.92.tgz",
+   "integrity": "sha512-y1ObDGG/pDGMmGgelb6bUgY1EFp0nQcUHVq1PnECrxpIQXv0LhJ/frASd5xot0Lb1aONWGZAuia9QEvzJKKhaw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_info-sections-v-3": {
+   "version": "1.0.107",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_info-sections-v-3/-/auto_sdk_stores_info-sections-v-3-1.0.107.tgz",
+   "integrity": "sha512-wShiCSDNuLPks0VIjsckf45jaBe6imoI+7x3/6/dFdm1ufMYRDg70aqzzgUeWMp6FVeEhqZWBiEEJKdo0LnuMA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_inventory": {
+   "version": "1.0.74",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_inventory/-/auto_sdk_stores_inventory-1.0.74.tgz",
+   "integrity": "sha512-m4taisJPIynd2hCEGnY501cxbOcmPyfOcTNtjmXaVtN2xQswaa1BA6CYIpk+wgG32N5MtTRILrbW3EQmg9e2mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_inventory-items-v-3": {
+   "version": "1.0.91",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_inventory-items-v-3/-/auto_sdk_stores_inventory-items-v-3-1.0.91.tgz",
+   "integrity": "sha512-FytMefbR/xy/bzEI4HGl0Dp2rtahrnynIh4sdbiVzeaU7n5ZT9jI/DdYABsNjokPu7oe3dAzobPQQiETMpfBXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_product-groups-v-3": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_product-groups-v-3/-/auto_sdk_stores_product-groups-v-3-1.0.6.tgz",
+   "integrity": "sha512-QIynglDeH1Z9dICpJCJU2MJlMqoBjrKnjwXSbpNDBZy5HLbvE8/MHzKoOzWzLPwzyU2qXVelNQ6D3UCnDFpHvA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_products": {
+   "version": "1.0.104",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_products/-/auto_sdk_stores_products-1.0.104.tgz",
+   "integrity": "sha512-mV6sm1jEAgkjRZN9jdWTVKch4ajoeBMZwxuUW9Fe07vAN0bY9rjWLQ4h74bmHTVaCF8NR7qKjRtmqLJjpaQJbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_products-v-3": {
+   "version": "1.0.217",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_products-v-3/-/auto_sdk_stores_products-v-3-1.0.217.tgz",
+   "integrity": "sha512-MSiOiCvpHZ9NkirqvbudxS4lzQZQWSTAjVggXGWeQYJdduW6todFIBcxU9fPt4CKsI+q7X/FQ6NrctqCsTiEgw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_promotions-v-3": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_promotions-v-3/-/auto_sdk_stores_promotions-v-3-1.0.2.tgz",
+   "integrity": "sha512-GB1n5II3IEyOjvqdQGGCsUdW0Ra5btXbwTYLt8xgef2qJHTh3tNObfmXU/FhtXpKDOaOxnuvn/m3XN5A3kk4Ew==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_read-only-variants-v-3": {
+   "version": "1.0.136",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_read-only-variants-v-3/-/auto_sdk_stores_read-only-variants-v-3-1.0.136.tgz",
+   "integrity": "sha512-SrpfRui07Nm3fZugfFnHWCz271BMLa7LIScFp/34KBOVMPIc2G7BVL4AfJ8X2se5ha9zPpEd5udvZAfmC1MDKQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_ribbons-v-3": {
+   "version": "1.0.59",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_ribbons-v-3/-/auto_sdk_stores_ribbons-v-3-1.0.59.tgz",
+   "integrity": "sha512-TpDBVN+w86AzQIy+ZkaVulnrJrJ/uvJDL2YvuCIfd/mfqUupzBCj+sOcBMAommLTb5HIPr0tmY6ThyX6dSKrYw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_stores-locations-v-3": {
+   "version": "1.0.55",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_stores-locations-v-3/-/auto_sdk_stores_stores-locations-v-3-1.0.55.tgz",
+   "integrity": "sha512-tmTvTGRMV6x+Z1jKAKBP+dPdXJYpgNgJWMTU9Of0TARuHAdPkLWWFIkuba5n4lpX226HekceI+z+SadCotR2Jw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_subscription-options": {
+   "version": "1.0.69",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_subscription-options/-/auto_sdk_stores_subscription-options-1.0.69.tgz",
+   "integrity": "sha512-SOyFaEZxAMZ6wRQLjWnaUMr/JdiElT44EPT/1VQ5zWtupiqFKN5RfOXsMwm1mG0mCC4gZbd+edBXBg+AkYqqDw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/auto_sdk_stores_wishlist": {
+   "version": "1.0.38",
+   "resolved": "https://registry.npmjs.org/@wix/auto_sdk_stores_wishlist/-/auto_sdk_stores_wishlist-1.0.38.tgz",
+   "integrity": "sha512-kdGETiwtnATkKXTTHUQ1wJZN8jsv6Nyaiyl/BD/k4CV0bKWXpvDiXyp1TeKH/TyEedMUw52UF5XoECr38bzQsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.19",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/categories": {
+   "version": "1.0.220",
+   "resolved": "https://registry.npmjs.org/@wix/categories/-/categories-1.0.220.tgz",
+   "integrity": "sha512-8W3Gu/0dIo/gEPzHWzvs/8tqfTfBUUlI00TL73OeRftdzC82hUWtXc2B0VlX70ine7pFmzVqqIoqLxfRvVgSOA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_categories_categories": "1.0.142"
+   }
+  },
+  "node_modules/@wix/cli": {
+   "version": "1.1.239",
+   "resolved": "https://registry.npmjs.org/@wix/cli/-/cli-1.1.239.tgz",
+   "integrity": "sha512-cTw065EapPgvW1R0kejuDCjzHFFNO+ok1x0sahRxK8CQQd40n8DTW4OMeUnVOh0D71wf0sEjsShHziKXEk8dwQ==",
+   "dev": true,
+   "dependencies": {
+    "@wix/agent-skills": "^1.1.0",
+    "node-gyp": "^8.4.1"
+   },
+   "bin": {
+    "wix": "bin/wix.cjs"
+   },
+   "engines": {
+    "node": ">= 20.11.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "^2.3.2"
+   }
+  },
+  "node_modules/@wix/communication-channel": {
+   "version": "1.0.10",
+   "resolved": "https://registry.npmjs.org/@wix/communication-channel/-/communication-channel-1.0.10.tgz",
+   "integrity": "sha512-u4XFUSeWyKsXTcmNzMmhQSOvJTbHYic/G2mddaoSdtR5BL+hSjbVGw1tmio4xtdpE91co9J0y7w4eZgtoPgoBw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "comlink": "4.3.0"
+   }
+  },
+  "node_modules/@wix/consent-policy-manager": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/consent-policy-manager/-/consent-policy-manager-1.15.0.tgz",
+   "integrity": "sha512-XIQeVkNYEdCmAA/jLVTFxzZ7E6lwHbd17HecHZaeCcWjZwVoGuFPlH4mAs4sdrUisMGxe3MJhIHWsoGZ3nBwmA==",
+   "license": "MIT"
+  },
+  "node_modules/@wix/credits-types": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/@wix/credits-types/-/credits-types-1.0.3.tgz",
+   "integrity": "sha512-NalwotJuEso6zHvozUnmSh3KiiIecstL3zahgODvDmIPCnEZcCjnYK2l3QwD2hQPu/zga/QXwhLosxjkIdOR1w==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/dashboard": {
+   "version": "1.3.47",
+   "resolved": "https://registry.npmjs.org/@wix/dashboard/-/dashboard-1.3.47.tgz",
+   "integrity": "sha512-JhDuqFji5xnM6Qy12RZFEa2vmmVPuAc6AiE/eTW2U5mJjNVtRMRtv1OKv4v82wT/isaYxxn381rgj6JH/xc4FQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/communication-channel": "1.0.10",
+    "@wix/feedback-loop-structure": "^1.34.0",
+    "@wix/media": "^1.0.249",
+    "@wix/monitoring-browser-sdk-host": "^0.1.27",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.17.8",
+    "@wix/workspace": "^1.3.14",
+    "zustand": "^4.5.0"
+   },
+   "peerDependencies": {
+    "@wix/sdk": ">=1.12.4",
+    "react": "^16.0.0 || ^18.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@wix/sdk": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/dashboard/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/ecom": {
+   "version": "1.0.2454",
+   "resolved": "https://registry.npmjs.org/@wix/ecom/-/ecom-1.0.2454.tgz",
+   "integrity": "sha512-fjkJZf+utwGk6db2W7/WUo/UiAiYzODeaJOkqSDoGVL4rt6j6u1YQRRtWoCSc1nixIZengHYs1amJp7+SZnEww==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_ecom_abandoned-checkouts": "1.0.83",
+    "@wix/auto_sdk_ecom_additional-fees": "1.0.49",
+    "@wix/auto_sdk_ecom_back-in-stock-notifications": "1.0.63",
+    "@wix/auto_sdk_ecom_back-in-stock-settings": "1.0.42",
+    "@wix/auto_sdk_ecom_cart": "1.0.174",
+    "@wix/auto_sdk_ecom_cart-v-2": "1.0.192",
+    "@wix/auto_sdk_ecom_catalog": "1.0.64",
+    "@wix/auto_sdk_ecom_checkout": "1.0.168",
+    "@wix/auto_sdk_ecom_checkout-content": "1.0.37",
+    "@wix/auto_sdk_ecom_checkout-settings": "1.0.73",
+    "@wix/auto_sdk_ecom_checkout-templates": "1.0.150",
+    "@wix/auto_sdk_ecom_contact-tax-details": "1.0.3",
+    "@wix/auto_sdk_ecom_currencies": "1.0.35",
+    "@wix/auto_sdk_ecom_current-cart": "1.0.184",
+    "@wix/auto_sdk_ecom_current-cart-v-2": "1.0.193",
+    "@wix/auto_sdk_ecom_custom-triggers": "1.0.40",
+    "@wix/auto_sdk_ecom_delivery-profile": "1.0.440",
+    "@wix/auto_sdk_ecom_delivery-solutions": "1.0.62",
+    "@wix/auto_sdk_ecom_discount-rules": "1.0.115",
+    "@wix/auto_sdk_ecom_discounts": "1.0.34",
+    "@wix/auto_sdk_ecom_discounts-custom-trigger": "1.0.45",
+    "@wix/auto_sdk_ecom_draft-orders": "1.0.171",
+    "@wix/auto_sdk_ecom_draft-subscription-contracts": "1.0.7",
+    "@wix/auto_sdk_ecom_ecommerce-settings": "1.0.33",
+    "@wix/auto_sdk_ecom_gift-vouchers": "1.0.45",
+    "@wix/auto_sdk_ecom_gift-vouchers-provider": "1.0.35",
+    "@wix/auto_sdk_ecom_inventory": "1.0.24",
+    "@wix/auto_sdk_ecom_local-delivery-options": "1.0.53",
+    "@wix/auto_sdk_ecom_manual-tax-mappings": "1.0.43",
+    "@wix/auto_sdk_ecom_memberships": "1.0.66",
+    "@wix/auto_sdk_ecom_order-billing": "1.0.104",
+    "@wix/auto_sdk_ecom_order-fulfillments": "1.0.62",
+    "@wix/auto_sdk_ecom_order-invoices": "1.0.52",
+    "@wix/auto_sdk_ecom_order-payment-requests": "1.0.67",
+    "@wix/auto_sdk_ecom_order-transactions": "1.0.104",
+    "@wix/auto_sdk_ecom_orders": "1.0.286",
+    "@wix/auto_sdk_ecom_orders-settings": "1.0.55",
+    "@wix/auto_sdk_ecom_payment-settings": "1.0.143",
+    "@wix/auto_sdk_ecom_pickup-locations": "1.0.52",
+    "@wix/auto_sdk_ecom_recommendations": "1.0.47",
+    "@wix/auto_sdk_ecom_recommendations-provider": "1.0.33",
+    "@wix/auto_sdk_ecom_shipping-options": "1.0.230",
+    "@wix/auto_sdk_ecom_shipping-rates": "1.0.39",
+    "@wix/auto_sdk_ecom_shippo-configurations": "1.0.71",
+    "@wix/auto_sdk_ecom_subscription-contracts": "1.0.125",
+    "@wix/auto_sdk_ecom_tax-calculation": "1.0.54",
+    "@wix/auto_sdk_ecom_tax-calculation-provider": "1.0.31",
+    "@wix/auto_sdk_ecom_tax-exempt-groups": "1.0.4",
+    "@wix/auto_sdk_ecom_tax-groups": "1.0.64",
+    "@wix/auto_sdk_ecom_tax-regions": "1.0.61",
+    "@wix/auto_sdk_ecom_tax-settings": "1.0.2",
+    "@wix/auto_sdk_ecom_tip-settings": "1.0.54",
+    "@wix/auto_sdk_ecom_tippable-staff": "1.0.40",
+    "@wix/auto_sdk_ecom_tips": "1.0.62",
+    "@wix/auto_sdk_ecom_totals-calculator": "1.0.115",
+    "@wix/auto_sdk_ecom_validations": "1.0.56",
+    "@wix/auto_sdk_ecom_wishlists": "1.0.2",
+    "@wix/ecom_app-extensions": "1.0.107",
+    "@wix/headless-ecom": "0.0.41"
+   }
+  },
+  "node_modules/@wix/ecom_app-extensions": {
+   "version": "1.0.107",
+   "resolved": "https://registry.npmjs.org/@wix/ecom_app-extensions/-/ecom_app-extensions-1.0.107.tgz",
+   "integrity": "sha512-oAUv1VGGFCth/G7YxkMlvJCv1RjPJ02QgcMWGJFwuorfgCZHEinoA3F8QKaQ97FaF+k7Nup00OMLYJl/TBpCwA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/editor": {
+   "version": "1.785.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor/-/editor-1.785.0.tgz",
+   "integrity": "sha512-2gjp52CPDm0NyHmOeSshY8JB8d9cZSim+wLhEtywvonapYmhMUYpk3apg5Y6Nq9EkkQKV78h3VBldbG89bA6zQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/editor-platform-environment-api": "1.161.0",
+    "@wix/monitoring-browser-sdk-host": "^0.1.25",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0",
+    "@wix/sdk-runtime": "^0.7.0",
+    "@wix/sdk-types": "^1.17.11",
+    "@wix/workspace": "^1.3.18"
+   }
+  },
+  "node_modules/@wix/editor-application": {
+   "version": "1.473.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-application/-/editor-application-1.473.0.tgz",
+   "integrity": "sha512-uMfBLWBF/XBcw5uZcn9Uwng+iQEfm+dWI34DfSgWuy52FrpnFrCiIxZpO/bKMK0lBGzvy6WGIVj9Sbzrd6iLjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-contexts": {
+   "version": "1.160.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-contexts/-/editor-platform-contexts-1.160.0.tgz",
+   "integrity": "sha512-5nBLeqPsWELDJECxcXVbsTm+uTI8W15e46Mi8wvm8i7SM87RfsOB0BY5kIIP33rfMFyBrZS2NJiRAGO9IzadZQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-environment-api": {
+   "version": "1.161.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-environment-api/-/editor-platform-environment-api-1.161.0.tgz",
+   "integrity": "sha512-hjUr8xmqDij0bKCKp2VPCfajz8Wj2JAeDL2ez9pcgtoPhtuPixaSRzrTNegK8Kk+p6sitLlhPxtOEi6FCsBtlw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/editor-application": "1.473.0",
+    "@wix/editor-platform-contexts": "1.160.0",
+    "@wix/editor-platform-transport": "1.15.0",
+    "@wix/public-editor-platform-errors": "1.9.0",
+    "@wix/public-editor-platform-events": "1.394.0",
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/editor-platform-transport": {
+   "version": "1.15.0",
+   "resolved": "https://registry.npmjs.org/@wix/editor-platform-transport/-/editor-platform-transport-1.15.0.tgz",
+   "integrity": "sha512-dQVqbJv1TiD7XtxGSu1vy+G7fOF5/33XqjwWR1sM4GagDa7FTlt5H+P490ih8ROeZM0g21yPPfA7Sar/2IKHtQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime": {
+   "version": "0.7.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.7.0.tgz",
+   "integrity": "sha512-wqLo26ZkMDoyMqVMC7H0lG5qYmGbCk7m3443XJB/cw0MrYl4o4Eermc+LPDf6vsaGKgiVSQ+6OY6G2SZ6RPnSg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.14.0"
+   }
+  },
+  "node_modules/@wix/editor/node_modules/@wix/sdk-runtime/node_modules/@wix/sdk-types": {
+   "version": "1.14.0",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.14.0.tgz",
+   "integrity": "sha512-1ae6emTMiiYr+cpupnmHS05WMU04vP12DlW5cII3pjau3iLhmfo6KjA++ZRSnmOJc0sNYI5iL7sMVrJFy46hPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/error-handler-core": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-core/-/error-handler-core-1.20.0.tgz",
+   "integrity": "sha512-ubswKgfxN/KwUZKoO0dcz27gER6uVtSbiaV7L91F9hwYUthvrb79zLZiP64NZCGVlgBFIsjHm2JrdPnCDL3TbA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-types": "1.20.0"
+   }
+  },
+  "node_modules/@wix/error-handler-types": {
+   "version": "1.20.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler-types/-/error-handler-types-1.20.0.tgz",
+   "integrity": "sha512-tMi5BucbWs6CnwIoMaPteWu4J6TeI6O2TsYx5hznKERz509We3ZKi+liJLp+oe2Kd/IUxZr3BAh1Zr+bcbKMVA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4"
+   }
+  },
+  "node_modules/@wix/essentials": {
+   "version": "1.0.14",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-1.0.14.tgz",
+   "integrity": "sha512-L144AyHA5TYmvCdOCT4KXlaqEolX40+HQY+e3J3lO3hB4YjP9Q/M9E6erlLRuWJv6Iu3Uhv5iKboWFeLdqstaA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/multilingual-manager": "^1.2.0",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "i18next": "^25.6.3",
+    "i18next-icu": "^2.4.1",
+    "intl-messageformat": "^10.7.18",
+    "react-i18next": "^16.1.2"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/essentials/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure": {
+   "version": "1.34.0",
+   "resolved": "https://registry.npmjs.org/@wix/feedback-loop-structure/-/feedback-loop-structure-1.34.0.tgz",
+   "integrity": "sha512-7oRFhiVTdfalMqJwS76yTDZP9SQOgRf1KacXsiLfAjD3IbBxk/PvuvLqmS/XEK9gFUvd971kUaAVKyaA/dT+QQ==",
+   "license": "MIT",
+   "dependencies": {
+    "zod": "^3.23.8"
+   }
+  },
+  "node_modules/@wix/feedback-loop-structure/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/@wix/headless-components": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-components/-/headless-components-0.0.0.tgz",
+   "integrity": "sha512-Ny+mygXkuSPPRuLtvpA0cfau7oChp8uD5mrvuvQojkLNmTcuVKAJQg5gKDMBnPxq3rvvVqqewYDxHWNfTfK8YA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@wix/headless-utils": "0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-ecom": {
+   "version": "0.0.41",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/headless-ecom-0.0.41.tgz",
+   "integrity": "sha512-YYZZtCLvY+2vcS0FxSJuuro8aWF8jnINHQRafxYwkZXQNvPMbewKpx1MF97/UiSaGyeSCJyZZoOTdSldEo7Vtw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/auto_sdk_ecom_checkout": "^1.0.61",
+    "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
+    "@wix/headless-media": "0.0.21",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-localization-utils": {
+   "version": "1.0.15",
+   "resolved": "https://registry.npmjs.org/@wix/headless-localization-utils/-/headless-localization-utils-1.0.15.tgz",
+   "integrity": "sha512-ZM1aw52LH4nTcWRIYuFcONQbrl6zdevtXCry3PwaA9J4ty7m+G7o/L4Xv3RzKsYq7djsTeVLggFgdW6/6q2jbQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-node": "^1.42.0",
+    "@wix/headless-site-assets": "^1.0.9"
+   }
+  },
+  "node_modules/@wix/headless-media": {
+   "version": "0.0.21",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.21.tgz",
+   "integrity": "sha512-7o9ctPfQsQwfLwLCjs4RDO9Ns900Hv+BNVc301tShulKeitxgMKTrFqUxCsCuSQqqgQYaOhm5hDB+994LtBozg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-node": {
+   "version": "1.44.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-node/-/headless-node-1.44.0.tgz",
+   "integrity": "sha512-CE/3/bL3Vxg54aEwMMCcPe6xihImQu21+p21rwQ79W7uQsYyI0GZ8+sVR3WQHuP3DOR/Nc9NcfRPQ48BDXGjdw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-seo": {
+   "version": "0.0.16",
+   "resolved": "https://registry.npmjs.org/@wix/headless-seo/-/headless-seo-0.0.16.tgz",
+   "integrity": "sha512-TgiUj4jWRJZkZE9zsAY0AAWrxi/oFPJRD8lV8W01VuaMhiQAFDIwCCDuj+a6McsufUNIbnafcmR8pHp+HP/yIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/seo": "^1.0.14",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-site": {
+   "version": "1.37.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site/-/headless-site-1.37.0.tgz",
+   "integrity": "sha512-C1teSScB62BAwSFvB8a4PwbzLyb4NfjRfF2g+krlePmOapZ4YDGM/JwttL8sl9kWV9DGICO3kNCC0+9G9xdUGg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/monitoring-velo": "^1.31.0",
+    "@wix/sdk-runtime": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/headless-site-assets": {
+   "version": "1.0.13",
+   "resolved": "https://registry.npmjs.org/@wix/headless-site-assets/-/headless-site-assets-1.0.13.tgz",
+   "integrity": "sha512-t8wo7ux7fWmzmz2UAUtsVuKnXnLW1SF4duEyTDWPlIw0vpsQjzcsY4fGpFIVvxXSAGpAIz+qecAZHPmUrP50Rw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_headless-site-assets_scripts": "1.0.13"
+   }
+  },
+  "node_modules/@wix/headless-stores": {
+   "version": "0.0.119",
+   "resolved": "https://registry.npmjs.org/@wix/headless-stores/-/headless-stores-0.0.119.tgz",
+   "integrity": "sha512-PcXXK0FyXffYKMqp8CHRGTnNZgOQftLaxMGDuA8bWY7WT05uzIsxceWK33xDRhzXFPz/lEWB/YvwQ1+vIy2XcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "@wix/auto_sdk_bookings_availability-calendar": "^1.0.155",
+    "@wix/auto_sdk_categories_categories": "^1.0.62",
+    "@wix/ecom": "^1.0.1744",
+    "@wix/essentials": "^0.1.24",
+    "@wix/headless-ecom": "0.0.45",
+    "@wix/headless-media": "0.0.25",
+    "@wix/headless-utils": "0.0.12",
+    "@wix/redirects": "^1.0.83",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3",
+    "@wix/site": "^1.40.0",
+    "@wix/stores": "^1.0.650"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/error-handler": {
+   "version": "1.68.0",
+   "resolved": "https://registry.npmjs.org/@wix/error-handler/-/error-handler-1.68.0.tgz",
+   "integrity": "sha512-DGP/C3Uv5cpGQX4OxDgXmSvDPJxQPjOkD3vpe+50kVm6CDd2UAvnvkMnvA/6SpvVJwowHeqBLC8DKqzBe5YuHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.28.4",
+    "@wix/error-handler-core": "1.20.0",
+    "events": "^3.3.0",
+    "http-status-codes": "^2.3.0",
+    "uuid": "^11.0.3"
+   },
+   "peerDependencies": {
+    "@wix/fe-essentials": "^1.233.0",
+    "i18next": ">=19.9.2",
+    "i18next-icu": ">=2.3.0",
+    "intl-messageformat": ">=7.8.4"
+   },
+   "peerDependenciesMeta": {
+    "@wix/fe-essentials": {
+     "optional": true
+    },
+    "i18next": {
+     "optional": true
+    },
+    "i18next-icu": {
+     "optional": true
+    },
+    "intl-messageformat": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/essentials": {
+   "version": "0.1.28",
+   "resolved": "https://registry.npmjs.org/@wix/essentials/-/essentials-0.1.28.tgz",
+   "integrity": "sha512-uAB9xpwqebaIrdgPD9YsdZA8XSqWEJvtLT4HKSpuWmSmtLZBRYb+8U0D6NfY5grVw1qYzw0Z4XaGdeM2LLyuuw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler": "^1.67.0",
+    "@wix/monitoring": "^0.21.0",
+    "@wix/sdk-runtime": "^0.3.62",
+    "@wix/sdk-types": "^1.13.41",
+    "i18next": "^25.3.2",
+    "i18next-icu": "^2.3.0",
+    "intl-messageformat": "^10.7.16"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/headless-ecom": {
+   "version": "0.0.45",
+   "resolved": "https://registry.npmjs.org/@wix/headless-ecom/-/headless-ecom-0.0.45.tgz",
+   "integrity": "sha512-CRbvUajeMijIitfPMCgOEPLJtBe8ry5ePD4PF9wTiUjFrHR+Ybz0u8wd9zomnH910zLFWdBcfIBqxFboBIP8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@wix/auto_sdk_ecom_checkout": "^1.0.61",
+    "@wix/auto_sdk_ecom_current-cart": "^1.0.56",
+    "@wix/headless-media": "0.0.25",
+    "@wix/redirects": "^1.0.0",
+    "@wix/sdk": "^1.15.24",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   },
+   "peerDependencies": {
+    "@wix/headless-components": "^0.0.0"
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/headless-utils": {
+   "version": "0.0.12",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.12.tgz",
+   "integrity": "sha512-CY5L2/KftFNvoCBzx68MJ2lhSlkjNNBrTXDAhg/fom5PORCruJAoRit4HuIK4u19pUWXkp7QLrhiQKapf1wucg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/headless-stores/node_modules/@wix/sdk-runtime": {
+   "version": "0.3.62",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-0.3.62.tgz",
+   "integrity": "sha512-5imt9mSEaceX365iLGzMJ7jS4qr4lJj+2DZox86Ge8P7V9IeuPYLsQ+0PN9wN6XgMfjNLHt4G6hJUIi3bdglGA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "^1.13.41"
+   }
+  },
+  "node_modules/@wix/headless-utils": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/headless-utils/-/headless-utils-0.0.0.tgz",
+   "integrity": "sha512-Pz4UZfMRCTfHf/nRmJ20vVVVPzjcz6VuiRpTzBgsjML9fI/ulviR6oV0ZAReMiyflptqGGl0PU/pTrj/fnhcow==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3"
+   },
+   "peerDependencies": {
+    "react": ">=16.3.0"
+   }
+  },
+  "node_modules/@wix/identity": {
+   "version": "1.0.230",
+   "resolved": "https://registry.npmjs.org/@wix/identity/-/identity-1.0.230.tgz",
+   "integrity": "sha512-nus+1nomRiDMEH823EZegXU9YaBvRcrlcX2UUwwd12rcC1AaFarAG6WMMuylXm1gmL833UwaraieDlzLp19KVw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_identity_authentication": "1.0.57",
+    "@wix/auto_sdk_identity_oauth": "1.0.53",
+    "@wix/auto_sdk_identity_recovery": "1.0.46",
+    "@wix/auto_sdk_identity_sign-on-policy": "1.0.1",
+    "@wix/auto_sdk_identity_verification": "1.0.48"
+   }
+  },
+  "node_modules/@wix/image-kit": {
+   "version": "1.125.0",
+   "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.125.0.tgz",
+   "integrity": "sha512-ALqciyP3E0DSoLPcF3w2h6vZYamUodXp15MYw5/yfwPFzOuHq4Uo2cbXANL3D1v/7ehxjZoxdqGb4wHf9r5R7g==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.26.0",
+    "tslib": "^2.8.1"
+   }
+  },
+  "node_modules/@wix/media": {
+   "version": "1.0.271",
+   "resolved": "https://registry.npmjs.org/@wix/media/-/media-1.0.271.tgz",
+   "integrity": "sha512-Ci/qsi/qouoC9NqIwwgiEvcRxk9xJugivsk59wPRDb0h/kQDAs9Jc8R06bgBPAC8ja3+frRMnBXTrVo2+bmaqw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_media_enterprise-media-categories": "1.0.37",
+    "@wix/auto_sdk_media_enterprise-media-items": "1.0.38",
+    "@wix/auto_sdk_media_files": "1.0.96",
+    "@wix/auto_sdk_media_folders": "1.0.57",
+    "@wix/headless-media": "^0.0.25"
+   }
+  },
+  "node_modules/@wix/media/node_modules/@wix/headless-media": {
+   "version": "0.0.25",
+   "resolved": "https://registry.npmjs.org/@wix/headless-media/-/headless-media-0.0.25.tgz",
+   "integrity": "sha512-qxS7892M8cr2y6Pata1laHmQDCXeF5SAepB2csxTvCk/bYzFsp7gJOTYwjVqKnZP2O28RW/JO8F00nkKwP1/NA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk": "^1.17.1",
+    "@wix/services-definitions": "^1.0.1",
+    "@wix/services-manager-react": "^1.0.3"
+   }
+  },
+  "node_modules/@wix/monitoring": {
+   "version": "0.21.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-0.21.0.tgz",
+   "integrity": "sha512-2KC4ZuJE4abToc2QelY7Bv99BOfbvZiAK8PY5090iP4YVGM9t+VgUdg8H6l94Q0bF/vF44dcA9rjFiEcUz4K7g==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.12.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama": {
+   "version": "0.10.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-panorama/-/monitoring-browser-panorama-0.10.0.tgz",
+   "integrity": "sha512-xZCyaVKIR/XRhIovPwDgIiySygb100jL2ZFRiYvk+KECAjX6HlVme6GvxV90dbDGREAZLm+qm0jyjptNHoVVjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-panorama/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host": {
+   "version": "0.1.27",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sdk-host/-/monitoring-browser-sdk-host-0.1.27.tgz",
+   "integrity": "sha512-sCJqMCvPX5hxpMblQx0rlJz/b0d/VcPzT1eA9Te97eop3yaRzJoaWI99XqwxvxyOqZZ8wNgF711UEHHFLTmVfQ==",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-browser-panorama": "0.10.0",
+    "@wix/monitoring-browser-sentry": "0.26.0",
+    "@wix/monitoring-types": "0.17.0",
+    "@wix/monitoring-velo": "1.29.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-browser-sdk-host/node_modules/@wix/monitoring-velo": {
+   "version": "1.29.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.29.0.tgz",
+   "integrity": "sha512-cJZI6yCMdnHuE0lTla04h74IxulsafLwoAx3aQzheda+jBhQtWHHNAB1Dr8OuNFF4jPbLPpHsbGAQNTC8DZ1vg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry": {
+   "version": "0.26.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-browser-sentry/-/monitoring-browser-sentry-0.26.0.tgz",
+   "integrity": "sha512-ghloi6CN7AvnHAXOxQgwKNcfPl0IZfzHXqLOfoAyVKQ9wqDepkK1HH0Yp5fOz5xvkvlnt0TXc8sTRCScFHTNjg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.0.0",
+    "@wix/monitoring-common-sentry": "0.2.0",
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.0.0.tgz",
+   "integrity": "sha512-l/0UaT0n4AFVU/7cbe5PLu09WX8s3Zs+dkHf0duacTYwjgnCA+oXuXJ+S2zIKo/85EBZvDEEUx2eD3FUFEztsA==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "0.17.0"
+   }
+  },
+  "node_modules/@wix/monitoring-browser-sentry/node_modules/@wix/monitoring-types": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.17.0.tgz",
+   "integrity": "sha512-1R3kOhnd/gGy3B88NFvIog4JRXpQy3Hs1zRtWXZybAFgP+nZiApClwbFwR6xBDIgxV9MaImaEfMN0Y5Sitvttw==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common/-/monitoring-common-1.13.0.tgz",
+   "integrity": "sha512-gT7sMyoJ50O+jGFKxxlsvg6vZm2K7Bvmwzf5KI1reu2Owz6eC7Rf2pDKnlMrHLTn2uJA7Zxynrj2nS8j0OURdQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-common-sentry": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-common-sentry/-/monitoring-common-sentry-0.2.0.tgz",
+   "integrity": "sha512-AE87Zt9MsJSbU5RczEqYijataEUyhChaKL06mJodrbt7we/rb09Ji8E4aZX4Pddfsf0tXG+XN0hI5kdeGXxM7g==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-types": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-0.12.0.tgz",
+   "integrity": "sha512-nlv4jwQMewjzPIWFF9rnKf9WhVojj67oLtvilYXfi+lnhXyVlYOfqCnL3qLJuKtJ6wT5XIJdt0Fj0su2NM5taQ==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/monitoring-velo": {
+   "version": "1.31.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-velo/-/monitoring-velo-1.31.0.tgz",
+   "integrity": "sha512-cgSOZO68e2f4DRzI8yyRiwYftn/7GJcxJ5hcpVPL8yfb7g1quPtFtsT5ChEZdvPjhbx1j0MSQ70dqYkVyWsacg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring": "1.1.0",
+    "@wix/monitoring-common": "1.13.0",
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring/-/monitoring-1.1.0.tgz",
+   "integrity": "sha512-sX8QKAuRZl6gaR5pOJ+8BpxtgOddYzyQAvv706A5F/wsO+YDcSU/ViE1U+i2rL2Jlr2B9J4+vnCCZgQH0CMPmQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/monitoring-types": "1.0.0"
+   }
+  },
+  "node_modules/@wix/monitoring-velo/node_modules/@wix/monitoring-types": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/@wix/monitoring-types/-/monitoring-types-1.0.0.tgz",
+   "integrity": "sha512-Cc9t8HCt4QUXZQ6T2+MmtARsEKx/UL78mQpouc1IZhblUsM1QF+N5J+o4D5qxZSjt7GzuIXN5cUdLFuUSAfvyA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/multilingual-manager": {
+   "version": "1.11.0",
+   "resolved": "https://registry.npmjs.org/@wix/multilingual-manager/-/multilingual-manager-1.11.0.tgz",
+   "integrity": "sha512-hyvEM9KqmYgHD00KB4yx4dIotMxM4wajAZlAyQkqjDFJaZtfa/aCidhQgmqJ3gyKbvK3I5MAWS0FyqR3vHNFkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/headless-localization-utils": "^1.0.11",
+    "lodash": "^4.17.21"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-errors": {
+   "version": "1.9.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-errors/-/public-editor-platform-errors-1.9.0.tgz",
+   "integrity": "sha512-nHiypFes1kQ0eUlwulwM6fmi5HTTJ0wFISPb6FUgcq3HpvDHbAO3DP8cLOIVYppyTfNv7Ew7yv/oubnuLcX/YA==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/public-editor-platform-events": {
+   "version": "1.394.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-events/-/public-editor-platform-events-1.394.0.tgz",
+   "integrity": "sha512-yHxIbhSpHZE8CIPoYonUrkNVDzDRYT36Ssb3HIJ8b1OZRhdtcjF1HNP+okdTVW+mBBiyXjGFNqfe1LWM0R6GDg==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/public-editor-platform-interfaces": "1.103.0"
+   }
+  },
+  "node_modules/@wix/public-editor-platform-interfaces": {
+   "version": "1.103.0",
+   "resolved": "https://registry.npmjs.org/@wix/public-editor-platform-interfaces/-/public-editor-platform-interfaces-1.103.0.tgz",
+   "integrity": "sha512-iWupfV581sAgrCd8UyWrlakRNHhjfEeH0tluwVBbD+OEoybKs58c4xLEAw2N4A+VzzRVcwOIk+b6hdF4wI6wjw==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@wix/app-extensions": "^1.0.131",
+    "@wix/sdk-types": "^1.17.11"
+   }
+  },
+  "node_modules/@wix/react-component-schema": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/@wix/react-component-schema/-/react-component-schema-1.8.0.tgz",
+   "integrity": "sha512-QTN6a/px13k/y0mjrDaibEOlHzOZmh3kj/WQahO77WS32fZIvkajODOYEboI9OvAiaecHQe//9dZ1UiFal0wWg==",
+   "license": "ISC"
+  },
+  "node_modules/@wix/redirects": {
+   "version": "1.0.125",
+   "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.125.tgz",
+   "integrity": "sha512-bcGrOADsRYg5HDkl9pM5WZDKD/pU0GdJntnjZI/K/8jgOUNhWhKQF8UABI5kV3QCzhjLfh+8ESiKHaBmhtf0rg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_redirects_redirects": "1.0.53"
+   }
+  },
+  "node_modules/@wix/sdk": {
+   "version": "1.21.16",
+   "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.21.16.tgz",
+   "integrity": "sha512-OGRzJDSmTGNftVOLn11jxgHeaWKfYkQRZDA7qtkEz4oo2KbjNqhV/O9bMghmmtXYivnHhZH5IBvNnBHxaWTCZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/identity": "^1.0.204",
+    "@wix/image-kit": "^1.114.0",
+    "@wix/redirects": "^1.0.70",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-runtime": "1.0.22",
+    "@wix/sdk-types": "1.17.11",
+    "jose": "^5.10.0",
+    "type-fest": "^4.41.0"
+   },
+   "optionalDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+   }
+  },
+  "node_modules/@wix/sdk-context": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-context/-/sdk-context-0.0.1.tgz",
+   "integrity": "sha512-ziSzrceUC0KFn4IJIVBn1cXXKrZ49ZKG5tQ6fl+TpontyUw5p/Z4VofFUUsnqNl9JYCpYNTzIXpzwok93Vrl8A==",
+   "license": "UNLICENSED"
+  },
+  "node_modules/@wix/sdk-react-context": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-react-context/-/sdk-react-context-1.0.2.tgz",
+   "integrity": "sha512-dX1A+IlLVzsW0pE7ZyhtJHNEeeCYnu/suELnHm4FrxX5alJl1JaEpHbvjuaCt6kD/kDP1iIu9Pu6AvyJUCtYrg==",
+   "license": "UNLICENSED",
+   "peerDependencies": {
+    "react": "*"
+   }
+  },
+  "node_modules/@wix/sdk-runtime": {
+   "version": "1.0.24",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.24.tgz",
+   "integrity": "sha512-1R0CC+vYX/pSVPqyDnKmsTxkZisrq8DeidYQxxnRyYk5EfxNlLRNjX1auE/Lj+Mhs6qQPY/doayUhtCBaOkL+Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/sdk-types": {
+   "version": "1.17.11",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.17.11.tgz",
+   "integrity": "sha512-yZf6pxh1FP8lTHpny1+f54ac26hfzamxe0ldK9EziMXHsbw+99kF+iTGDrbHZ1YT9OV8xo82fWjK7Dhu45AzTA==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/error-handler-types": "^1.19.0",
+    "@wix/monitoring-types": "^0.12.0",
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/sdk/node_modules/@wix/sdk-runtime": {
+   "version": "1.0.22",
+   "resolved": "https://registry.npmjs.org/@wix/sdk-runtime/-/sdk-runtime-1.0.22.tgz",
+   "integrity": "sha512-gGfT3+j4NBakQbm2SOb2OneKBAcbxWuDzJKMRgte3QyXxdnXARCv3h1LmBRAstLqxDsgaW7EDPv66oGIE6cb6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-context": "0.0.1",
+    "@wix/sdk-types": "1.17.11"
+   }
+  },
+  "node_modules/@wix/seo": {
+   "version": "1.0.79",
+   "resolved": "https://registry.npmjs.org/@wix/seo/-/seo-1.0.79.tgz",
+   "integrity": "sha512-9kGWaY42QKs98qe+Dbp+tALK+oOuPVMVZVDGf6UZlFTKS7wtqNpA1G8uqDRd4IF8l7GZZiX+PMwTMYiUaYlpng==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_seo_item-seo-tags": "1.0.12",
+    "@wix/auto_sdk_seo_llms-txt": "1.0.0",
+    "@wix/auto_sdk_seo_redirects": "1.0.2",
+    "@wix/auto_sdk_seo_robots-txt": "1.0.21",
+    "@wix/auto_sdk_seo_seo-patterns": "1.0.8",
+    "@wix/auto_sdk_seo_seo-sitemap-entries": "1.0.20",
+    "@wix/auto_sdk_seo_seo-tags": "1.0.28",
+    "@wix/auto_sdk_seo_site-seo-tags": "1.0.8",
+    "@wix/headless-seo": "^0.0.16"
+   }
+  },
+  "node_modules/@wix/services-definitions": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/@wix/services-definitions/-/services-definitions-1.0.5.tgz",
+   "integrity": "sha512-69+ZTkae11GNVXA4WeHs5yINpmhNQHMZ00OhogP77fZXZQHmvFsd7yKpQBXFJKeWj+5wSd1hoL3o0s36jGza/Q==",
+   "dependencies": {
+    "type-fest": "^4.41.0"
+   }
+  },
+  "node_modules/@wix/services-manager": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager/-/services-manager-1.0.7.tgz",
+   "integrity": "sha512-Yp985K427nJaNQh5fZoe3p/C5hUzlNprFKTfJJtYCakc+Mpvo0xTBJrIzzZG62gThAjV5741BLA5qT4fIIYMRg==",
+   "peer": true,
+   "dependencies": {
+    "@preact/signals-core": "^1.12.1",
+    "@wix/sdk-context": "0.0.1",
+    "@wix/services-definitions": "1.0.5"
+   }
+  },
+  "node_modules/@wix/services-manager-react": {
+   "version": "1.0.8",
+   "resolved": "https://registry.npmjs.org/@wix/services-manager-react/-/services-manager-react-1.0.8.tgz",
+   "integrity": "sha512-7prwGFLcJ0p0KDbzoMXJ6WiSE6kvMAxLDwRayU2vMVhgQwjiUxuqx0HopU8oR33RimV+3YJbDPrnoPqh3qCqZw==",
+   "license": "MIT",
+   "dependencies": {
+    "@preact/signals-react": "^3.6.1",
+    "@wix/sdk-react-context": "1.0.2",
+    "@wix/services-definitions": "1.0.5"
+   },
+   "peerDependencies": {
+    "@wix/services-manager": "^1.0.0",
+    "react": "^16.14.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^18.3.1",
+    "use-sync-external-store": "^1.0.0"
+   }
+  },
+  "node_modules/@wix/site": {
+   "version": "1.66.0",
+   "resolved": "https://registry.npmjs.org/@wix/site/-/site-1.66.0.tgz",
+   "integrity": "sha512-MGujYqSgSMJws82TITn2KQAXDN/Us/6mLGAoFhMtMfFh4e1lt3Z+kSzUqjfpAKB6kzY3x1v35cAD16ihHivaBQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/analytics": "1.19.0",
+    "@wix/authentication": "1.16.0",
+    "@wix/consent-policy-manager": "1.15.0",
+    "@wix/multilingual-manager": "1.11.0",
+    "@wix/sdk-types": "^1.13.2"
+   }
+  },
+  "node_modules/@wix/stores": {
+   "version": "1.0.889",
+   "resolved": "https://registry.npmjs.org/@wix/stores/-/stores-1.0.889.tgz",
+   "integrity": "sha512-H+gn+6YEriDRt5fAuCtiT87fAEiD8PycOLfqV8ayAu8ncOka9ckatZkZO7IAx3BAKk3YGP+3i4ephPOvjlu+lg==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/auto_sdk_stores_abandoned-carts": "1.0.42",
+    "@wix/auto_sdk_stores_brands-v-3": "1.0.80",
+    "@wix/auto_sdk_stores_catalog-imports-v-3": "1.0.84",
+    "@wix/auto_sdk_stores_catalog-versioning": "1.0.77",
+    "@wix/auto_sdk_stores_collections": "1.0.47",
+    "@wix/auto_sdk_stores_customizations-v-3": "1.0.92",
+    "@wix/auto_sdk_stores_info-sections-v-3": "1.0.107",
+    "@wix/auto_sdk_stores_inventory": "1.0.74",
+    "@wix/auto_sdk_stores_inventory-items-v-3": "1.0.91",
+    "@wix/auto_sdk_stores_product-groups-v-3": "1.0.6",
+    "@wix/auto_sdk_stores_products": "1.0.104",
+    "@wix/auto_sdk_stores_products-v-3": "1.0.217",
+    "@wix/auto_sdk_stores_promotions-v-3": "1.0.2",
+    "@wix/auto_sdk_stores_read-only-variants-v-3": "1.0.136",
+    "@wix/auto_sdk_stores_ribbons-v-3": "1.0.59",
+    "@wix/auto_sdk_stores_stores-locations-v-3": "1.0.55",
+    "@wix/auto_sdk_stores_subscription-options": "1.0.69",
+    "@wix/auto_sdk_stores_wishlist": "1.0.38",
+    "@wix/headless-stores": "^0.0.119",
+    "@wix/stores_app-extensions": "1.0.54"
+   }
+  },
+  "node_modules/@wix/stores_app-extensions": {
+   "version": "1.0.54",
+   "resolved": "https://registry.npmjs.org/@wix/stores_app-extensions/-/stores_app-extensions-1.0.54.tgz",
+   "integrity": "sha512-m+/iwpsySTwqOmeloE6/aW1aiqAjiadoCLw+t0Je8kN5jIzFhytodnJlEjQVHzAB+3DYCK586+B96qTrkwSynQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11",
+    "zod": "^4.3.6"
+   }
+  },
+  "node_modules/@wix/workspace": {
+   "version": "1.3.19",
+   "resolved": "https://registry.npmjs.org/@wix/workspace/-/workspace-1.3.19.tgz",
+   "integrity": "sha512-FN3ipuF/FqRM0L2Ib10g8w7jyWQrx9JoMhwrXOl4kNeeyQA7NNd3rpDT1B8FOMtEmR5NZ0t+AZycX+jl8wXjiQ==",
+   "license": "UNLICENSED",
+   "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "@wix/credits-types": "^1.0.3",
+    "@wix/sdk-runtime": "^1.0.24",
+    "@wix/sdk-types": "^1.17.11"
+   },
+   "peerDependencies": {
+    "@wix/sdk": "^1.21.3"
+   }
+  },
+  "node_modules/abbrev": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/acorn": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+   "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+   "license": "MIT",
+   "bin": {
+    "acorn": "bin/acorn"
+   },
+   "engines": {
+    "node": ">=0.4.0"
+   }
+  },
+  "node_modules/agent-base": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+   "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6.0.0"
+   }
+  },
+  "node_modules/agentkeepalive": {
+   "version": "4.6.0",
+   "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+   "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "humanize-ms": "^1.2.1"
+   },
+   "engines": {
+    "node": ">= 8.0.0"
+   }
+  },
+  "node_modules/aggregate-error": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+   "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "clean-stack": "^2.0.0",
+    "indent-string": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-align": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+   "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^4.1.0"
+   }
+  },
+  "node_modules/ansi-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "license": "MIT"
+  },
+  "node_modules/ansi-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-regex": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+   "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/ansi-styles": {
+   "version": "6.2.3",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+   "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+   }
+  },
+  "node_modules/anymatch": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+   "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+   "license": "ISC",
+   "dependencies": {
+    "normalize-path": "^3.0.0",
+    "picomatch": "^2.0.4"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/anymatch/node_modules/picomatch": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+   "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8.6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/aproba": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+   "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/are-we-there-yet": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+   "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "delegates": "^1.0.0",
+    "readable-stream": "^3.6.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/argparse": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+   "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+   "license": "Python-2.0"
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/aria-query": {
+   "version": "5.3.2",
+   "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+   "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/array-iterate": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+   "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/astro": {
+   "version": "5.18.2",
+   "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+   "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@astrojs/compiler": "^2.13.0",
+    "@astrojs/internal-helpers": "0.7.6",
+    "@astrojs/markdown-remark": "6.3.11",
+    "@astrojs/telemetry": "3.3.0",
+    "@capsizecss/unpack": "^4.0.0",
+    "@oslojs/encoding": "^1.1.0",
+    "@rollup/pluginutils": "^5.3.0",
+    "acorn": "^8.15.0",
+    "aria-query": "^5.3.2",
+    "axobject-query": "^4.1.0",
+    "boxen": "8.0.1",
+    "ci-info": "^4.3.1",
+    "clsx": "^2.1.1",
+    "common-ancestor-path": "^1.0.1",
+    "cookie": "^1.1.1",
+    "cssesc": "^3.0.0",
+    "debug": "^4.4.3",
+    "deterministic-object-hash": "^2.0.2",
+    "devalue": "^5.6.2",
+    "diff": "^8.0.3",
+    "dlv": "^1.1.3",
+    "dset": "^3.1.4",
+    "es-module-lexer": "^1.7.0",
+    "esbuild": "^0.27.3",
+    "estree-walker": "^3.0.3",
+    "flattie": "^1.1.1",
+    "fontace": "~0.4.0",
+    "github-slugger": "^2.0.0",
+    "html-escaper": "3.0.3",
+    "http-cache-semantics": "^4.2.0",
+    "import-meta-resolve": "^4.2.0",
+    "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "magicast": "^0.5.1",
+    "mrmime": "^2.0.1",
+    "neotraverse": "^0.6.18",
+    "p-limit": "^6.2.0",
+    "p-queue": "^8.1.1",
+    "package-manager-detector": "^1.6.0",
+    "piccolore": "^0.1.3",
+    "picomatch": "^4.0.3",
+    "prompts": "^2.4.2",
+    "rehype": "^13.0.2",
+    "semver": "^7.7.3",
+    "shiki": "^3.21.0",
+    "smol-toml": "^1.6.0",
+    "svgo": "^4.0.0",
+    "tinyexec": "^1.0.2",
+    "tinyglobby": "^0.2.15",
+    "tsconfck": "^3.1.6",
+    "ultrahtml": "^1.6.0",
+    "unifont": "~0.7.3",
+    "unist-util-visit": "^5.0.0",
+    "unstorage": "^1.17.4",
+    "vfile": "^6.0.3",
+    "vite": "^6.4.1",
+    "vitefu": "^1.1.1",
+    "xxhash-wasm": "^1.1.0",
+    "yargs-parser": "^21.1.1",
+    "yocto-spinner": "^0.2.3",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1",
+    "zod-to-ts": "^1.2.0"
+   },
+   "bin": {
+    "astro": "astro.js"
+   },
+   "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+    "npm": ">=9.6.5",
+    "pnpm": ">=7.1.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/astrodotbuild"
+   },
+   "optionalDependencies": {
+    "sharp": "^0.34.0"
+   }
+  },
+  "node_modules/astro/node_modules/lru-cache": {
+   "version": "11.5.2",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+   "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": "20 || >=22"
+   }
+  },
+  "node_modules/astro/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/astro/node_modules/unstorage": {
+   "version": "1.17.5",
+   "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+   "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+   "license": "MIT",
+   "dependencies": {
+    "anymatch": "^3.1.3",
+    "chokidar": "^5.0.0",
+    "destr": "^2.0.5",
+    "h3": "^1.15.10",
+    "lru-cache": "^11.2.7",
+    "node-fetch-native": "^1.6.7",
+    "ofetch": "^1.5.1",
+    "ufo": "^1.6.3"
+   },
+   "peerDependencies": {
+    "@azure/app-configuration": "^1.8.0",
+    "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.6.0",
+    "@azure/keyvault-secrets": "^4.9.0",
+    "@azure/storage-blob": "^12.26.0",
+    "@capacitor/preferences": "^6 || ^7 || ^8",
+    "@deno/kv": ">=0.9.0",
+    "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+    "@planetscale/database": "^1.19.0",
+    "@upstash/redis": "^1.34.3",
+    "@vercel/blob": ">=0.27.1",
+    "@vercel/functions": "^2.2.12 || ^3.0.0",
+    "@vercel/kv": "^1 || ^2 || ^3",
+    "aws4fetch": "^1.0.20",
+    "db0": ">=0.2.1",
+    "idb-keyval": "^6.2.1",
+    "ioredis": "^5.4.2",
+    "uploadthing": "^7.4.4"
+   },
+   "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+     "optional": true
+    },
+    "@azure/cosmos": {
+     "optional": true
+    },
+    "@azure/data-tables": {
+     "optional": true
+    },
+    "@azure/identity": {
+     "optional": true
+    },
+    "@azure/keyvault-secrets": {
+     "optional": true
+    },
+    "@azure/storage-blob": {
+     "optional": true
+    },
+    "@capacitor/preferences": {
+     "optional": true
+    },
+    "@deno/kv": {
+     "optional": true
+    },
+    "@netlify/blobs": {
+     "optional": true
+    },
+    "@planetscale/database": {
+     "optional": true
+    },
+    "@upstash/redis": {
+     "optional": true
+    },
+    "@vercel/blob": {
+     "optional": true
+    },
+    "@vercel/functions": {
+     "optional": true
+    },
+    "@vercel/kv": {
+     "optional": true
+    },
+    "aws4fetch": {
+     "optional": true
+    },
+    "db0": {
+     "optional": true
+    },
+    "idb-keyval": {
+     "optional": true
+    },
+    "ioredis": {
+     "optional": true
+    },
+    "uploadthing": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/astro/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/astro/node_modules/zod-to-ts": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+   "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+   "peerDependencies": {
+    "typescript": "^4.9.4 || ^5.0.2",
+    "zod": "^3"
+   }
+  },
+  "node_modules/axobject-query": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+   "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">= 0.4"
+   }
+  },
+  "node_modules/bail": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+   "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/balanced-match": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+   "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/base-64": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+   "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+   "license": "MIT"
+  },
+  "node_modules/baseline-browser-mapping": {
+   "version": "2.11.13",
+   "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+   "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+   "dev": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "baseline-browser-mapping": "dist/cli.cjs"
+   },
+   "engines": {
+    "node": ">=6.0.0"
+   }
+  },
+  "node_modules/blake3-wasm": {
+   "version": "2.1.5",
+   "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+   "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/boolbase": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+   "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+   "license": "ISC"
+  },
+  "node_modules/boxen": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+   "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-align": "^3.0.1",
+    "camelcase": "^8.0.0",
+    "chalk": "^5.3.0",
+    "cli-boxes": "^3.0.0",
+    "string-width": "^7.2.0",
+    "type-fest": "^4.21.0",
+    "widest-line": "^5.0.0",
+    "wrap-ansi": "^9.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/brace-expansion": {
+   "version": "1.1.18",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+   "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "balanced-match": "^1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "node_modules/browserslist": {
+   "version": "4.28.8",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+   "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "baseline-browser-mapping": "^2.11.12",
+    "caniuse-lite": "^1.0.30001809",
+    "electron-to-chromium": "^1.5.402",
+    "node-releases": "^2.0.53",
+    "update-browserslist-db": "^1.3.0"
+   },
+   "bin": {
+    "browserslist": "cli.js"
+   },
+   "engines": {
+    "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+   }
+  },
+  "node_modules/cacache": {
+   "version": "15.3.0",
+   "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+   "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "@npmcli/fs": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "glob": "^7.1.4",
+    "infer-owner": "^1.0.4",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.1",
+    "minipass-collect": "^1.0.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.2",
+    "mkdirp": "^1.0.3",
+    "p-map": "^4.0.0",
+    "promise-inflight": "^1.0.1",
+    "rimraf": "^3.0.2",
+    "ssri": "^8.0.1",
+    "tar": "^6.0.2",
+    "unique-filename": "^1.1.1"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/cacache/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/cacache/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/camelcase": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+   "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/caniuse-lite": {
+   "version": "1.0.30001809",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+   "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "CC-BY-4.0"
+  },
+  "node_modules/ccount": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+   "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chalk": {
+   "version": "5.6.2",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+   "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+   "license": "MIT",
+   "engines": {
+    "node": "^12.17.0 || ^14.13 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/chalk?sponsor=1"
+   }
+  },
+  "node_modules/character-entities": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+   "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-html4": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+   "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/character-entities-legacy": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+   "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/chokidar": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+   "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+   "license": "MIT",
+   "dependencies": {
+    "readdirp": "^5.0.0"
+   },
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/chownr": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+   "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ci-info": {
+   "version": "4.4.0",
+   "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+   "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/sibiraj-s"
+    }
+   ],
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/clean-stack": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+   "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/cli-boxes": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+   "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/clsx": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+   "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/color-support": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+   "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "color-support": "bin.js"
+   }
+  },
+  "node_modules/comlink": {
+   "version": "4.3.0",
+   "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+   "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==",
+   "license": "Apache-2.0"
+  },
+  "node_modules/comma-separated-tokens": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+   "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/commander": {
+   "version": "11.1.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+   "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=16"
+   }
+  },
+  "node_modules/common-ancestor-path": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+   "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+   "license": "ISC"
+  },
+  "node_modules/concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/console-control-strings": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+   "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/convert-source-map": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+   "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/cookie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+   "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/express"
+   }
+  },
+  "node_modules/cookie-es": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+   "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+   "license": "MIT"
+  },
+  "node_modules/crossws": {
+   "version": "0.3.5",
+   "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+   "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+   "license": "MIT",
+   "dependencies": {
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/css-select": {
+   "version": "5.2.2",
+   "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+   "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0",
+    "css-what": "^6.1.0",
+    "domhandler": "^5.0.2",
+    "domutils": "^3.0.1",
+    "nth-check": "^2.0.1"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/css-tree": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+   "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.27.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+   }
+  },
+  "node_modules/css-what": {
+   "version": "6.2.2",
+   "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+   "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">= 6"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/fb55"
+   }
+  },
+  "node_modules/cssesc": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+   "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+   "license": "MIT",
+   "bin": {
+    "cssesc": "bin/cssesc"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/csso": {
+   "version": "5.0.5",
+   "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+   "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "~2.2.0"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/css-tree": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+   "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+   "license": "MIT",
+   "dependencies": {
+    "mdn-data": "2.0.28",
+    "source-map-js": "^1.0.1"
+   },
+   "engines": {
+    "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+    "npm": ">=7.0.0"
+   }
+  },
+  "node_modules/csso/node_modules/mdn-data": {
+   "version": "2.0.28",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+   "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/csstype": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+   "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+   "devOptional": true,
+   "license": "MIT"
+  },
+  "node_modules/debug": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+   "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.1.3"
+   },
+   "engines": {
+    "node": ">=6.0"
+   },
+   "peerDependenciesMeta": {
+    "supports-color": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/decimal.js": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+   "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+   "license": "MIT"
+  },
+  "node_modules/decode-named-character-reference": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+   "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/defu": {
+   "version": "6.1.7",
+   "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+   "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+   "license": "MIT"
+  },
+  "node_modules/delegates": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+   "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/dequal": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+   "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/destr": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+   "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+   "license": "MIT"
+  },
+  "node_modules/detect-libc": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+   "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+   "license": "Apache-2.0",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT",
+   "peer": true
+  },
+  "node_modules/deterministic-object-hash": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+   "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "base-64": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/devalue": {
+   "version": "5.9.0",
+   "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+   "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+   "license": "MIT"
+  },
+  "node_modules/devlop": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+   "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+   "license": "MIT",
+   "dependencies": {
+    "dequal": "^2.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/diff": {
+   "version": "8.0.4",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+   "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.3.1"
+   }
+  },
+  "node_modules/dlv": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+   "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+   "license": "MIT"
+  },
+  "node_modules/dom-serializer": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+   "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+   "license": "MIT",
+   "dependencies": {
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.2",
+    "entities": "^4.2.0"
+   },
+   "funding": {
+    "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+   }
+  },
+  "node_modules/dom-serializer/node_modules/entities": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+   "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/domelementtype": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+   "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/fb55"
+    }
+   ],
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/domhandler": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+   "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "domelementtype": "^2.3.0"
+   },
+   "engines": {
+    "node": ">= 4"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domhandler?sponsor=1"
+   }
+  },
+  "node_modules/domutils": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+   "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domelementtype": "^2.3.0",
+    "domhandler": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/domutils?sponsor=1"
+   }
+  },
+  "node_modules/dset": {
+   "version": "3.1.4",
+   "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+   "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/electron-to-chromium": {
+   "version": "1.5.405",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+   "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/emoji-regex": {
+   "version": "10.6.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+   "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+   "license": "MIT"
+  },
+  "node_modules/encoding": {
+   "version": "0.1.13",
+   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+   "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "iconv-lite": "^0.6.2"
+   }
+  },
+  "node_modules/enhanced-resolve": {
+   "version": "5.24.5",
+   "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+   "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+   "license": "MIT",
+   "dependencies": {
+    "graceful-fs": "^4.2.4",
+    "tapable": "^2.3.3"
+   },
+   "engines": {
+    "node": ">=10.13.0"
+   }
+  },
+  "node_modules/entities": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+   "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+   "license": "BSD-2-Clause",
+   "engines": {
+    "node": ">=0.12"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/entities?sponsor=1"
+   }
+  },
+  "node_modules/env-paths": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+   "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/err-code": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+   "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/error-stack-parser-es": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+   "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/antfu"
+   }
+  },
+  "node_modules/es-module-lexer": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+   "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+   "license": "MIT"
+  },
+  "node_modules/esbuild": {
+   "version": "0.27.7",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+   "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.7",
+    "@esbuild/android-arm": "0.27.7",
+    "@esbuild/android-arm64": "0.27.7",
+    "@esbuild/android-x64": "0.27.7",
+    "@esbuild/darwin-arm64": "0.27.7",
+    "@esbuild/darwin-x64": "0.27.7",
+    "@esbuild/freebsd-arm64": "0.27.7",
+    "@esbuild/freebsd-x64": "0.27.7",
+    "@esbuild/linux-arm": "0.27.7",
+    "@esbuild/linux-arm64": "0.27.7",
+    "@esbuild/linux-ia32": "0.27.7",
+    "@esbuild/linux-loong64": "0.27.7",
+    "@esbuild/linux-mips64el": "0.27.7",
+    "@esbuild/linux-ppc64": "0.27.7",
+    "@esbuild/linux-riscv64": "0.27.7",
+    "@esbuild/linux-s390x": "0.27.7",
+    "@esbuild/linux-x64": "0.27.7",
+    "@esbuild/netbsd-arm64": "0.27.7",
+    "@esbuild/netbsd-x64": "0.27.7",
+    "@esbuild/openbsd-arm64": "0.27.7",
+    "@esbuild/openbsd-x64": "0.27.7",
+    "@esbuild/openharmony-arm64": "0.27.7",
+    "@esbuild/sunos-x64": "0.27.7",
+    "@esbuild/win32-arm64": "0.27.7",
+    "@esbuild/win32-ia32": "0.27.7",
+    "@esbuild/win32-x64": "0.27.7"
+   }
+  },
+  "node_modules/escalade": {
+   "version": "3.2.0",
+   "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+   "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/escape-string-regexp": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+   "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/estree-walker": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+   "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "^1.0.0"
+   }
+  },
+  "node_modules/eventemitter3": {
+   "version": "5.0.4",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+   "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+   "license": "MIT"
+  },
+  "node_modules/events": {
+   "version": "3.3.0",
+   "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+   "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.x"
+   }
+  },
+  "node_modules/extend": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+   "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+   "license": "MIT"
+  },
+  "node_modules/fdir": {
+   "version": "6.5.0",
+   "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+   "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "peerDependencies": {
+    "picomatch": "^3 || ^4"
+   },
+   "peerDependenciesMeta": {
+    "picomatch": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/flattie": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+   "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/fontace": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+   "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+   "license": "MIT",
+   "dependencies": {
+    "fontkitten": "^1.0.2"
+   }
+  },
+  "node_modules/fontkitten": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+   "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+   "license": "MIT",
+   "dependencies": {
+    "tiny-inflate": "^1.0.3"
+   },
+   "engines": {
+    "node": ">=20"
+   }
+  },
+  "node_modules/fs-minipass": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+   "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/fsevents": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+   "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+   }
+  },
+  "node_modules/gauge": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+   "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "aproba": "^1.0.3 || ^2.0.0",
+    "color-support": "^1.1.3",
+    "console-control-strings": "^1.1.0",
+    "has-unicode": "^2.0.1",
+    "signal-exit": "^3.0.7",
+    "string-width": "^4.2.3",
+    "strip-ansi": "^6.0.1",
+    "wide-align": "^1.1.5"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/gauge/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/gauge/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/gensync": {
+   "version": "1.0.0-beta.2",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+   "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=6.9.0"
+   }
+  },
+  "node_modules/get-east-asian-width": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+   "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "peer": true,
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/github-slugger": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+   "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+   "license": "ISC"
+  },
+  "node_modules/glob": {
+   "version": "7.2.3",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+   "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+   "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "fs.realpath": "^1.0.0",
+    "inflight": "^1.0.4",
+    "inherits": "2",
+    "minimatch": "^3.1.1",
+    "once": "^1.3.0",
+    "path-is-absolute": "^1.0.0"
+   },
+   "engines": {
+    "node": "*"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/graceful-fs": {
+   "version": "4.2.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+   "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+   "license": "ISC"
+  },
+  "node_modules/graphql": {
+   "version": "17.0.2",
+   "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
+   "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
+   "license": "MIT",
+   "optional": true,
+   "engines": {
+    "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+   }
+  },
+  "node_modules/h3": {
+   "version": "1.15.11",
+   "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+   "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+   "license": "MIT",
+   "dependencies": {
+    "cookie-es": "^1.2.3",
+    "crossws": "^0.3.5",
+    "defu": "^6.1.6",
+    "destr": "^2.0.5",
+    "iron-webcrypto": "^1.2.1",
+    "node-mock-http": "^1.0.4",
+    "radix3": "^1.1.2",
+    "ufo": "^1.6.3",
+    "uncrypto": "^0.1.3"
+   }
+  },
+  "node_modules/has-unicode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+   "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/hast-util-from-html": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+   "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "devlop": "^1.1.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "parse5": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-from-parse5": {
+   "version": "8.0.3",
+   "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+   "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "devlop": "^1.0.0",
+    "hastscript": "^9.0.0",
+    "property-information": "^7.0.0",
+    "vfile": "^6.0.0",
+    "vfile-location": "^5.0.0",
+    "web-namespaces": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-is-element": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+   "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-parse-selector": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+   "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-raw": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+   "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "hast-util-from-parse5": "^8.0.0",
+    "hast-util-to-parse5": "^8.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "parse5": "^7.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-html": {
+   "version": "9.0.5",
+   "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+   "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "ccount": "^2.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-whitespace": "^3.0.0",
+    "html-void-elements": "^3.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "stringify-entities": "^4.0.0",
+    "zwitch": "^2.0.4"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-parse5": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+   "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "devlop": "^1.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0",
+    "web-namespaces": "^2.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-to-text": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+   "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/unist": "^3.0.0",
+    "hast-util-is-element": "^3.0.0",
+    "unist-util-find-after": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hast-util-whitespace": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+   "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/hastscript": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+   "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "comma-separated-tokens": "^2.0.0",
+    "hast-util-parse-selector": "^4.0.0",
+    "property-information": "^7.0.0",
+    "space-separated-tokens": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/html-escaper": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+   "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+   "license": "MIT"
+  },
+  "node_modules/html-parse-stringify": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+   "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "void-elements": "3.1.0"
+   }
+  },
+  "node_modules/html-void-elements": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+   "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/http-cache-semantics": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+   "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+   "license": "BSD-2-Clause"
+  },
+  "node_modules/http-proxy-agent": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+   "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@tootallnate/once": "1",
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/http-status-codes": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+   "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+   "license": "MIT"
+  },
+  "node_modules/https-proxy-agent": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+   "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "6",
+    "debug": "4"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/humanize-ms": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+   "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ms": "^2.0.0"
+   }
+  },
+  "node_modules/i18next": {
+   "version": "25.10.10",
+   "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+   "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+   "funding": [
+    {
+     "type": "individual",
+     "url": "https://www.locize.com/i18next"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+    },
+    {
+     "type": "individual",
+     "url": "https://www.locize.com"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2"
+   },
+   "peerDependencies": {
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/i18next-icu": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.4.4.tgz",
+   "integrity": "sha512-yfYdGTftClNUnZAQG1cu0yHHLaMVsrqfcgQHHchGDufkunBLKHuw2wXTCDuE+8mWMMcdePl8UBR0EUUA/3+FDw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "intl-messageformat": ">=10.3.3 <12.0.0"
+   }
+  },
+  "node_modules/iconv-lite": {
+   "version": "0.6.3",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+   "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "dependencies": {
+    "safer-buffer": ">= 2.1.2 < 3.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/import-meta-resolve": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+   "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/imurmurhash": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+   "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.8.19"
+   }
+  },
+  "node_modules/indent-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+   "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/infer-owner": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+   "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+   "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "once": "^1.3.0",
+    "wrappy": "1"
+   }
+  },
+  "node_modules/inherits": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+   "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/intl-messageformat": {
+   "version": "10.7.18",
+   "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+   "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+   "license": "BSD-3-Clause",
+   "dependencies": {
+    "@formatjs/ecma402-abstract": "2.3.6",
+    "@formatjs/fast-memoize": "2.2.7",
+    "@formatjs/icu-messageformat-parser": "2.11.4",
+    "tslib": "^2.8.0"
+   }
+  },
+  "node_modules/ip-address": {
+   "version": "10.5.0",
+   "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+   "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 12"
+   }
+  },
+  "node_modules/iron-webcrypto": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+   "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/brc-dd"
+   }
+  },
+  "node_modules/is-docker": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+   "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+   "license": "MIT",
+   "bin": {
+    "is-docker": "cli.js"
+   },
+   "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-fullwidth-code-point": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+   "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/is-inside-container": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+   "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+   "license": "MIT",
+   "dependencies": {
+    "is-docker": "^3.0.0"
+   },
+   "bin": {
+    "is-inside-container": "cli.js"
+   },
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-lambda": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+   "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/is-plain-obj": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+   "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/is-wsl": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+   "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+   "license": "MIT",
+   "dependencies": {
+    "is-inside-container": "^1.0.0"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/jiti": {
+   "version": "2.7.0",
+   "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+   "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+   "license": "MIT",
+   "bin": {
+    "jiti": "lib/jiti-cli.mjs"
+   }
+  },
+  "node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/js-tokens": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+   "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+   "license": "MIT"
+  },
+  "node_modules/js-yaml": {
+   "version": "4.3.1",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+   "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/nodeca"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "argparse": "^2.0.1"
+   },
+   "bin": {
+    "js-yaml": "bin/js-yaml.js"
+   }
+  },
+  "node_modules/jsesc": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+   "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "jsesc": "bin/jsesc"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/json5": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+   "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "json5": "lib/cli.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/kleur": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+   "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/lightningcss": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+   "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+   "license": "MPL-2.0",
+   "dependencies": {
+    "detect-libc": "^2.0.3"
+   },
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   },
+   "optionalDependencies": {
+    "lightningcss-android-arm64": "1.32.0",
+    "lightningcss-darwin-arm64": "1.32.0",
+    "lightningcss-darwin-x64": "1.32.0",
+    "lightningcss-freebsd-x64": "1.32.0",
+    "lightningcss-linux-arm-gnueabihf": "1.32.0",
+    "lightningcss-linux-arm64-gnu": "1.32.0",
+    "lightningcss-linux-arm64-musl": "1.32.0",
+    "lightningcss-linux-x64-gnu": "1.32.0",
+    "lightningcss-linux-x64-musl": "1.32.0",
+    "lightningcss-win32-arm64-msvc": "1.32.0",
+    "lightningcss-win32-x64-msvc": "1.32.0"
+   }
+  },
+  "node_modules/lightningcss-android-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+   "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-arm64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+   "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-darwin-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+   "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-freebsd-x64": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+   "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm-gnueabihf": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+   "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+   "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-arm64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+   "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-gnu": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+   "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-linux-x64-musl": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+   "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-arm64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+   "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lightningcss-win32-x64-msvc": {
+   "version": "1.32.0",
+   "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+   "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MPL-2.0",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">= 12.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+   }
+  },
+  "node_modules/lodash": {
+   "version": "4.18.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+   "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+   "license": "MIT"
+  },
+  "node_modules/longest-streak": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+   "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/loose-envify": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "js-tokens": "^3.0.0 || ^4.0.0"
+   },
+   "bin": {
+    "loose-envify": "cli.js"
+   }
+  },
+  "node_modules/lru-cache": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+   "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^3.0.2"
+   }
+  },
+  "node_modules/magic-string": {
+   "version": "0.30.21",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+   "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5"
+   }
+  },
+  "node_modules/magicast": {
+   "version": "0.5.4",
+   "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+   "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/parser": "^7.29.7",
+    "@babel/types": "^7.29.7",
+    "source-map-js": "^1.2.1"
+   }
+  },
+  "node_modules/make-fetch-happen": {
+   "version": "9.1.0",
+   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+   "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "agentkeepalive": "^4.1.3",
+    "cacache": "^15.2.0",
+    "http-cache-semantics": "^4.1.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "is-lambda": "^1.0.1",
+    "lru-cache": "^6.0.0",
+    "minipass": "^3.1.3",
+    "minipass-collect": "^1.0.2",
+    "minipass-fetch": "^1.3.2",
+    "minipass-flush": "^1.0.5",
+    "minipass-pipeline": "^1.2.4",
+    "negotiator": "^0.6.2",
+    "promise-retry": "^2.0.1",
+    "socks-proxy-agent": "^6.0.0",
+    "ssri": "^8.0.0"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/make-fetch-happen/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/markdown-table": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+   "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/mdast-util-definitions": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+   "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-find-and-replace": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+   "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-from-markdown": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+   "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark": "^4.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+   "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+   "license": "MIT",
+   "dependencies": {
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.0",
+    "mdast-util-gfm-footnote": "^2.0.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-autolink-literal": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+   "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "ccount": "^2.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-find-and-replace": "^3.0.0",
+    "micromark-util-character": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.1.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-strikethrough": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+   "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-table": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+   "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "markdown-table": "^3.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-gfm-task-list-item": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+   "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "devlop": "^1.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "mdast-util-to-markdown": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-phrasing": {
+   "version": "4.1.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+   "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-hast": {
+   "version": "13.2.1",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+   "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "@ungap/structured-clone": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "trim-lines": "^3.0.0",
+    "unist-util-position": "^5.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-markdown": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+   "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "@types/unist": "^3.0.0",
+    "longest-streak": "^3.0.0",
+    "mdast-util-phrasing": "^4.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-decode-string": "^2.0.0",
+    "unist-util-visit": "^5.0.0",
+    "zwitch": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdast-util-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+   "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/mdn-data": {
+   "version": "2.27.1",
+   "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+   "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+   "license": "CC0-1.0"
+  },
+  "node_modules/micromark": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+   "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "@types/debug": "^4.0.0",
+    "debug": "^4.0.0",
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-core-commonmark": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+   "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "devlop": "^1.0.0",
+    "micromark-factory-destination": "^2.0.0",
+    "micromark-factory-label": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-factory-title": "^2.0.0",
+    "micromark-factory-whitespace": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-html-tag-name": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-subtokenize": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-extension-gfm": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+   "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-extension-gfm-autolink-literal": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
+    "micromark-extension-gfm-table": "^2.0.0",
+    "micromark-extension-gfm-tagfilter": "^2.0.0",
+    "micromark-extension-gfm-task-list-item": "^2.0.0",
+    "micromark-util-combine-extensions": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-autolink-literal": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+   "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-footnote": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+   "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-core-commonmark": "^2.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-normalize-identifier": "^2.0.0",
+    "micromark-util-sanitize-uri": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-strikethrough": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+   "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
+    "micromark-util-resolve-all": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-table": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+   "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-tagfilter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+   "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-extension-gfm-task-list-item": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+   "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/micromark-factory-destination": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+   "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-label": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+   "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-space": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+   "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-title": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+   "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-factory-whitespace": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+   "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-character": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+   "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-chunked": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+   "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-classify-character": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+   "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-combine-extensions": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+   "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-numeric-character-reference": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+   "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-decode-string": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+   "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "decode-named-character-reference": "^1.0.0",
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-encode": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+   "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-html-tag-name": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+   "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-normalize-identifier": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+   "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-resolve-all": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+   "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-sanitize-uri": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+   "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "micromark-util-character": "^2.0.0",
+    "micromark-util-encode": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-subtokenize": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+   "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "devlop": "^1.0.0",
+    "micromark-util-chunked": "^2.0.0",
+    "micromark-util-symbol": "^2.0.0",
+    "micromark-util-types": "^2.0.0"
+   }
+  },
+  "node_modules/micromark-util-symbol": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+   "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/micromark-util-types": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+   "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+   "funding": [
+    {
+     "type": "GitHub Sponsors",
+     "url": "https://github.com/sponsors/unifiedjs"
+    },
+    {
+     "type": "OpenCollective",
+     "url": "https://opencollective.com/unified"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/miniflare": {
+   "version": "4.20260114.0",
+   "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260114.0.tgz",
+   "integrity": "sha512-QwHT7S6XqGdQxIvql1uirH/7/i3zDEt0B/YBXTYzMfJtVCR4+ue3KPkU+Bl0zMxvpgkvjh9+eCHhJbKEqya70A==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@cspotcode/source-map-support": "0.8.1",
+    "sharp": "^0.34.5",
+    "undici": "7.14.0",
+    "workerd": "1.20260114.0",
+    "ws": "8.18.0",
+    "youch": "4.1.0-beta.10",
+    "zod": "^3.25.76"
+   },
+   "bin": {
+    "miniflare": "bootstrap.js"
+   },
+   "engines": {
+    "node": ">=18.0.0"
+   }
+  },
+  "node_modules/miniflare/node_modules/undici": {
+   "version": "7.14.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+   "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=20.18.1"
+   }
+  },
+  "node_modules/miniflare/node_modules/zod": {
+   "version": "3.25.76",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+   "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+   "dev": true,
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/minimatch": {
+   "version": "3.1.5",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+   "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "brace-expansion": "^1.1.7"
+   },
+   "engines": {
+    "node": "*"
+   }
+  },
+  "node_modules/minipass": {
+   "version": "3.3.6",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+   "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-collect": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+   "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-fetch": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+   "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.1.0",
+    "minipass-sized": "^1.0.3",
+    "minizlib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   },
+   "optionalDependencies": {
+    "encoding": "^0.1.12"
+   }
+  },
+  "node_modules/minipass-flush": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+   "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+   "dev": true,
+   "license": "BlueOak-1.0.0",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minipass-pipeline": {
+   "version": "1.2.4",
+   "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+   "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass-sized": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+   "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/minipass/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/minizlib": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+   "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "minipass": "^3.0.0",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/minizlib/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/mkdirp": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+   "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+   "dev": true,
+   "license": "MIT",
+   "bin": {
+    "mkdirp": "bin/cmd.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/mrmime": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+   "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/ms": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+   "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+   "license": "MIT"
+  },
+  "node_modules/nanoid": {
+   "version": "3.3.18",
+   "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+   "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "bin": {
+    "nanoid": "bin/nanoid.cjs"
+   },
+   "engines": {
+    "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+   }
+  },
+  "node_modules/negotiator": {
+   "version": "0.6.4",
+   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+   "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/neotraverse": {
+   "version": "0.6.18",
+   "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+   "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/nlcst-to-string": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+   "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/node-fetch-native": {
+   "version": "1.6.7",
+   "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+   "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+   "license": "MIT"
+  },
+  "node_modules/node-gyp": {
+   "version": "8.4.1",
+   "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+   "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "env-paths": "^2.2.0",
+    "glob": "^7.1.4",
+    "graceful-fs": "^4.2.6",
+    "make-fetch-happen": "^9.1.0",
+    "nopt": "^5.0.0",
+    "npmlog": "^6.0.0",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
+    "tar": "^6.1.2",
+    "which": "^2.0.2"
+   },
+   "bin": {
+    "node-gyp": "bin/node-gyp.js"
+   },
+   "engines": {
+    "node": ">= 10.12.0"
+   }
+  },
+  "node_modules/node-gyp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/node-mock-http": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+   "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+   "license": "MIT"
+  },
+  "node_modules/node-releases": {
+   "version": "2.0.53",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+   "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/nopt": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+   "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "abbrev": "1"
+   },
+   "bin": {
+    "nopt": "bin/nopt.js"
+   },
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/normalize-path": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+   "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/npmlog": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+   "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+   "deprecated": "This package is no longer supported.",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "are-we-there-yet": "^3.0.0",
+    "console-control-strings": "^1.1.0",
+    "gauge": "^4.0.3",
+    "set-blocking": "^2.0.0"
+   },
+   "engines": {
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+   }
+  },
+  "node_modules/nth-check": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+   "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+   "license": "BSD-2-Clause",
+   "dependencies": {
+    "boolbase": "^1.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/fb55/nth-check?sponsor=1"
+   }
+  },
+  "node_modules/ofetch": {
+   "version": "1.5.1",
+   "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+   "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+   "license": "MIT",
+   "dependencies": {
+    "destr": "^2.0.5",
+    "node-fetch-native": "^1.6.7",
+    "ufo": "^1.6.1"
+   }
+  },
+  "node_modules/ohash": {
+   "version": "2.0.11",
+   "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+   "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+   "license": "MIT"
+  },
+  "node_modules/once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "wrappy": "1"
+   }
+  },
+  "node_modules/oniguruma-parser": {
+   "version": "0.12.2",
+   "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+   "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+   "license": "MIT"
+  },
+  "node_modules/oniguruma-to-es": {
+   "version": "4.3.6",
+   "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+   "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+   "license": "MIT",
+   "dependencies": {
+    "oniguruma-parser": "^0.12.2",
+    "regex": "^6.1.0",
+    "regex-recursion": "^6.0.2"
+   }
+  },
+  "node_modules/p-limit": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+   "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+   "license": "MIT",
+   "dependencies": {
+    "yocto-queue": "^1.1.1"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-map": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+   "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "aggregate-error": "^3.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-queue": {
+   "version": "8.1.1",
+   "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+   "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+   "license": "MIT",
+   "dependencies": {
+    "eventemitter3": "^5.0.1",
+    "p-timeout": "^6.1.2"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/p-timeout": {
+   "version": "6.1.4",
+   "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+   "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=14.16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/package-manager-detector": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+   "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+   "license": "MIT"
+  },
+  "node_modules/parse-latin": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+   "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "@types/unist": "^3.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-modify-children": "^4.0.0",
+    "unist-util-visit-children": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/parse5": {
+   "version": "7.3.0",
+   "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+   "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+   "license": "MIT",
+   "dependencies": {
+    "entities": "^6.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/inikulin/parse5?sponsor=1"
+   }
+  },
+  "node_modules/path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/path-to-regexp": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+   "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/pathe": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+   "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/piccolore": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+   "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+   "license": "ISC"
+  },
+  "node_modules/picocolors": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+   "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+   "license": "ISC"
+  },
+  "node_modules/picomatch": {
+   "version": "4.0.5",
+   "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+   "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/jonschlinkert"
+   }
+  },
+  "node_modules/postcss": {
+   "version": "8.5.26",
+   "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+   "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/postcss/"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/postcss"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "nanoid": "^3.3.17",
+    "picocolors": "^1.1.1",
+    "source-map-js": "^1.2.1"
+   },
+   "engines": {
+    "node": "^10 || ^12 || >=14"
+   }
+  },
+  "node_modules/prismjs": {
+   "version": "1.30.0",
+   "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+   "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/promise-inflight": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+   "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/promise-retry": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+   "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "err-code": "^2.0.2",
+    "retry": "^0.12.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/prompts": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+   "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+   "license": "MIT",
+   "dependencies": {
+    "kleur": "^3.0.3",
+    "sisteransi": "^1.0.5"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/property-information": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+   "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/radix3": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+   "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+   "license": "MIT"
+  },
+  "node_modules/react": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+   "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-dom": {
+   "version": "18.3.1",
+   "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+   "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0",
+    "scheduler": "^0.23.2"
+   },
+   "peerDependencies": {
+    "react": "^18.3.1"
+   }
+  },
+  "node_modules/react-i18next": {
+   "version": "16.6.6",
+   "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+   "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@babel/runtime": "^7.29.2",
+    "html-parse-stringify": "^3.0.1",
+    "use-sync-external-store": "^1.6.0"
+   },
+   "peerDependencies": {
+    "i18next": ">= 25.10.9",
+    "react": ">= 16.8.0",
+    "typescript": "^5 || ^6"
+   },
+   "peerDependenciesMeta": {
+    "react-dom": {
+     "optional": true
+    },
+    "react-native": {
+     "optional": true
+    },
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-refresh": {
+   "version": "0.17.0",
+   "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+   "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/readable-stream": {
+   "version": "3.6.2",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+   "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "inherits": "^2.0.3",
+    "string_decoder": "^1.1.1",
+    "util-deprecate": "^1.0.1"
+   },
+   "engines": {
+    "node": ">= 6"
+   }
+  },
+  "node_modules/readdirp": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+   "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 20.19.0"
+   },
+   "funding": {
+    "type": "individual",
+    "url": "https://paulmillr.com/funding/"
+   }
+  },
+  "node_modules/regex": {
+   "version": "6.1.0",
+   "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+   "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-recursion": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+   "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+   "license": "MIT",
+   "dependencies": {
+    "regex-utilities": "^2.3.0"
+   }
+  },
+  "node_modules/regex-utilities": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+   "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+   "license": "MIT"
+  },
+  "node_modules/rehype": {
+   "version": "13.0.2",
+   "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+   "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-stringify": "^10.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-parse": {
+   "version": "9.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+   "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-from-html": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-raw": {
+   "version": "7.0.0",
+   "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+   "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-raw": "^9.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/rehype-stringify": {
+   "version": "10.0.1",
+   "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+   "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "hast-util-to-html": "^9.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-gfm": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+   "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-parse": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+   "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
+    "micromark-util-types": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-rehype": {
+   "version": "11.1.2",
+   "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+   "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/hast": "^3.0.0",
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-hast": "^13.0.0",
+    "unified": "^11.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/remark-smartypants": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+   "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+   "license": "MIT",
+   "dependencies": {
+    "retext": "^9.0.0",
+    "retext-smartypants": "^6.0.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+   },
+   "engines": {
+    "node": ">=16.0.0"
+   }
+  },
+  "node_modules/remark-stringify": {
+   "version": "11.0.0",
+   "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+   "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/mdast": "^4.0.0",
+    "mdast-util-to-markdown": "^2.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext": {
+   "version": "9.0.0",
+   "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+   "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "retext-latin": "^4.0.0",
+    "retext-stringify": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-latin": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+   "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "parse-latin": "^7.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-smartypants": {
+   "version": "6.2.0",
+   "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+   "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retext-stringify": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+   "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/nlcst": "^2.0.0",
+    "nlcst-to-string": "^4.0.0",
+    "unified": "^11.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/retry": {
+   "version": "0.12.0",
+   "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+   "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 4"
+   }
+  },
+  "node_modules/rimraf": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+   "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+   "deprecated": "Rimraf versions prior to v4 are no longer supported",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "glob": "^7.1.3"
+   },
+   "bin": {
+    "rimraf": "bin.js"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/isaacs"
+   }
+  },
+  "node_modules/rollup": {
+   "version": "4.62.4",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+   "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/estree": "1.0.9"
+   },
+   "bin": {
+    "rollup": "dist/bin/rollup"
+   },
+   "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+   },
+   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+    "@rollup/rollup-android-arm-eabi": "4.62.4",
+    "@rollup/rollup-android-arm64": "4.62.4",
+    "@rollup/rollup-darwin-arm64": "4.62.4",
+    "@rollup/rollup-darwin-x64": "4.62.4",
+    "@rollup/rollup-freebsd-arm64": "4.62.4",
+    "@rollup/rollup-freebsd-x64": "4.62.4",
+    "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+    "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+    "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+    "@rollup/rollup-linux-arm64-musl": "4.62.4",
+    "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+    "@rollup/rollup-linux-loong64-musl": "4.62.4",
+    "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+    "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+    "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+    "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+    "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-gnu": "4.62.4",
+    "@rollup/rollup-linux-x64-musl": "4.62.4",
+    "@rollup/rollup-openbsd-x64": "4.62.4",
+    "@rollup/rollup-openharmony-arm64": "4.62.4",
+    "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+    "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+    "@rollup/rollup-win32-x64-gnu": "4.62.4",
+    "@rollup/rollup-win32-x64-msvc": "4.62.4",
+    "fsevents": "~2.3.2"
+   }
+  },
+  "node_modules/safe-buffer": {
+   "version": "5.2.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+   "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/feross"
+    },
+    {
+     "type": "patreon",
+     "url": "https://www.patreon.com/feross"
+    },
+    {
+     "type": "consulting",
+     "url": "https://feross.org/support"
+    }
+   ],
+   "license": "MIT"
+  },
+  "node_modules/safer-buffer": {
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+   "dev": true,
+   "license": "MIT",
+   "optional": true
+  },
+  "node_modules/sax": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+   "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+   "license": "BlueOak-1.0.0",
+   "engines": {
+    "node": ">=11.0.0"
+   }
+  },
+  "node_modules/scheduler": {
+   "version": "0.23.2",
+   "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+   "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+   "license": "MIT",
+   "dependencies": {
+    "loose-envify": "^1.1.0"
+   }
+  },
+  "node_modules/semver": {
+   "version": "6.3.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+   "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+   "dev": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   }
+  },
+  "node_modules/set-blocking": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+   "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sharp": {
+   "version": "0.34.5",
+   "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+   "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+   "devOptional": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@img/colour": "^1.0.0",
+    "detect-libc": "^2.1.2",
+    "semver": "^7.7.3"
+   },
+   "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+   },
+   "funding": {
+    "url": "https://opencollective.com/libvips"
+   },
+   "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
+   }
+  },
+  "node_modules/sharp/node_modules/semver": {
+   "version": "7.8.5",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+   "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+   "devOptional": true,
+   "license": "ISC",
+   "bin": {
+    "semver": "bin/semver.js"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/shiki": {
+   "version": "3.23.0",
+   "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+   "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+   "license": "MIT",
+   "dependencies": {
+    "@shikijs/core": "3.23.0",
+    "@shikijs/engine-javascript": "3.23.0",
+    "@shikijs/engine-oniguruma": "3.23.0",
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0",
+    "@shikijs/types": "3.23.0",
+    "@shikijs/vscode-textmate": "^10.0.2",
+    "@types/hast": "^3.0.4"
+   }
+  },
+  "node_modules/signal-exit": {
+   "version": "3.0.7",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+   "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/sisteransi": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+   "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+   "license": "MIT"
+  },
+  "node_modules/smart-buffer": {
+   "version": "4.2.0",
+   "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+   "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/smol-toml": {
+   "version": "1.8.0",
+   "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+   "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">= 18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/cyyynthia"
+   }
+  },
+  "node_modules/socks": {
+   "version": "2.8.9",
+   "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+   "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "ip-address": "^10.1.1",
+    "smart-buffer": "^4.2.0"
+   },
+   "engines": {
+    "node": ">= 10.0.0",
+    "npm": ">= 3.0.0"
+   }
+  },
+  "node_modules/socks-proxy-agent": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+   "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "agent-base": "^6.0.2",
+    "debug": "^4.3.3",
+    "socks": "^2.6.2"
+   },
+   "engines": {
+    "node": ">= 10"
+   }
+  },
+  "node_modules/source-map-js": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+   "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+   "license": "BSD-3-Clause",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/space-separated-tokens": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+   "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/ssri": {
+   "version": "8.0.1",
+   "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+   "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "minipass": "^3.1.1"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/string_decoder": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+   "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "safe-buffer": "~5.2.0"
+   }
+  },
+  "node_modules/string-width": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+   "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "get-east-asian-width": "^1.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/string-width/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/string-width/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/stringify-entities": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+   "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+   "license": "MIT",
+   "dependencies": {
+    "character-entities-html4": "^2.0.0",
+    "character-entities-legacy": "^3.0.0"
+   },
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/strip-ansi": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+   "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^5.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/supports-color": {
+   "version": "10.2.2",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+   "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/supports-color?sponsor=1"
+   }
+  },
+  "node_modules/svgo": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+   "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+   "license": "MIT",
+   "dependencies": {
+    "commander": "^11.1.0",
+    "css-select": "^5.1.0",
+    "css-tree": "^3.0.1",
+    "css-what": "^6.1.0",
+    "csso": "^5.0.5",
+    "picocolors": "^1.1.1",
+    "sax": "^1.5.0"
+   },
+   "bin": {
+    "svgo": "bin/svgo.js"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+   }
+  },
+  "node_modules/tailwindcss": {
+   "version": "4.3.3",
+   "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+   "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+   "license": "MIT"
+  },
+  "node_modules/tapable": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+   "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+   }
+  },
+  "node_modules/tar": {
+   "version": "6.2.1",
+   "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+   "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+   "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "chownr": "^2.0.0",
+    "fs-minipass": "^2.0.0",
+    "minipass": "^5.0.0",
+    "minizlib": "^2.1.1",
+    "mkdirp": "^1.0.3",
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/tar/node_modules/minipass": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+   "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+   "dev": true,
+   "license": "ISC",
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/tar/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/tiny-inflate": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+   "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+   "license": "MIT"
+  },
+  "node_modules/tinyexec": {
+   "version": "1.3.0",
+   "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+   "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/tinyglobby": {
+   "version": "0.2.17",
+   "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+   "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+   "license": "MIT",
+   "dependencies": {
+    "fdir": "^6.5.0",
+    "picomatch": "^4.0.4"
+   },
+   "engines": {
+    "node": ">=12.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/SuperchupuDev"
+   }
+  },
+  "node_modules/trim-lines": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+   "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/trough": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+   "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/tsconfck": {
+   "version": "3.1.6",
+   "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+   "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+   "deprecated": "unmaintained",
+   "license": "MIT",
+   "bin": {
+    "tsconfck": "bin/tsconfck.js"
+   },
+   "engines": {
+    "node": "^18 || >=20"
+   },
+   "peerDependencies": {
+    "typescript": "^5.0.0"
+   },
+   "peerDependenciesMeta": {
+    "typescript": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/tslib": {
+   "version": "2.8.1",
+   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+   "license": "0BSD"
+  },
+  "node_modules/type-fest": {
+   "version": "4.41.0",
+   "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+   "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+   "license": "(MIT OR CC0-1.0)",
+   "engines": {
+    "node": ">=16"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/typescript": {
+   "version": "5.9.3",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+   "license": "Apache-2.0",
+   "bin": {
+    "tsc": "bin/tsc",
+    "tsserver": "bin/tsserver"
+   },
+   "engines": {
+    "node": ">=14.17"
+   }
+  },
+  "node_modules/ufo": {
+   "version": "1.6.4",
+   "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+   "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+   "license": "MIT"
+  },
+  "node_modules/ultrahtml": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+   "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+   "license": "MIT"
+  },
+  "node_modules/uncrypto": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+   "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+   "license": "MIT"
+  },
+  "node_modules/undici": {
+   "version": "8.10.0",
+   "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+   "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=22.19.0"
+   }
+  },
+  "node_modules/unenv": {
+   "version": "2.0.0-rc.24",
+   "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+   "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "pathe": "^2.0.3"
+   }
+  },
+  "node_modules/unified": {
+   "version": "11.0.5",
+   "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+   "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "bail": "^2.0.0",
+    "devlop": "^1.0.0",
+    "extend": "^3.0.0",
+    "is-plain-obj": "^4.0.0",
+    "trough": "^2.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unifont": {
+   "version": "0.7.5",
+   "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+   "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+   "license": "MIT",
+   "dependencies": {
+    "css-tree": "^3.1.0",
+    "ohash": "^2.0.11",
+    "undici": "^8.0.0"
+   }
+  },
+  "node_modules/unique-filename": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+   "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "unique-slug": "^2.0.0"
+   }
+  },
+  "node_modules/unique-slug": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+   "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "imurmurhash": "^0.1.4"
+   }
+  },
+  "node_modules/unist-util-find-after": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+   "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-is": {
+   "version": "6.0.1",
+   "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+   "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-modify-children": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+   "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "array-iterate": "^2.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+   "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-remove-position": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+   "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-visit": "^5.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-stringify-position": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+   "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit": {
+   "version": "5.1.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+   "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0",
+    "unist-util-visit-parents": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-children": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+   "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/unist-util-visit-parents": {
+   "version": "6.0.2",
+   "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+   "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-is": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/update-browserslist-db": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+   "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+   "dev": true,
+   "funding": [
+    {
+     "type": "opencollective",
+     "url": "https://opencollective.com/browserslist"
+    },
+    {
+     "type": "tidelift",
+     "url": "https://tidelift.com/funding/github/npm/browserslist"
+    },
+    {
+     "type": "github",
+     "url": "https://github.com/sponsors/ai"
+    }
+   ],
+   "license": "MIT",
+   "dependencies": {
+    "escalade": "^3.2.0",
+    "picocolors": "^1.1.1"
+   },
+   "bin": {
+    "update-browserslist-db": "cli.js"
+   },
+   "peerDependencies": {
+    "browserslist": ">= 4.21.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "peer": true,
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sync-external-store": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+   "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   }
+  },
+  "node_modules/util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/uuid": {
+   "version": "11.1.1",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+   "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+   "funding": [
+    "https://github.com/sponsors/broofa",
+    "https://github.com/sponsors/ctavan"
+   ],
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/esm/bin/uuid"
+   }
+  },
+  "node_modules/vfile": {
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+   "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile-message": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-location": {
+   "version": "5.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+   "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "vfile": "^6.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vfile-message": {
+   "version": "4.0.3",
+   "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+   "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/unist": "^3.0.0",
+    "unist-util-stringify-position": "^4.0.0"
+   },
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+   }
+  },
+  "node_modules/vite": {
+   "version": "6.4.3",
+   "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+   "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+   "license": "MIT",
+   "dependencies": {
+    "esbuild": "^0.25.0",
+    "fdir": "^6.4.4",
+    "picomatch": "^4.0.2",
+    "postcss": "^8.5.3",
+    "rollup": "^4.34.9",
+    "tinyglobby": "^0.2.13"
+   },
+   "bin": {
+    "vite": "bin/vite.js"
+   },
+   "engines": {
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+   },
+   "funding": {
+    "url": "https://github.com/vitejs/vite?sponsor=1"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.3"
+   },
+   "peerDependencies": {
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+    "jiti": ">=1.21.0",
+    "less": "*",
+    "lightningcss": "^1.21.0",
+    "sass": "*",
+    "sass-embedded": "*",
+    "stylus": "*",
+    "sugarss": "*",
+    "terser": "^5.16.0",
+    "tsx": "^4.8.1",
+    "yaml": "^2.4.2"
+   },
+   "peerDependenciesMeta": {
+    "@types/node": {
+     "optional": true
+    },
+    "jiti": {
+     "optional": true
+    },
+    "less": {
+     "optional": true
+    },
+    "lightningcss": {
+     "optional": true
+    },
+    "sass": {
+     "optional": true
+    },
+    "sass-embedded": {
+     "optional": true
+    },
+    "stylus": {
+     "optional": true
+    },
+    "sugarss": {
+     "optional": true
+    },
+    "terser": {
+     "optional": true
+    },
+    "tsx": {
+     "optional": true
+    },
+    "yaml": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+   "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+   "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+   "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/android-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+   "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+   "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+   "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+   "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+   "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+   "cpu": [
+    "arm"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+   "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+   "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+   "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+   "cpu": [
+    "loong64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+   "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+   "cpu": [
+    "mips64el"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+   "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+   "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+   "cpu": [
+    "riscv64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+   "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+   "cpu": [
+    "s390x"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/linux-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+   "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+   "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+   "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+   "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+   "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+   "cpu": [
+    "x64"
+   ],
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+   "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+   "cpu": [
+    "arm64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+   "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/@esbuild/win32-x64": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+   "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+   "cpu": [
+    "x64"
+   ],
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/vite/node_modules/esbuild": {
+   "version": "0.25.12",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+   "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.25.12",
+    "@esbuild/android-arm": "0.25.12",
+    "@esbuild/android-arm64": "0.25.12",
+    "@esbuild/android-x64": "0.25.12",
+    "@esbuild/darwin-arm64": "0.25.12",
+    "@esbuild/darwin-x64": "0.25.12",
+    "@esbuild/freebsd-arm64": "0.25.12",
+    "@esbuild/freebsd-x64": "0.25.12",
+    "@esbuild/linux-arm": "0.25.12",
+    "@esbuild/linux-arm64": "0.25.12",
+    "@esbuild/linux-ia32": "0.25.12",
+    "@esbuild/linux-loong64": "0.25.12",
+    "@esbuild/linux-mips64el": "0.25.12",
+    "@esbuild/linux-ppc64": "0.25.12",
+    "@esbuild/linux-riscv64": "0.25.12",
+    "@esbuild/linux-s390x": "0.25.12",
+    "@esbuild/linux-x64": "0.25.12",
+    "@esbuild/netbsd-arm64": "0.25.12",
+    "@esbuild/netbsd-x64": "0.25.12",
+    "@esbuild/openbsd-arm64": "0.25.12",
+    "@esbuild/openbsd-x64": "0.25.12",
+    "@esbuild/openharmony-arm64": "0.25.12",
+    "@esbuild/sunos-x64": "0.25.12",
+    "@esbuild/win32-arm64": "0.25.12",
+    "@esbuild/win32-ia32": "0.25.12",
+    "@esbuild/win32-x64": "0.25.12"
+   }
+  },
+  "node_modules/vitefu": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+   "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+   "license": "MIT",
+   "workspaces": [
+    "tests/deps/*",
+    "tests/projects/*",
+    "tests/projects/workspace/packages/*"
+   ],
+   "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+   },
+   "peerDependenciesMeta": {
+    "vite": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/void-elements": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+   "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/web-namespaces": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+   "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
+  },
+  "node_modules/which": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+   "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "isexe": "^2.0.0"
+   },
+   "bin": {
+    "node-which": "bin/node-which"
+   },
+   "engines": {
+    "node": ">= 8"
+   }
+  },
+  "node_modules/which-pm-runs": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+   "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/wide-align": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+   "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+   "dev": true,
+   "license": "ISC",
+   "dependencies": {
+    "string-width": "^1.0.2 || 2 || 3 || 4"
+   }
+  },
+  "node_modules/wide-align/node_modules/emoji-regex": {
+   "version": "8.0.0",
+   "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+   "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/wide-align/node_modules/string-width": {
+   "version": "4.2.3",
+   "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+   "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "emoji-regex": "^8.0.0",
+    "is-fullwidth-code-point": "^3.0.0",
+    "strip-ansi": "^6.0.1"
+   },
+   "engines": {
+    "node": ">=8"
+   }
+  },
+  "node_modules/widest-line": {
+   "version": "5.0.0",
+   "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+   "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+   "license": "MIT",
+   "dependencies": {
+    "string-width": "^7.0.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/workerd": {
+   "version": "1.20260114.0",
+   "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260114.0.tgz",
+   "integrity": "sha512-kTJ+jNdIllOzWuVA3NRQRvywP0T135zdCjAE2dAUY1BFbxM6fmMZV8BbskEoQ4hAODVQUfZQmyGctcwvVCKxFA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "Apache-2.0",
+   "bin": {
+    "workerd": "bin/workerd"
+   },
+   "engines": {
+    "node": ">=16"
+   },
+   "optionalDependencies": {
+    "@cloudflare/workerd-darwin-64": "1.20260114.0",
+    "@cloudflare/workerd-darwin-arm64": "1.20260114.0",
+    "@cloudflare/workerd-linux-64": "1.20260114.0",
+    "@cloudflare/workerd-linux-arm64": "1.20260114.0",
+    "@cloudflare/workerd-windows-64": "1.20260114.0"
+   }
+  },
+  "node_modules/wrangler": {
+   "version": "4.59.2",
+   "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.59.2.tgz",
+   "integrity": "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw==",
+   "dev": true,
+   "license": "MIT OR Apache-2.0",
+   "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.4.2",
+    "@cloudflare/unenv-preset": "2.10.0",
+    "blake3-wasm": "2.1.5",
+    "esbuild": "0.27.0",
+    "miniflare": "4.20260114.0",
+    "path-to-regexp": "6.3.0",
+    "unenv": "2.0.0-rc.24",
+    "workerd": "1.20260114.0"
+   },
+   "bin": {
+    "wrangler": "bin/wrangler.js",
+    "wrangler2": "bin/wrangler.js"
+   },
+   "engines": {
+    "node": ">=20.0.0"
+   },
+   "optionalDependencies": {
+    "fsevents": "~2.3.2"
+   },
+   "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20260114.0"
+   },
+   "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+   "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "aix"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+   "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+   "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+   "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "android"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+   "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+   "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "darwin"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+   "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "freebsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+   "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+   "cpu": [
+    "arm"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+   "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+   "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+   "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+   "cpu": [
+    "loong64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+   "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+   "cpu": [
+    "mips64el"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+   "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+   "cpu": [
+    "ppc64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+   "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+   "cpu": [
+    "riscv64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+   "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+   "cpu": [
+    "s390x"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+   "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "linux"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "netbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+   "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+   "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openbsd"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+   "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "openharmony"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+   "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "optional": true,
+   "os": [
+    "sunos"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+   "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+   "cpu": [
+    "arm64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+   "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+   "cpu": [
+    "ia32"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+   "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+   "cpu": [
+    "x64"
+   ],
+   "dev": true,
+   "license": "MIT",
+   "optional": true,
+   "os": [
+    "win32"
+   ],
+   "engines": {
+    "node": ">=18"
+   }
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+   "version": "0.27.0",
+   "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+   "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+   "dev": true,
+   "hasInstallScript": true,
+   "license": "MIT",
+   "bin": {
+    "esbuild": "bin/esbuild"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "optionalDependencies": {
+    "@esbuild/aix-ppc64": "0.27.0",
+    "@esbuild/android-arm": "0.27.0",
+    "@esbuild/android-arm64": "0.27.0",
+    "@esbuild/android-x64": "0.27.0",
+    "@esbuild/darwin-arm64": "0.27.0",
+    "@esbuild/darwin-x64": "0.27.0",
+    "@esbuild/freebsd-arm64": "0.27.0",
+    "@esbuild/freebsd-x64": "0.27.0",
+    "@esbuild/linux-arm": "0.27.0",
+    "@esbuild/linux-arm64": "0.27.0",
+    "@esbuild/linux-ia32": "0.27.0",
+    "@esbuild/linux-loong64": "0.27.0",
+    "@esbuild/linux-mips64el": "0.27.0",
+    "@esbuild/linux-ppc64": "0.27.0",
+    "@esbuild/linux-riscv64": "0.27.0",
+    "@esbuild/linux-s390x": "0.27.0",
+    "@esbuild/linux-x64": "0.27.0",
+    "@esbuild/netbsd-arm64": "0.27.0",
+    "@esbuild/netbsd-x64": "0.27.0",
+    "@esbuild/openbsd-arm64": "0.27.0",
+    "@esbuild/openbsd-x64": "0.27.0",
+    "@esbuild/openharmony-arm64": "0.27.0",
+    "@esbuild/sunos-x64": "0.27.0",
+    "@esbuild/win32-arm64": "0.27.0",
+    "@esbuild/win32-ia32": "0.27.0",
+    "@esbuild/win32-x64": "0.27.0"
+   }
+  },
+  "node_modules/wrap-ansi": {
+   "version": "9.0.2",
+   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+   "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "string-width": "^7.0.0",
+    "strip-ansi": "^7.1.0"
+   },
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/ansi-regex": {
+   "version": "6.3.0",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+   "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+   }
+  },
+  "node_modules/wrap-ansi/node_modules/strip-ansi": {
+   "version": "7.2.0",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+   "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+   "license": "MIT",
+   "dependencies": {
+    "ansi-regex": "^6.2.2"
+   },
+   "engines": {
+    "node": ">=12"
+   },
+   "funding": {
+    "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+   }
+  },
+  "node_modules/wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/ws": {
+   "version": "8.18.0",
+   "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+   "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+   "dev": true,
+   "license": "MIT",
+   "engines": {
+    "node": ">=10.0.0"
+   },
+   "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": ">=5.0.2"
+   },
+   "peerDependenciesMeta": {
+    "bufferutil": {
+     "optional": true
+    },
+    "utf-8-validate": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/xxhash-wasm": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+   "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+   "license": "MIT"
+  },
+  "node_modules/yallist": {
+   "version": "3.1.1",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+   "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+   "dev": true,
+   "license": "ISC"
+  },
+  "node_modules/yargs-parser": {
+   "version": "21.1.1",
+   "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+   "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/yocto-queue": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+   "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12.20"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yocto-spinner": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+   "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+   "license": "MIT",
+   "dependencies": {
+    "yoctocolors": "^2.1.1"
+   },
+   "engines": {
+    "node": ">=18.19"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/yoctocolors": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+   "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=18"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/youch": {
+   "version": "4.1.0-beta.10",
+   "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+   "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/colors": "^4.1.5",
+    "@poppinss/dumper": "^0.6.4",
+    "@speed-highlight/core": "^1.2.7",
+    "cookie": "^1.0.2",
+    "youch-core": "^0.3.3"
+   }
+  },
+  "node_modules/youch-core": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+   "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+   "dev": true,
+   "license": "MIT",
+   "dependencies": {
+    "@poppinss/exception": "^1.2.2",
+    "error-stack-parser-es": "^1.0.5"
+   }
+  },
+  "node_modules/zod": {
+   "version": "4.4.3",
+   "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+   "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/colinhacks"
+   }
+  },
+  "node_modules/zod-to-json-schema": {
+   "version": "3.25.2",
+   "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+   "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+   "license": "ISC",
+   "peerDependencies": {
+    "zod": "^3.25.28 || ^4"
+   }
+  },
+  "node_modules/zustand": {
+   "version": "4.5.7",
+   "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+   "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.2.2"
+   },
+   "engines": {
+    "node": ">=12.7.0"
+   },
+   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "immer": ">=9.0.6",
+    "react": ">=16.8"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "immer": {
+     "optional": true
+    },
+    "react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/zwitch": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+   "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+   "license": "MIT",
+   "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/wooorm"
+   }
   }
+ }
 }


### PR DESCRIPTION
A remote (non-Wix-network) e2e run took ~14 minutes instead of ~6 — the entire delta was the shipped lockfile. Every `@wix/*` entry in all nine per-vertical lockfiles carried the internal registry's tarball path layout (`…/-/@wix/name-1.2.3.tgz`) with the host swapped to `registry.npmjs.org`, where the real scoped-tarball path is `…/-/name-1.2.3.tgz`.

Why we never saw it: on Wix machines npm substitutes the configured internal registry into resolved URLs — and there the "malformed" path is the native one. Every local verification silently ran against the internal registry. On the remote box, all `@wix` tarballs 404'd → `npm ci` failed → `npm install` under the same lock failed too → the fast-path install marker never appeared → the agent waited 5 minutes, diagnosed, and recovered only by deleting the lock (~8 minutes total tax; the transcript is otherwise clean).

Fix: rewrote all **1,180** resolved URLs across the nine locks to the public layout. Verified each with a real `npm ci --ignore-scripts` against the **pure public registry** (project `.npmrc` `registry=` override so the machine's internal config can't mask anything): **9/9 install clean**. The integrity hashes passing also proves wixpress and npmjs tarballs are byte-identical — no version re-resolution happened.

Follow-up worth noting for lockfile regeneration: generate on a public-registry `.npmrc` from the start, and verify with the same override — "installs on a Wix machine" proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)