### PR TITLE
feat(evalforge-skill-gate): prune superseded PR skill versions on each push

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -31944,11 +31944,12 @@ function describeError(error) {
     return error instanceof Error ? error.message : String(error);
 }
 /**
- * Deletes every capability version this PR minted (`pr-<n>-*`). Best-effort throughout:
- * cleanup runs after the PR closed, so a failure here must never fail the workflow — the
- * next run of the same job sweeps whatever was left behind.
+ * Deletes the capability versions this PR minted (`pr-<n>-*`). `keepVersionId` spares one —
+ * the gate passes the current commit's version so each push prunes only its predecessors;
+ * close-time cleanup passes nothing and sweeps them all. Best-effort throughout: a failure
+ * here must never fail the workflow, and the next run sweeps whatever was left behind.
  */
-async function deletePrCapabilityVersions(client, capabilityId, projectId, prNumber, io) {
+async function deletePrCapabilityVersions(client, capabilityId, projectId, prNumber, io, options = {}) {
     let versions;
     try {
         versions = await client.listCapabilityVersions(capabilityId, projectId);
@@ -31958,7 +31959,8 @@ async function deletePrCapabilityVersions(client, capabilityId, projectId, prNum
         return;
     }
     const prefix = `pr-${prNumber}-`;
-    for (const version of versions.filter(candidate => candidate.version.startsWith(prefix))) {
+    const doomed = versions.filter(candidate => candidate.version.startsWith(prefix) && candidate.id !== options.keepVersionId);
+    for (const version of doomed) {
         try {
             await client.deleteCapabilityVersion(capabilityId, projectId, version.id);
             io.log(`Deleted capability version ${version.version}`);
@@ -63119,6 +63121,11 @@ async function runGate() {
     const version = await (0, report_1.guardedCall)(() => client.createOrReuseSkillVersion(config.capabilityId, config.projectId, config.versionLabel, config.prNumber, scope.value.skillFiles), { message: 'Could not create the PR skill capability version', label: 'Version Not Created' }, comment, config.isBlocking);
     if (!version.ok)
         return;
+    // Keep only the current commit's version live. Each push mints a fresh pr-<n>-<sha>, and a
+    // superseded run is cancelled mid-flight, leaving its version behind — prune those now so a
+    // long-lived PR stops accumulating one version per commit. Best-effort: never fails the gate,
+    // and close-time cleanup still sweeps the rest.
+    await (0, evalforge_core_1.deletePrCapabilityVersions)(client, config.capabilityId, config.projectId, config.prNumber, { log: core.info, warn: core.warning }, { keepVersionId: version.value.id });
     const nameToId = await (0, sync_draft_scenarios_1.syncDraftScenarios)(client, octokit, config, scope.value, draftTag, workspace, comment);
     if (!nameToId.ok)
         return;

--- a/.github/actions/evalforge-skill-gate/src/utils/gate-run.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/gate-run.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { EvalForgeClient, draftTagFor, formatGateSkipped } from '@wix/evalforge-core';
+import { EvalForgeClient, deletePrCapabilityVersions, draftTagFor, formatGateSkipped } from '@wix/evalforge-core';
 import { getGateConfig } from './config';
 import { workspaceRoot } from './workspace';
 import { guardedCall, makeAnalysisUpdater, makeGateCommenter } from './report';
@@ -46,6 +46,16 @@ export async function runGate(): Promise<void> {
     comment, config.isBlocking,
   );
   if (!version.ok) return;
+
+  // Keep only the current commit's version live. Each push mints a fresh pr-<n>-<sha>, and a
+  // superseded run is cancelled mid-flight, leaving its version behind — prune those now so a
+  // long-lived PR stops accumulating one version per commit. Best-effort: never fails the gate,
+  // and close-time cleanup still sweeps the rest.
+  await deletePrCapabilityVersions(
+    client, config.capabilityId, config.projectId, config.prNumber,
+    { log: core.info, warn: core.warning },
+    { keepVersionId: version.value.id },
+  );
 
   const nameToId = await syncDraftScenarios(
     client, octokit, config, scope.value, draftTag, workspace, comment,

--- a/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
@@ -16,6 +16,8 @@ const updateTestScenario = vi.fn().mockResolvedValue(undefined);
 const deleteTestScenario = vi.fn().mockResolvedValue(undefined);
 const createOrReuseSkillVersion = vi.fn();
 const createAndRunEvalRun = vi.fn();
+const listCapabilityVersions = vi.fn().mockResolvedValue([]);
+const deleteCapabilityVersion = vi.fn().mockResolvedValue(undefined);
 
 // pulls.get is real: with a bare `{}` the call threw a TypeError that isDraftTagActive's catch
 // swallowed into `true`, so the FOREIGN_DRAFT tests below passed via the error path rather than
@@ -47,6 +49,7 @@ vi.mock('@wix/evalforge-core', async (importOriginal) => {
     EvalForgeClient: vi.fn().mockImplementation(() => ({
       listTestScenarios, listTestScenariosByTag, createTestScenario, updateTestScenario,
       deleteTestScenario, createOrReuseSkillVersion, createAndRunEvalRun,
+      listCapabilityVersions, deleteCapabilityVersion,
     })),
   };
 });
@@ -116,6 +119,8 @@ beforeEach(async () => {
   listTestScenarios.mockResolvedValue([]);
   listTestScenariosByTag.mockResolvedValue([]);
   createTestScenario.mockResolvedValue({ id: 'created-id' });
+  listCapabilityVersions.mockResolvedValue([]);
+  deleteCapabilityVersion.mockResolvedValue(undefined);
 });
 
 async function harness(configOverrides: Partial<GateConfig> = {}) {
@@ -272,6 +277,19 @@ describe('runGate — the happy path', () => {
     expect(createOrReuseSkillVersion).toHaveBeenCalledWith(
       'cap', 'proj', 'pr-42-merge99', 42, [{ path: 'SKILL.md', content: '# skill' }],
     );
+  });
+
+  it('prunes the PR\'s superseded versions, keeping the current commit\'s', async () => {
+    const { runGate } = await harness();
+    listCapabilityVersions.mockResolvedValue([
+      { id: 'ver-1', capabilityId: 'cap', version: 'pr-42-merge99' },
+      { id: 'ver-0', capabilityId: 'cap', version: 'pr-42-oldsha1' },
+    ]);
+
+    await runGate();
+
+    expect(deleteCapabilityVersion).toHaveBeenCalledWith('cap', 'proj', 'ver-0');
+    expect(deleteCapabilityVersion).not.toHaveBeenCalledWith('cap', 'proj', 'ver-1');
   });
 
   it('collects from the configured skill dir', async () => {

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -36058,11 +36058,12 @@ function describeError(error) {
     return error instanceof Error ? error.message : String(error);
 }
 /**
- * Deletes every capability version this PR minted (`pr-<n>-*`). Best-effort throughout:
- * cleanup runs after the PR closed, so a failure here must never fail the workflow — the
- * next run of the same job sweeps whatever was left behind.
+ * Deletes the capability versions this PR minted (`pr-<n>-*`). `keepVersionId` spares one —
+ * the gate passes the current commit's version so each push prunes only its predecessors;
+ * close-time cleanup passes nothing and sweeps them all. Best-effort throughout: a failure
+ * here must never fail the workflow, and the next run sweeps whatever was left behind.
  */
-async function deletePrCapabilityVersions(client, capabilityId, projectId, prNumber, io) {
+async function deletePrCapabilityVersions(client, capabilityId, projectId, prNumber, io, options = {}) {
     let versions;
     try {
         versions = await client.listCapabilityVersions(capabilityId, projectId);
@@ -36072,7 +36073,8 @@ async function deletePrCapabilityVersions(client, capabilityId, projectId, prNum
         return;
     }
     const prefix = `pr-${prNumber}-`;
-    for (const version of versions.filter(candidate => candidate.version.startsWith(prefix))) {
+    const doomed = versions.filter(candidate => candidate.version.startsWith(prefix) && candidate.id !== options.keepVersionId);
+    for (const version of doomed) {
         try {
             await client.deleteCapabilityVersion(capabilityId, projectId, version.id);
             io.log(`Deleted capability version ${version.version}`);

--- a/packages/evalforge-core/src/plan-version-cleanup.ts
+++ b/packages/evalforge-core/src/plan-version-cleanup.ts
@@ -15,9 +15,10 @@ function describeError(error: unknown): string {
 }
 
 /**
- * Deletes every capability version this PR minted (`pr-<n>-*`). Best-effort throughout:
- * cleanup runs after the PR closed, so a failure here must never fail the workflow — the
- * next run of the same job sweeps whatever was left behind.
+ * Deletes the capability versions this PR minted (`pr-<n>-*`). `keepVersionId` spares one —
+ * the gate passes the current commit's version so each push prunes only its predecessors;
+ * close-time cleanup passes nothing and sweeps them all. Best-effort throughout: a failure
+ * here must never fail the workflow, and the next run sweeps whatever was left behind.
  */
 export async function deletePrCapabilityVersions(
   client: VersionCleanupClient,
@@ -25,6 +26,7 @@ export async function deletePrCapabilityVersions(
   projectId: string,
   prNumber: number,
   io: VersionCleanupIo,
+  options: { keepVersionId?: string } = {},
 ): Promise<void> {
   let versions: CapabilityVersion[];
   try {
@@ -35,7 +37,10 @@ export async function deletePrCapabilityVersions(
   }
 
   const prefix = `pr-${prNumber}-`;
-  for (const version of versions.filter(candidate => candidate.version.startsWith(prefix))) {
+  const doomed = versions.filter(
+    candidate => candidate.version.startsWith(prefix) && candidate.id !== options.keepVersionId,
+  );
+  for (const version of doomed) {
     try {
       await client.deleteCapabilityVersion(capabilityId, projectId, version.id);
       io.log(`Deleted capability version ${version.version}`);

--- a/packages/evalforge-core/tests/plan-version-cleanup.test.ts
+++ b/packages/evalforge-core/tests/plan-version-cleanup.test.ts
@@ -27,6 +27,23 @@ describe('deletePrCapabilityVersions', () => {
     expect(deleteCapabilityVersion.mock.calls.map(call => call[2])).toEqual(['v1', 'v2']);
   });
 
+  it('spares the kept version and deletes the PR\'s other versions', async () => {
+    const listCapabilityVersions = vi.fn().mockResolvedValue([
+      version('v1', 'pr-42-old1111'),
+      version('v2', 'pr-42-current'),
+      version('v3', 'pr-7-aaaaaaa'),
+    ]);
+    const deleteCapabilityVersion = vi.fn().mockResolvedValue(undefined);
+    const { io } = recorder();
+
+    await deletePrCapabilityVersions(
+      { listCapabilityVersions, deleteCapabilityVersion }, 'C', 'P', 42, io,
+      { keepVersionId: 'v2' },
+    );
+
+    expect(deleteCapabilityVersion.mock.calls.map(call => call[2])).toEqual(['v1']);
+  });
+
   it('does not delete pr-4 versions when sweeping PR 42', async () => {
     const listCapabilityVersions = vi.fn().mockResolvedValue([version('v1', 'pr-4-abc1234')]);
     const deleteCapabilityVersion = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## What

The wix-app eval gate mints a **content-addressed** capability version (`pr-<n>-<sha>`) on every push, and a superseded run is cancelled mid-flight. So a long-lived PR accumulated **one orphaned skill version per commit** — they were only swept at close-time cleanup (as #1100 showed).

This prunes them as it goes: after creating the current commit's version, the gate deletes the PR's other `pr-<n>-*` versions, keeping the current one. Net effect — **at most one live version per PR**.

## How

- `deletePrCapabilityVersions` (evalforge-core) gains an optional `keepVersionId`. The gate passes the current version's id (prune predecessors); close-time cleanup keeps passing nothing (sweep all). Same list-and-delete-by-prefix path, still scoped strictly to this PR's `pr-<n>-*`.
- The prune call sits right after version creation and **before** the comparison arms are built, so it only removes leftovers from earlier pushes — never a version the current run needs.
- **Best-effort:** it never throws and never fails the gate; close-time cleanup remains the backstop.
- Content-addressing is kept deliberately (re-runs of the same commit still dedupe), which is why this prunes rather than reusing one PR-keyed version.

## Why not just leave it to close-time cleanup

Nothing broke, but a busy PR could hold dozens of versions for its whole life. This keeps the project's version list to the versions actually in play.

> Note: this is bootstrap-era. Once native git-linked versioning (CODEAI-898) lands, EvalForge owns the per-ref version lifecycle and the in-action version code — including this prune — goes away.

## Testing

- `evalforge-core`: new unit test for `keepVersionId` (spares the kept version, deletes the PR's others). 421 tests pass.
- `evalforge-skill-gate`: new gate test — prunes a stale `pr-42-*` version, keeps the current commit's. 219 tests pass. Typecheck clean.
- Both action bundles rebuilt (yaml-gate inlines the shared core too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)