### PR TITLE
feat(wix-vibe-headless): forms vertical

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-forms.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-forms.md
@@ -456,7 +456,7 @@ async function submitContact(formEl) {
     formId: SEEDED_FORM_ID,          // from seeded.forms[].formId
     submissions: values,             // map of target -> value (or -> nested object, for an address)
   });
-  return { _id, status };            // CONFIRMED → render a thank-you (see the status note below)
+  return { _id, status };            // CONFIRMED or PENDING → render a thank-you (see the status note below)
 }
 ```
 
@@ -482,13 +482,25 @@ construction, with no hand-maintained list to drift.
 
 Both are fixed in `setup-forms.md` STEP 2.
 
-**⚠️ A resolved promise is not always a recorded submission.** Read `status` from the result: for the
-Wix Forms namespace it is `CONFIRMED` (recorded — show the thank-you), but a form that collects
-payment returns `PAYMENT_WAITING` and some namespaces return `PENDING`, neither of which is recorded
-or visible to the owner yet
+**⚠️ Read `status` from the result — but only `PAYMENT_WAITING` means "not done".** For the Wix Forms
+namespace the status is `CONFIRMED` (recorded — show the thank-you). Some namespaces return `PENDING`,
+which is **not yet recorded** in the Wix Forms collection but **is a created submission**
 ([Submission status](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction#submission-status)).
-Since this renderer skips `PAYMENT` fields, treat anything other than `CONFIRMED` as "not done yet"
-rather than showing a success state.
+
+**Treat `PENDING` as success and show the thank-you.** The visitor has done everything they can, and
+confirming it is a server-side step they play no part in. Showing an error instead invites them to
+submit again — so the cost of getting this wrong is duplicate submissions in the owner's inbox for a
+submission that already exists, which is worse than the rare `PENDING` that never gets confirmed.
+
+The one status to **not** treat as success is **`PAYMENT_WAITING`** — a form collecting payment, where
+the visitor genuinely has a step left. Since this renderer skips `PAYMENT` fields, that shouldn't
+arise; if it does, the schema has a payment field the UI isn't rendering.
+
+```js
+const { _id, status } = await submissions.createSubmission({ formId, submissions: values });
+if (status === "PAYMENT_WAITING") { /* payment still owed — don't show the thank-you */ }
+else { /* CONFIRMED or PENDING → thank-you */ }
+```
 
 **⚠️ Per-field validation errors — the SDK buries them two levels deeper than the docs' shape.** The
 documented entries (`errorPath`, `errorType`, `errorMessage`, `params` — see
@@ -667,9 +679,9 @@ A correct Wix Forms frontend:
   `target`** so the `submissions` map is keyed by `target` by construction;
 - submits on the **plain visitor token with NO `auth.elevate`** (anonymous submit works; a pure SPA
   can't elevate anyway) and, at the default `ADVANCED` protection, **no captcha**;
-- **only writes submissions** — reading them back is owner-only — and treats
-  **`status === "CONFIRMED"`**, not a resolved promise, as the signal to show the thank-you; reads
-  the created id as **`result._id`**, never `result.id`;
+- **only writes submissions** — reading them back is owner-only — and shows the thank-you for
+  **`CONFIRMED` *or* `PENDING`** (both are created submissions), withholding it only for
+  **`PAYMENT_WAITING`**; reads the created id as **`result._id`**, never `result.id`;
 - is **accessible by construction** (the inputs are generated, so a slip repeats on every field):
   each error carries a deterministic id from its `errorPath` and is referenced by `aria-describedby`
   + `role="alert"` and persisted (not conditionally unmounted); a choice group's error and

--- a/skills/wix-headless/references/inline-recipes/how-to-code-forms.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-forms.md
@@ -456,7 +456,7 @@ async function submitContact(formEl) {
     formId: SEEDED_FORM_ID,          // from seeded.forms[].formId
     submissions: values,             // map of target -> value (or -> nested object, for an address)
   });
-  return { _id, status };            // CONFIRMED or PENDING → render a thank-you (see the status note below)
+  return { _id, status };            // any status → the submission exists; render a thank-you (see the status note below)
 }
 ```
 
@@ -482,24 +482,27 @@ construction, with no hand-maintained list to drift.
 
 Both are fixed in `setup-forms.md` STEP 2.
 
-**⚠️ Read `status` from the result — but only `PAYMENT_WAITING` means "not done".** For the Wix Forms
-namespace the status is `CONFIRMED` (recorded — show the thank-you). Some namespaces return `PENDING`,
-which is **not yet recorded** in the Wix Forms collection but **is a created submission**
+**⚠️ Read `status` from the result — but a resolved call means the submission EXISTS, whatever the
+status.** For the Wix Forms namespace it's `CONFIRMED` (recorded). Some namespaces return `PENDING`,
+which is **not yet recorded** in the Wix Forms collection but **is a created submission**;
+`PAYMENT_WAITING` is a created submission on a form that collects payment
 ([Submission status](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction#submission-status)).
 
-**Treat `PENDING` as success and show the thank-you.** The visitor has done everything they can, and
-confirming it is a server-side step they play no part in. Showing an error instead invites them to
-submit again — so the cost of getting this wrong is duplicate submissions in the owner's inbox for a
-submission that already exists, which is worse than the rare `PENDING` that never gets confirmed.
+**All three are a successful submit — show the thank-you.** The visitor has done everything the form
+asked of them; confirming a `PENDING` is a server-side step they play no part in. Showing an error
+instead invites them to submit again, so the cost of getting this wrong is duplicate submissions in
+the owner's inbox for a submission that already exists.
 
-The one status to **not** treat as success is **`PAYMENT_WAITING`** — a form collecting payment, where
-the visitor genuinely has a step left. Since this renderer skips `PAYMENT` fields, that shouldn't
-arise; if it does, the schema has a payment field the UI isn't rendering.
+`PAYMENT_WAITING` is the same call: the entry is in the owner's inbox and the *submit* succeeded, so
+**never fail it back to the visitor**. Payment is a separate step — surface it *inside* the success
+state (a "complete your payment" link or instruction) rather than as a failed submission. Since this
+renderer skips `PAYMENT` fields it shouldn't arise at all; if it does, the schema has a payment field
+the UI isn't rendering.
 
 ```js
 const { _id, status } = await submissions.createSubmission({ formId, submissions: values });
-if (status === "PAYMENT_WAITING") { /* payment still owed — don't show the thank-you */ }
-else { /* CONFIRMED or PENDING → thank-you */ }
+// CONFIRMED | PENDING | PAYMENT_WAITING → the submission exists. Thank-you either way.
+if (status === "PAYMENT_WAITING") { /* …and surface the payment step within it */ }
 ```
 
 **⚠️ Per-field validation errors — the SDK buries them two levels deeper than the docs' shape.** The
@@ -680,8 +683,9 @@ A correct Wix Forms frontend:
 - submits on the **plain visitor token with NO `auth.elevate`** (anonymous submit works; a pure SPA
   can't elevate anyway) and, at the default `ADVANCED` protection, **no captcha**;
 - **only writes submissions** — reading them back is owner-only — and shows the thank-you for
-  **`CONFIRMED` *or* `PENDING`** (both are created submissions), withholding it only for
-  **`PAYMENT_WAITING`**; reads the created id as **`result._id`**, never `result.id`;
+  **`CONFIRMED`, `PENDING` *or* `PAYMENT_WAITING`** (all three are created submissions; a payment
+  form surfaces the payment step *within* that success state, never as a failed submit); reads the
+  created id as **`result._id`**, never `result.id`;
 - is **accessible by construction** (the inputs are generated, so a slip repeats on every field):
   each error carries a deterministic id from its `errorPath` and is referenced by `aria-describedby`
   + `role="alert"` and persisted (not conditionally unmounted); a choice group's error and

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -119,30 +119,27 @@ Each vertical's UI + helpers ship in `references/<vertical>/app/`; copy that dir
 | The user wants… | Vertical | Read |
 |---|---|---|
 | Online store: products, categories, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` |
-| Appointments: services, time slots, booking, checkout | **bookings** | `references/bookings/INSTRUCTIONS.md` |
+| Appointments: services, time slots, booking, checkout — **and the form attached to a bookable service** | **bookings** | `references/bookings/INSTRUCTIONS.md` |
 | Blog/news: post feed, post pages, categories, tags | **blog** | `references/blog/INSTRUCTIONS.md` |
-| Events: browse, event page, RSVP, ticketing | **events** | `references/events/INSTRUCTIONS.md` |
+| Events: browse, event page, RSVP, ticketing — **an RSVP is here, not `forms`**, even for one occasion with no tickets | **events** | `references/events/INSTRUCTIONS.md` |
 | Portfolio/showcase: collections, projects, media galleries | **portfolio** | `references/portfolio/INSTRUCTIONS.md` |
 | Restaurant: menu, online ordering, table reservations | **restaurants** | `references/restaurants/INSTRUCTIONS.md` |
-| Any visitor-fillable form: contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration | **forms** | `references/forms/INSTRUCTIONS.md` |
-| CMS content: list/detail, filter/search, data CRUD | **cms** | `references/cms/INSTRUCTIONS.md` |
+| Any visitor-fillable form: contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration. **Not** an event RSVP (`events`) or a per-service booking form (`bookings`) | **forms** | `references/forms/INSTRUCTIONS.md` |
+| CMS content: list/detail, filter/search, data CRUD. **A visitor-fillable form is `forms`** — cms only when the app must read the entries back | **cms** | `references/cms/INSTRUCTIONS.md` |
 | Plans & pricing: memberships/subscriptions, subscribe, my plans | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` |
 | Member accounts: custom login/sign-up (email+password, Google/Facebook, SSO), account area, gated content | **members** | `references/members/INSTRUCTIONS.md` |
 
-**⚠️ A form is `forms`, not `cms`.** Any form a visitor fills in and submits is the **forms** vertical
-— "contact form" most of all. **Lead capture is the most common case, not the boundary**, and whether
-a submission also becomes a CRM contact is an optional per-field mapping. Wiring a form to a CMS
-collection with `insertDataItem` works, and is the wrong build: it gives up the dashboard form
-builder, spam protection, submission notifications and that contact mapping, and it needs the owner to
-set collection permissions by hand before a visitor can submit at all. Route to **cms** only when the
-app must **read the entries back** (a public gallery, a listing, a member's "my submissions") — a
-visitor genuinely cannot read Forms submissions. Submit-only → **forms**.
+**⚠️ Anything a visitor fills in and submits is `forms` — with three exceptions:**
 
-Two boundaries: **an RSVP is `events`** — confirming attendance to an event or occasion (a wedding,
-party, or gathering) is the **events** vertical, which ships a built-in RSVP registration form; route
-there even for a single occasion with no tickets. **A per-service booking form is `bookings`** — the
-form attached to a bookable service belongs there. Use `forms` only when neither an event nor a
-bookable service is involved.
+1. **The app must read the entries back → `cms`.** A public gallery, a listing, a member's "my
+   submissions". A visitor cannot read Forms submissions, so those need a collection. Submit-only is
+   always `forms`: a form wired to `insertDataItem` works, but gives up the dashboard form builder,
+   spam protection, submission notifications and CRM contact mapping, and needs the owner to set
+   collection permissions by hand before anyone can submit at all.
+2. **Confirming attendance to an event or occasion → `events`.** A wedding, party or gathering —
+   events ships a built-in RSVP registration form. Route there even for a single occasion with no
+   tickets.
+3. **A form attached to a bookable service → `bookings`.**
 
 ### When the request doesn't name a Wix Business Solution — ask, or check the site
 

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-vibe-headless
-description: "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vite project, a design-tool export) to a live Wix site over the site's public WIX_CLIENT_ID — the browser talks to Wix directly, no SDK, no backend, no build step. One skill covering every Wix business solution: Stores/eCommerce storefront (products, cart, checkout), Bookings (services, slots, appointments), Blog (posts, categories, tags), Events & Tickets (browse, RSVP, ticketing), Portfolio (collections, projects, galleries), Restaurants (menu, online ordering, reservations), CMS / Wix Data (list, detail, filter, forms, CRUD), Pricing Plans (memberships, subscriptions, checkout), and Members (custom login — email+password, Google/Facebook, and custom SSO — plus account areas and member-gated content). Each vertical ships a copy-as-is REST layer plus wiring instructions. Read-only over the owner's content — never provisions, never mocks data. Triggers: connect my Wix store/shop, build a storefront over Wix, add a cart and checkout, connect Wix Bookings, take appointments/reservations, show my Wix blog, list my Wix events, sell tickets, take RSVPs, build a portfolio from Wix Portfolio, show my restaurant menu / order online / book a table, display my Wix CMS collection, wire a contact form to Wix, sell membership/subscription plans, add member login / sign up, let members log in with Google or Facebook, custom login page, account / profile page, gate content behind login, sign in with SSO/Okta, 'here is my WIX_CLIENT_ID', connect this app to my Wix site over REST. Use this for CLIENT-ONLY REST integration over an existing site; use `wix-headless` instead for SDK + Wix CLI builds, hosting, and one-prompt new-site creation."
+description: "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vite project, a design-tool export) to a live Wix site over the site's public WIX_CLIENT_ID — the browser talks to Wix directly, no SDK, no backend, no build step. One skill covering every Wix business solution: Stores/eCommerce storefront (products, cart, checkout), Bookings (services, slots, appointments), Blog (posts, categories, tags), Events & Tickets (browse, RSVP, ticketing), Portfolio (collections, projects, galleries), Restaurants (menu, online ordering, reservations), Forms (any visitor-fillable form — contact/enquiry, signup, waitlist, application, survey, quote request; schema-driven render + submit), CMS / Wix Data (list, detail, filter, CRUD), Pricing Plans (memberships, subscriptions, checkout), and Members (custom login — email+password, Google/Facebook, and custom SSO — plus account areas and member-gated content). Each vertical ships a copy-as-is REST layer plus wiring instructions. Read-only over the owner's content — never provisions, never mocks data. Triggers: connect my Wix store/shop, build a storefront over Wix, add a cart and checkout, connect Wix Bookings, take appointments/reservations, show my Wix blog, list my Wix events, sell tickets, take RSVPs, build a portfolio from Wix Portfolio, show my restaurant menu / order online / book a table, display my Wix CMS collection, wire a contact form to Wix, add a contact/enquiry form, build a signup or application form, take survey responses, sell membership/subscription plans, add member login / sign up, let members log in with Google or Facebook, custom login page, account / profile page, gate content behind login, sign in with SSO/Okta, 'here is my WIX_CLIENT_ID', connect this app to my Wix site over REST. Use this for CLIENT-ONLY REST integration over an existing site; use `wix-headless` instead for SDK + Wix CLI builds, hosting, and one-prompt new-site creation."
 ---
 
 # Wix Vibe Headless — client-only REST connectors
@@ -124,9 +124,25 @@ Each vertical's UI + helpers ship in `references/<vertical>/app/`; copy that dir
 | Events: browse, event page, RSVP, ticketing | **events** | `references/events/INSTRUCTIONS.md` |
 | Portfolio/showcase: collections, projects, media galleries | **portfolio** | `references/portfolio/INSTRUCTIONS.md` |
 | Restaurant: menu, online ordering, table reservations | **restaurants** | `references/restaurants/INSTRUCTIONS.md` |
-| CMS content: list/detail, filter/search, forms, data CRUD | **cms** | `references/cms/INSTRUCTIONS.md` |
+| Any visitor-fillable form: contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration | **forms** | `references/forms/INSTRUCTIONS.md` |
+| CMS content: list/detail, filter/search, data CRUD | **cms** | `references/cms/INSTRUCTIONS.md` |
 | Plans & pricing: memberships/subscriptions, subscribe, my plans | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` |
 | Member accounts: custom login/sign-up (email+password, Google/Facebook, SSO), account area, gated content | **members** | `references/members/INSTRUCTIONS.md` |
+
+**⚠️ A form is `forms`, not `cms`.** Any form a visitor fills in and submits is the **forms** vertical
+— "contact form" most of all. **Lead capture is the most common case, not the boundary**, and whether
+a submission also becomes a CRM contact is an optional per-field mapping. Wiring a form to a CMS
+collection with `insertDataItem` works, and is the wrong build: it gives up the dashboard form
+builder, spam protection, submission notifications and that contact mapping, and it needs the owner to
+set collection permissions by hand before a visitor can submit at all. Route to **cms** only when the
+app must **read the entries back** (a public gallery, a listing, a member's "my submissions") — a
+visitor genuinely cannot read Forms submissions. Submit-only → **forms**.
+
+Two boundaries: **an RSVP is `events`** — confirming attendance to an event or occasion (a wedding,
+party, or gathering) is the **events** vertical, which ships a built-in RSVP registration form; route
+there even for a single occasion with no tickets. **A per-service booking form is `bookings`** — the
+form attached to a bookable service belongs there. Use `forms` only when neither an event nor a
+bookable service is involved.
 
 ### When the request doesn't name a Wix Business Solution — ask, or check the site
 

--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -9,7 +9,7 @@
 // members and cms names both, and its CMS helpers then come from the skill instead of being
 // hand-written. Order matters only where two verticals ship a file at the SAME path (both have
 // components/…, pages/…): the first one listed wins, since the copy never overwrites. Verticals whose
-// file sets don't overlap (cms ships utils only, no UI) combine freely.
+// file sets don't overlap (cms and forms ship utils only, no UI) combine freely.
 // paths are the Base44 sandbox's /app. Re-running is non-destructive: it fills in only missing files,
 // never overwriting the agent's edits (see COPY), so a later call can add a vertical safely.
 // No vertical arg -> deploys just the shared transport; re-run with the vertical(s) once known.

--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -1,6 +1,6 @@
 // Post-install deploy — run by base44.md STEP 1 with the vertical(s) the app needs:
 //   node deploy.cjs <vertical> [<vertical> …] --client-id <id> --metasite-id <id>
-//   (storefront | bookings | blog | cms | portfolio | pricing-plans | events | members)
+//   (storefront | bookings | blog | cms | forms | portfolio | pricing-plans | events | members | restaurants)
 // Pass the two ids from the prompt and this writes src/rest/wix-config.js for you — see WRITE below.
 // Retyping those ids into the file by hand is how a storefront ships with a dead client id.
 // ONE mechanism: recursively copy `app/` -> /app/src. The shared transport (app/rest/wix-client.js,
@@ -19,7 +19,7 @@ const { existsSync, cpSync, readFileSync, writeFileSync } = require('fs');
 
 const REF = '/app/.agents/skills/wix-vibe-headless/references';
 const WIX_CONFIG = '/app/src/rest/wix-config.js';
-const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'portfolio', 'pricing-plans', 'events', 'members', 'restaurants'];
+const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'forms', 'portfolio', 'pricing-plans', 'events', 'members', 'restaurants'];
 
 // force:false + errorOnExist:false — fill in only files that AREN'T there yet; never overwrite.
 // A re-run (e.g. the "files missing? re-run" fallback) then restores what's missing without

--- a/skills/wix-vibe-headless/install/pin-agents-md.cjs
+++ b/skills/wix-vibe-headless/install/pin-agents-md.cjs
@@ -18,7 +18,8 @@ The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from th
   - **storefront** — sell physical or digital products online.
   - **bookings** — let customers book appointments or services with your business.
   - **blog** — publish articles for visitors to read.
-  - **cms** — model and serve your own custom, structured content — for anything the other verticals don't cover.
+  - **forms** — any visitor-fillable form: contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration. **Not forms** — an event or occasion RSVP is **events** (built-in RSVP registration form), and a per-service booking form is **bookings**.
+  - **cms** — model and serve your own custom, structured content — for anything the other verticals don't cover. **Not cms** — a visitor-fillable form is **forms**; reach for cms only when the app must read the entries back.
   - **portfolio** — showcase creative work in collections and project pages.
   - **pricing-plans** — sell memberships or subscriptions to your service.
   - **events** — publish events and handle RSVPs or ticket sales.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,7 +8,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **The Wix skills installed below are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
-Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3).
+Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **except `forms`**, see STEP 3).
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -23,7 +23,7 @@ Install three skills — they land under `.agents/skills/`:
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
 
-**Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
+**Set `VERTICALS`** to what the prompt asks for — **list every vertical the app uses**, since several often join the main one (too vague to tell? do STEP 2 first, then set it). Adding one later: re-run with the extra name.
 
 | vertical | pick it when the app needs to |
 |---|---|
@@ -35,15 +35,15 @@ Run this through exec_tool, exactly as written — installs all three skills, de
 | `pricing-plans` | sell memberships or subscriptions |
 | `restaurants` | show a menu, take orders, book tables |
 | `members` | let visitors sign in — this is **auth** |
-| `cms` | keep its own structured content — user submissions, galleries, listings, anything the rows above don't already cover |
-
-**List every vertical the app uses.** `cms` for app-stored content, `members` for visitor sign-in — these often join the main vertical. Adding one later: re-run with the extra name.
+| `forms` | any visitor-fillable form — contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration. **Any "contact form" request is this row.** **Not `forms` — an RSVP is `events`**: confirming attendance to an event or occasion (a wedding, party, or gathering) uses events' built-in RSVP registration form, even for a single occasion with no tickets. **Not `forms` — a per-service booking form is `bookings`**: the form attached to a bookable service belongs there. Pick `forms` only when neither an event nor a bookable service is involved. |
+| `cms` | keep its own structured content that the app READS BACK — galleries, listings, "my submissions", anything the rows above don't already cover. **Not `cms` — a visitor-fillable form is `forms`**: a CMS collection can take a submission, but gives up the dashboard form builder, spam protection, notifications and the optional CRM contact mapping, and needs the owner to set collection permissions by hand first. Pick `cms` only when the app must read the entries back — a visitor can't read Forms submissions. |
 
 ```js
 const { execSync } = require('child_process');
 const { existsSync, readdirSync } = require('fs');
-const VERTICALS = ['storefront'];        // ← set from the prompt; list every vertical the app uses
-// const VERTICALS = ['members', 'cms']; // ← e.g. visitors sign in AND the app stores what they submit
+const VERTICALS = ['storefront'];         // ← set from the prompt; list every vertical the app uses
+// const VERTICALS = ['forms'];           // ← e.g. "create contact form" — a visitor-submitted form
+// const VERTICALS = ['members', 'cms'];  // ← e.g. visitors sign in AND the app stores what they submit
 // COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js, so never
 // retype either one into a file by hand afterwards.
 const WIX_CLIENT_ID = '<client id from the prompt>';
@@ -93,6 +93,10 @@ truth for how the client is built.
 
 **REST scaffolds + `wix-config.js` are already in `src/rest/`** (STEP 1 wrote them). Some verticals also ship a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
 
+**⚠️ `forms` is the ONE vertical that does NOT run in parallel with STEP 4** — its UI is gated on a
+file the seed writes. Read its `INSTRUCTIONS.md` **Prerequisites** before building any form UI; seed
+it first (STEP 4) and build the rest of the app meanwhile.
+
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
 rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
@@ -104,7 +108,7 @@ user-owned business, so never delete or overwrite existing content, even apparen
 cleanup truly seems needed, ask the user first.
 
 Seed by calling your vertical's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and load its `seed-*.js` via
+`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and load its `seed-*.js` (if present) via
 its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
 shape → the **`wix-base44-connector`** skill's doc discovery.
 
@@ -152,4 +156,4 @@ Once the site is built and seeded:
 For any later admin/management request, work as in STEP 4: your vertical's seed module first, else
 `wix-base44-connector` doc discovery — all over the connector.
 
-version: v1338
+version: v1340

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -37,7 +37,7 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
 | events | `wix-events-browse.js`, `wix-events-registration.js` — events & categories; RSVP / ticketing + checkout | `seed-events.js` |
 | portfolio | `wix-portfolio.js` — collections, projects, galleries | `seed-portfolio.js` |
 | restaurants | `wix-restaurants-menu.js`, `-ordering.js`, `-reservations.js` — menu; online ordering; table reservations | `seed-restaurants.js` |
-| forms | `wix-forms.js` — any visitor-fillable form: read the schema, project it to inputs, create a submission | *(none — REST shapes in `seed/SEED.md`)* |
+| forms | `wix-forms.js`, `wix-forms-submissions.js` — any visitor-fillable form: read the schema; upload attachments, create a submission (schema accessors ship alongside in `lib/wix-form-schema-utils.js`) | *(none — REST shapes in `seed/SEED.md`)* |
 | cms | `wix-cms.js` — Wix Data collections: list / detail / filter | `seed-cms.js` |
 | pricing-plans | `wix-pricing-plans.js` — plans list + subscribe/checkout | `seed-pricing-plans.js` |
 | members | `wix-members-auth.js` — custom login/signup (email+password, social, SSO), session, account | *(none — members sign up at runtime; nothing to seed)* |

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -27,7 +27,7 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
 - `INSTRUCTIONS.md` — the vertical's build guide + field-shape snippets; `seed/SEED.md` — how the seed
   module is run.
 
-**The nine verticals — data layer (`app/rest/`) + seed module (`seed/`):**
+**The verticals — data layer (`app/rest/`) + seed module (`seed/`):**
 
 | vertical | `app/rest/` data layer | seed module |
 |---|---|---|
@@ -37,7 +37,8 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
 | events | `wix-events-browse.js`, `wix-events-registration.js` — events & categories; RSVP / ticketing + checkout | `seed-events.js` |
 | portfolio | `wix-portfolio.js` — collections, projects, galleries | `seed-portfolio.js` |
 | restaurants | `wix-restaurants-menu.js`, `-ordering.js`, `-reservations.js` — menu; online ordering; table reservations | `seed-restaurants.js` |
-| cms | `wix-cms.js` — Wix Data collections: list / detail / filter + form CRUD | `seed-cms.js` |
+| forms | `wix-forms.js` — any visitor-fillable form: read the schema, project it to inputs, create a submission | *(none — REST shapes in `seed/SEED.md`)* |
+| cms | `wix-cms.js` — Wix Data collections: list / detail / filter | `seed-cms.js` |
 | pricing-plans | `wix-pricing-plans.js` — plans list + subscribe/checkout | `seed-pricing-plans.js` |
 | members | `wix-members-auth.js` — custom login/signup (email+password, social, SSO), session, account | *(none — members sign up at runtime; nothing to seed)* |
 
@@ -49,7 +50,9 @@ the token set) is **universal — follow it as-is**.
 
 ## The flow — install → build client → seed → done
 
-Run **build the client** (step 2) and **seed** (step 3) in parallel; parallelize independent work within each.
+Run **build the client** (step 2) and **seed** (step 3) in parallel; parallelize independent work
+within each. **One exception — `forms` must be seeded before its UI is built; read that gate in
+`references/forms/INSTRUCTIONS.md` (Prerequisites) first.** Everything else still parallelizes.
 
 ### 1 · Install the skills
 

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -2,9 +2,12 @@
 
 Unlike the other verticals, CMS ships **no UI**. A CMS is schema-driven — every collection is
 different — so there are no meaningful "list/detail" components to hand you. You **build the UI
-yourself** (list, detail, home, forms) in your own framework and design tokens, calling the shipped
-**utils**. Everything talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor token)
-using the official Wix Data endpoints — never hand-build a Wix Data URL, never mock items.
+yourself** (list, detail, home) in your own framework and design tokens, calling the shipped
+**utils**. **A visitor-fillable form is the `forms` vertical, not `cms`** — come here only when the
+app must read the entries back (a public gallery, a listing, a member's "my submissions"); a visitor
+cannot read Forms submissions. Everything talks to Wix directly over the public `WIX_CLIENT_ID`
+(anonymous visitor token) using the official Wix Data endpoints — never hand-build a Wix Data URL,
+never mock items.
 
 ## What ships (utils only)
 

--- a/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
@@ -1,0 +1,436 @@
+# Wix Forms — client utils (you build the UI)
+
+**Intent:** contact / enquiry / lead / signup / waitlist / application / feedback / survey / quote
+request / intake or registration — any form a visitor fills in and submits. Whether the submission
+also becomes a CRM contact is a per-field mapping, not a different vertical.
+
+This vertical ships **no UI**: the owner picks the fields in their dashboard, so every form has a
+different field set and no "contact form" component could ship for it. You generate one control per
+field from the live schema, using the shipped utils. Everything runs on the public `WIX_CLIENT_ID`
+(anonymous visitor token) — no SDK, no backend, no elevated credential.
+
+> **⚠️ A visitor-fillable form is FORMS, not CMS.** Wiring one to `insertDataItem` works, and is the
+> wrong call: it gives up the dashboard form builder, spam protection, notifications and contact
+> mapping, and needs the owner to set collection permissions before a visitor can submit at all.
+> Use **`cms`** only when the app must **read the entries back** (a gallery, a listing, "my
+> submissions") — a visitor cannot read Forms submissions. Submit-only → forms.
+
+## What ships (utils only)
+
+| file | what it is |
+|---|---|
+| `lib/wix-form-schema-utils.js` | **Reading the raw schema** — `orderedInputs`, `submitTextOf`, and per field `targetOf`, `labelOf`, `isRequired`, `validationOf`, `componentOf`, `optionsOf`, `inputTypeOf`, `componentTypeOf`, `choicesOf`, `addressPartsOf`, `phoneCountryOf`, `isMulti`/`isFile`/`isNumber`/`isAddress`. No React, no REST; the hook hands them back as `read`. |
+| `rest/wix-forms.js` | Schema transport: `getForm`, `listForms`, plus `phoneExample` (what a visitor is shown), `normalizePhone` (what goes on the wire), `setSiteCountry`. |
+| `rest/wix-forms-submissions.js` | Write transport: `toSubmissionValues`, `createSubmission`, `SUBMITTED_OK`, the file flow (`getMediaUploadUrl`, `uploadSubmissionFile`, `uploadFormFiles`), `submissionViolations`. |
+| `hooks/useWixForm.js` | The form's non-visual half: `useWixForm(formId)` → `{ form, values, setValues, submit, validate, errors, loading, read }`. Also exports `validateField`, `mapSubmissionErrors`, `FORM_ERROR`. Not on React? Those plus `lib/` are the load-bearing part; port the state around them. |
+| `wix-config.js` *(shared)* | the two ids, written by the install step. |
+| `wix-forms.config.js` *(generated)* | **the gate** — `WIX_FORMS`: each form's `formId` + read-back `targets`, written by the seed after verification. |
+| `WixManageBanner` *(shared)* | Dev-only manage banner — mount it in your Layout. |
+
+## Prerequisites — a HARD GATE
+
+- **`src/rest/wix-forms.config.js` must exist.** No file → the seed hasn't succeeded → **stop and
+  run the seed**. It's the one vertical whose client can't be built in parallel with its seed.
+- **Never invent a `formId`, and never write that file early.** Its only value is as proof that a
+  verified schema exists; the seed writes it after creating *and* verifying each schema.
+- **The Wix Forms app installed, with at least one form.** This vertical doesn't provision forms.
+- **No permission setup** — unlike CMS, a visitor can read a published form's schema and submit to it
+  out of the box.
+
+## Build the UI
+
+Render from the **live schema**, always: field set, order, labels, `required`, validation rules and
+choice options all come from it, so an owner's dashboard edit reaches the site with no code change
+and the submission map can't desync. A dropdown, tricky validation or several forms on a page are not
+reasons to hardcode — that's exactly what the schema carries.
+
+*(The one exception: an explicitly design-led brief where the form is a fixed part of a hand-crafted
+layout and dashboard-editability is not a goal. Even then take the `target`s from
+`WIX_FORMS.<key>.targets` — a key that isn't an exact schema `target` 400s the whole submission.)*
+
+The JSDoc in `hooks/useWixForm.js` and `lib/wix-form-schema-utils.js` covers what each util does;
+this covers which control a field wants and where the obvious implementation is wrong. Markup and
+styling are yours (on base44: shadcn + `src/index.css`).
+
+### 1 · Load the form
+
+```jsx
+import { useWixForm, FORM_ERROR } from "@/hooks/useWixForm";
+import { WIX_FORMS } from "@/rest/wix-forms.config";   // written by the seed — never by hand
+
+const { form, values, setValues, submit, validate, errors, loading, read } =
+  useWixForm(WIX_FORMS.contact.formId);
+
+const fields = read.orderedInputs(form);   // the raw fields to render, in the owner's layout order
+```
+
+| | |
+|---|---|
+| `form` | the Form exactly as Wix returned it (`null` until loaded). Nothing stripped or renamed. |
+| `values` | state, keyed by `target`: string for text/choice/date, **array** for multi-choice and files, **object** for an address. Seeded from the schema's defaults. |
+| `setValues` | plain React setter — `setValues((v) => ({ ...v, [name]: value }))`. |
+| `submit(event)` | use as `onSubmit`; resolves **`true`** only when the submission was created. |
+| `validate(target?)` | one field, one address subfield, or the whole form. Returns whether it passed. |
+| `errors` | control name → visitor-facing message; `errors[FORM_ERROR]` is form-level. |
+| `loading` | loading the schema (`form` still `null`) **or** submitting (`form` set). |
+| `read` | the schema accessors, so the UI needs one import. |
+
+Fields are the raw objects Wix sent, so anything the accessors don't cover is still on them —
+`pii`, `showLabel`, `buttonText`, `explanationText`, `options[].image`, the `steps[]` a multi-page
+form would need.
+
+**`contact` is this example's key.** The seed names each form — `waitlist`, `quote`, `application` —
+so use the keys `wix-forms.config.js` actually contains.
+
+**Several forms on one page?** The hook loads one schema each. Past two, call
+`listForms({ formIds: [...] })` once (up to 100 ids) and run `orderedInputs` over each result.
+
+**Set the site's country once at app start**, so locale-derived examples match the business, not the
+visitor's browser:
+
+```js
+import { setSiteCountry } from "@/rest/wix-forms";
+setSiteCountry("GB");
+```
+
+### 2 · Render one control per field
+
+Map over `fields`. Every control carries the same four things:
+
+1. **`name={read.targetOf(field)}`** — the immutable storage key, and also the state key, the error
+   key and the submission key. Keying everything by it makes the submission right by construction;
+   it's how a blocked submit finds the control to focus, and it drives autofill.
+2. **`value` from `values[target]`, written back through `setValues`.** (A file input can't be
+   controlled — it takes only `onChange`.)
+3. **`onBlur={() => validate(target)}`** — not on the first keystroke of an untouched field, which
+   reddens a required field before the visitor types. Once flagged, re-check as they type from an
+   **effect on the value**: React hasn't committed the new value when `onChange` runs, so a check
+   there judges the value they just replaced.
+4. **A real `<label>` from `read.labelOf(field)`, and an error node** — see step 6 for the wiring
+   both need.
+
+**Stamp the schema's constraints as native attributes.** They reinforce the JS checks and drive
+mobile keyboards:
+
+| from the schema | onto the control |
+|---|---|
+| `isRequired(field)` | `required` |
+| `validationOf(field).minLength` / `.maxLength` | `minLength` / `maxLength` |
+| `validationOf(field).pattern` | `pattern` |
+| `validationOf(field).minimum` / `.maximum` | `min` / `max` (number and rating) |
+| `validationOf(field).format` | input `type` — `EMAIL`→`email`, `PHONE`→`tel`, `URL`→`url`, `DATE`→`date`, `TIME`→`time`, `DATE_TIME`→`datetime-local`, else `text`; `isNumber(field)`→`number` |
+| the resolved `type` | `inputMode` — `number`→`decimal`, `tel`/`email`/`url` as themselves; omit for date/time (native picker) |
+| `componentOf(field).placeholder` | `placeholder` |
+| `validationOf(field).fileLimit` | `multiple`, when above 1 |
+| `validationOf(field).uploadFileFormats` | `accept` — map the media kinds a browser knows (`IMAGE`→`image/*`, `VIDEO`, `AUDIO`, `DOCUMENT`); omit `accept` when the owner allows anything |
+| `field.identifier` for `CONTACTS_*` kinds | `autoComplete` — `email`, `tel`, `given-name`, `family-name`, `organization`, `bday`; address subfields take `address-line1`, `address-level2`, `postal-code`, `country` |
+
+**A constrained field with no placeholder gets a synthesized one:** PHONE →
+`phoneExample(read.phoneCountryOf(field))` (that country's regulator-reserved fictional number,
+falling back to the site's), URL → `https://…`. It prevents the `must match format "phone"` rejection
+without a hint line under every field.
+
+#### Which control
+
+`identifier` and `componentType` are **independent axes** — several fields share one component — so
+branch on whichever distinguishes the control, and **never on the `target` name**, which an owner's
+rename silently breaks.
+
+| control | branch on | `values[target]` |
+|---|---|---|
+| `<textarea>` | `field.identifier === "TEXT_AREA"` | string |
+| `<select>` | `read.componentTypeOf(field) === "DROPDOWN"` | string |
+| radios | `read.componentTypeOf(field) === "RADIO_GROUP"` | string |
+| checkbox group | `read.isMulti(field)` | **array** of checked values |
+| address group | `read.isAddress(field)` | **object** keyed by subfield |
+| file / signature | `read.isFile(field)` | **`File` objects** until submit |
+| text / email / tel / url / date / time / number | `validationOf(field).format`, `isNumber` | string |
+
+Two that bite: `componentType` is `TEXT_INPUT` for short **and** long answer, so keying a textarea
+off it renders every long field single-line; and `IMAGE_CHOICE` is indistinguishable from multi
+choice except by `identifier` — it falls out as plain checkboxes, and its pictures are on
+`componentOf(field).options[].image`.
+
+**Coverage check — every field kind an owner can add:**
+
+| dashboard field | `identifier` | renders as | `values[target]` |
+|---|---|---|---|
+| Short answer, Link, Company, Position, Tax ID, First/Last name, Email, single-line Address | `TEXT_INPUT`, `URL_INPUT`, `CONTACTS_*` | text input, `type` from `format` | string |
+| Long answer | `TEXT_AREA` | `<textarea>` | string |
+| Phone | `CONTACTS_PHONE` | `type="tel"` + reserved example | string (E.164 on submit) |
+| Number, Rating | `NUMBER_INPUT`, `RATING_INPUT` | `type="number"` (or your stars) | string in state, number on the wire |
+| Dropdown | `DROPDOWN` | `<select>` | string |
+| Single choice | `RADIO_GROUP` | radios | string |
+| Multi choice, Tag picker, Image choice | `CHECKBOX_GROUP`, `TAGS`, `IMAGE_CHOICE` | checkboxes (or a chip / image control) | **array** |
+| Date, Date picker, Date and time, Time, Birthdate | `DATE_INPUT`, `DATE_PICKER`, `DATE_TIME_INPUT`, `TIME_INPUT`, `CONTACTS_BIRTHDATE` | native date/time input | string |
+| Multi-line address | `MULTILINE_ADDRESS` | fieldset of subfields | **object** |
+| File upload, Signature | `FILE_UPLOAD`, `SIGNATURE` | file input (a signature deserves a canvas) | **`File` objects** |
+| Checkbox, Subscribe checkbox | `CHECKBOX`, `CONTACTS_SUBSCRIBE` | not covered here — `BOOLEAN`, and its label is Ricos rich content, not a string | boolean |
+| Product, Fixed price, Custom price, Donation | `PRODUCT_LIST`, `FIXED_PAYMENT`, `PAYMENT_INPUT`, `DONATION` | not covered here — `PAYMENT` | array of product objects |
+| Appointment | `APPOINTMENT` | not covered here — `SCHEDULING` | appointment object |
+| Service picker, Multi-service picker | `SERVICES_DROPDOWN`, `SERVICES_MULTI_CHOICE` | `<select>` / checkboxes, options from the connected app | string / **array** |
+
+`orderedInputs` returns the uncovered types too — nothing is filtered for you. Write the control, or
+have the owner drop the field; a **required** field you don't render makes the form unsubmittable.
+
+**Display fields never reach this loop.** `RICH_TEXT` blocks and the submit button are
+`fieldType: "DISPLAY"`, so `orderedInputs` drops them. If a form uses rich-content blocks as section
+copy between fields, read them off `form.formFields` yourself — their content is Ricos, not a string.
+
+Wix's [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields.md)
+is the spec behind this table. `seed/SEED.md` carries the same identifiers from the authoring side
+(which JSON creates each field); this one is the rendering side (which control, which value shape) —
+they join on `identifier`.
+
+#### Controls that need more than an input
+
+**Choice groups** go in a `<fieldset>` with a `<legend>`; the group's `aria-describedby`,
+`aria-invalid` and `aria-required` go on the fieldset, since no single radio can carry them. Options
+come from `read.choicesOf(field)` (`{ value, label }`, label falling back to value). A checkbox
+group's value is an array — toggle values in and out of it.
+
+**A dropdown** needs a disabled `<option value="">` first (state starts empty, so otherwise the first
+real option looks pre-selected); use `componentOf(field).placeholder` for its text.
+
+**An address** is a group whose value is a nested object. Subfields come from
+`read.addressPartsOf(field)` (`{ sub, required }`, hidden `addressLine2` already dropped); name each
+control **`${target}/${sub}`**, which is exactly the server's error path for a nested field, so
+rejections land on the right control with no mapping of your own. Subfield keys are storage keys —
+humanize them (`postalCode` → "Postal code"). **`country` and `subdivision` are country-dependent
+enums the schema doesn't enumerate**: render `country` as a select over ISO-3166 alpha-2 codes,
+narrowed to `validationOf(field).allowedCountries` when set. Keeping `subdivision` free text means
+leaving it optional and relying on the mapped error.
+
+#### File uploads — the value is the upload URL
+
+The hook's `submit` runs this before it sends anything:
+
+1. **`getMediaUploadUrl(formId, filename, mimeType)`** → a signed `uploadUrl`. This Forms-scoped
+   wrapper is what makes a visitor upload possible at all: `site-media` directly needs a Manage-Media
+   credential and 403s for a visitor.
+2. **`PUT` the bytes to it** with the file's `Content-Type`, via plain `fetch` — the URL is
+   pre-signed, and adding the visitor's `Authorization` header turns a working upload into a 400.
+3. **Submit that same `uploadUrl` as the value** — not the CDN URL the upload returns, not a file id.
+   One file submits the string; several submit an array.
+
+So `values[target]` holds `File` objects until submit, and validation checks the count (`required`,
+`fileLimit`) since no string rule applies. Three render consequences: the input can't be controlled
+(wire `onChange`, list the picked filenames yourself); clearing it after success needs a `key` bump,
+because resetting state leaves the browser's own "1 file selected" text; and uploads run inside
+`loading`, so the button's progress state matters more here.
+
+**A signature** shares `WIX_FILE`, so a file input accepts one — but the honest control is a canvas:
+`canvas.toBlob(...)` → a `File` named `signature.png` in `values[target]`, same upload path.
+
+**Never base64 a file into a value.** It stores no real file and blows past the submission size
+limit. A form with no file field at all is a plan gate — file, signature and payment fields need a
+Core-or-above plan — fixed by the owner's plan, never an inlined blob.
+
+### 3 · Validation — schema-driven on the client, authoritative on the server
+
+`validate(target?)` applies only rules the schema states:
+
+| rule | from |
+|---|---|
+| required | `isRequired(field)` — including a multi-choice or file field with nothing picked, and each required address subfield |
+| length | `validationOf(field).minLength` / `.maxLength` |
+| shape | `.pattern`, and `.format` — EMAIL, PHONE (E.164 after stripping spaces/dashes/parens), URL |
+| range | `.minimum` / `.maximum` on number and rating, parsed before comparing |
+
+Call it as `validate("email")` (the `onBlur` wiring), `validate("address/city")` for one subfield, or
+`validate()` for everything — `submit` already does the last, so reach for it only to gate something
+else. It reads `values`, and it clears what now passes as well as flagging what doesn't. An address
+subfield gets the `required` check only; `country`/`subdivision` content is the server's call.
+
+**Show invalid state on the control**, keyed off the same `aria-invalid` the render sets, so visual
+and assistive-tech state can't drift — no parallel `.has-error` class:
+
+```css
+input[aria-invalid="true"], select[aria-invalid="true"], textarea[aria-invalid="true"],
+fieldset[aria-invalid="true"] { border-color: var(--destructive); outline-color: var(--destructive); }
+.error:empty { display: none; }
+```
+
+**Never key a check on a field's name** (the classic slip: keying the email check on
+`target === "email"`) — derive it from `format` and the schema's constraints, as `validateField`
+does. And a client rule **laxer** than the server's is worse than none: the visitor
+then learns about the problem after a round trip, in Wix's wording instead of yours.
+
+### 4 · Submit
+
+`submit(event)` client-validates → uploads picked files → builds the submission map (empty optionals
+dropped, PHONE normalized to E.164, NUMBER coerced; it walks the *schema*, so a stray key in `values`
+can't reach the API) → creates the submission → maps server violations onto controls and focuses the
+first invalid one. On success it resets `values` to the schema's defaults.
+
+**The resolved `true` is the only success signal there is.** Submissions are write-only from the
+browser — reading them back needs an owner scope and 403s for a visitor. The submission lands in the
+owner's dashboard.
+
+`CONFIRMED`, `PENDING` and `PAYMENT_WAITING` all mean created. A `PAYMENT_WAITING` form leaves the
+visitor a payment step: surface it **inside** the success state, never as a failed submit.
+
+**No captcha** at the default protection level — don't add captcha plumbing speculatively.
+
+### 5 · The states around the form
+
+```jsx
+export default function ContactForm() {
+  const { form, values, setValues, submit, validate, errors, loading, read } =
+    useWixForm(WIX_FORMS.contact.formId);
+  const [sent, setSent] = useState(false);
+  const [resetKey, setResetKey] = useState(0);   // bump on success to clear file inputs
+
+  async function handleSubmit(event) {
+    const ok = await submit(event);
+    setSent(ok);
+    if (ok) setResetKey((k) => k + 1);
+  }
+
+  if (loading && !form) return <p>Loading…</p>;
+  // A form that can't load is a setup problem — say so; never fall through to a hand-built form,
+  // which silently drops real enquiries.
+  if (!form) return <p role="alert">This form isn't available right now. {errors[FORM_ERROR]}</p>;
+  // Swapping the form out is a silent DOM change, so the success state announces itself.
+  if (sent) {
+    return (
+      <div role="status">
+        <h3 tabIndex={-1}>Thank you</h3>
+        <p>We'll be in touch shortly.</p>
+        <button type="button" onClick={() => setSent(false)}>Send another</button>
+      </div>
+    );
+  }
+
+  const fields = read.orderedInputs(form);
+  if (fields.length === 0) return <p>This form has no fields yet — add them in your Wix dashboard.</p>;
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      {fields.map((field) => (
+        <Field key={read.targetOf(field)} field={field} values={values} setValues={setValues}
+               errors={errors} validate={validate} resetKey={resetKey} />
+      ))}
+      <p role="alert">{errors[FORM_ERROR]}</p>
+      <button type="submit" disabled={loading}>
+        {loading ? "Sending…" : (read.submitTextOf(form) || "Submit")}
+      </button>
+    </form>
+  );
+}
+```
+
+`Field` is yours — one branch per control (step 2). `noValidate` keeps your messages instead of the
+browser's bubbles; the native constraints still drive keyboards and assistive tech.
+
+Two things the shell doesn't show:
+
+- **Server violations land on controls**, keyed exactly like the client's (`target`, or `target/sub`
+  for an address subfield). The copy comes from the violation's `errorType` plus the field's schema;
+  an unmapped type degrades to safe copy, and Wix's internal `errorMessage` goes to `console.debug`.
+  Only a failure with no per-field violations sets `errors[FORM_ERROR]`.
+- **A required field you didn't render** blocks submit with a message that has no control to display
+  it. Check `read.orderedInputs(form)` against your branches before shipping.
+
+### 6 · Accessibility — the controls are generated, so one slip hits every field
+
+- **The error node renders always**, empty or filled, with `role="alert"` and a deterministic id
+  (`err-${target}`) the control points at via `aria-describedby`. `aria-describedby` alone only reads
+  on focus; conditional rendering (`{error && …}`) destroys the live region entirely. Hide the empty
+  state with CSS.
+- **`aria-invalid` only when invalid** — `undefined`, never `"false"`.
+- **A group's error and `aria-*` go on the `<fieldset>`** — choice groups and addresses have no
+  single control to describe.
+- **Required is programmatic**: the `required` attribute (or `aria-required` on a group) carries the
+  meaning, the `*` is `aria-hidden` decoration. Both, never the glyph alone.
+- **Every control has a real `<label>`** — a placeholder disappears on input and fails contrast.
+- **The success state is announced** (`role="status"`, or focus its heading).
+
+Don't reach for `role="form"`, an `aria-label` on an input that already has a `<label>`, or a custom
+`role="radio"` — native radios in a `<fieldset>` are already a radiogroup.
+
+## Hard rules
+
+- A visitor-fillable form is this vertical, not `cms`.
+- Read and write only through the shipped helpers — never hand-build a Wix Forms URL.
+- Never hardcode a field list; never detect a control by its `target` name.
+- Read fields through the accessors, not by reaching into `inputOptions` — the block names are enum
+  derived, and the accessors map every one of them.
+- Key every control by `target`: `values[target]`, `errors[target]`, `name`. Address subfields use
+  `target/sub`.
+- Derive validation from the schema, and keep every client rule at least as strict as the server's.
+- **Never add `auth.elevate`, a backend function or a connector token to make a form work.** The
+  visitor token reads the schema and creates the submission; the API spec's owner scopes are wrong
+  for the published-site path. This is the most common wrong turn on this vertical.
+- Submissions are write-only from the browser — the resolved `createSubmission` **is** the success
+  signal. Listing entries back needs `cms`.
+- Every status the submit resolves on is a created submission: show the thank-you, and put a payment
+  step inside it. Treating one as failure costs the owner duplicates.
+- Order comes from `steps[]`, not `formFields[]`; take the order only, not the geometry.
+- Render every field `orderedInputs` returns, or confirm what you skip isn't `required`.
+- A file field submits the URL from `getMediaUploadUrl` — never base64, never a Manage-Media
+  credential, never the CDN URL the upload returns.
+- `UNKNOWN_VALUE_ERROR` / `NOT_ALLOWED_VALUE_ERROR` are seed bugs — fix the schema, don't mangle the
+  key or value.
+- Never mock a form. No `formId`, or a form that won't load, is a setup problem to surface.
+- Never show a locale-wrong example, and never submit the reserved one you display.
+
+## Fallback
+
+Three sources answer what this file doesn't: the **JSDoc** in `hooks/useWixForm.js` and
+`lib/wix-form-schema-utils.js`; the **Wix reference** below; and `seed/SEED.md` for how a field was
+authored. Calling an endpoint the helpers don't wrap is fine via `wixApiRequest` — look up the exact
+method and body first (or use the `wix-docs` skill), never guess.
+
+- Form object (the shape `form` and its fields arrive in): https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md
+- Form Schemas API: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md
+- About Form Fields (every field-level rule): https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields.md
+- Form Submissions API: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions.md
+- About Submission Values (per-`inputType` value shapes): https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values.md
+- Validation errors: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction#validation-errors
+- Get Media Upload URL: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/get-media-upload-url.md
+- Uploading to a generated URL: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/upload-api.md
+
+## Not this vertical
+
+An event **RSVP** → `events` (it ships its own registration form). A **bookable service's** form →
+`bookings`. Content the app **lists back** — reviews, galleries, "my items" → `cms`. A form only
+logged-in members may reach → `members` for the gate, forms for the form. `SKILL.md`'s routing table
+is the deciding copy.
+
+## Seeding
+
+Seed per `seed/SEED.md`: it installs the Forms app, creates each schema, verifies it (reads it back,
+checks the dashboard summary, sends and deletes one real submission), then writes
+`src/rest/wix-forms.config.js`. Needs an elevated credential, and **does not run in parallel with the
+client** — see Prerequisites.
+
+## Point the user to their dashboard
+
+Substitute the site's `metaSiteId`:
+
+- **Forms list** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms`
+- **Form builder** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}` → add,
+  relabel, reorder or require fields; every change reflects on the site with no code change.
+- **Submissions** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms-and-payments/submissions`
+- **Forms settings** (incl. notifications) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms-and-payments/settings`
+- **Contacts** — `https://manage.wix.com/dashboard/{metaSiteId}/contacts` → contact-mapped fields
+  create or update a contact automatically.
+
+## Verify
+
+- [ ] `wix-forms.config.js` exists; every `formId` comes from `WIX_FORMS`, none typed by hand.
+- [ ] `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] Relabel a field in the dashboard, reload: the new label appears with no code change.
+- [ ] Every field `read.orderedInputs(form)` returns has a control — long answer is a `<textarea>`,
+      choice groups render their options, an address renders its subfields — or what you skipped
+      isn't `required`.
+- [ ] Required fields show inline errors on blur, in your wording, before any round trip.
+- [ ] A deliberately invalid email/phone is rejected inline, on the right control.
+- [ ] A real submission shows the thank-you, then appears in the owner's **submissions inbox** and
+      (for contact-mapped fields) as a **contact**.
+- [ ] Has a file field? Attached a real file, submitted, and opened the attachment from the
+      dashboard — a submission recording an unusable attachment still "succeeds".
+- [ ] Keyboard pass: a blocked submit focuses the first invalid control, errors are announced, every
+      control has a real label.
+- [ ] No `auth.elevate`, backend function or connector token in the submit path.

--- a/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
@@ -5,8 +5,8 @@ request / intake or registration — any form a visitor fills in and submits. Wh
 also becomes a CRM contact is a per-field mapping, not a different vertical.
 
 This vertical ships **no UI**: the owner picks the fields in their dashboard, so every form has a
-different field set and no "contact form" component could ship for it. You generate one control per
-field from the live schema, using the shipped utils. Everything runs on the public `WIX_CLIENT_ID`
+different field set and no "contact form" component could ship for it. You write one control per
+field — the shipped utils supply the schema behind it, the state, the validation and the submit. Everything runs on the public `WIX_CLIENT_ID`
 (anonymous visitor token) — no SDK, no backend, no elevated credential.
 
 > **⚠️ A visitor-fillable form is FORMS, not CMS.** Wiring one to `insertDataItem` works, and is the
@@ -22,7 +22,7 @@ field from the live schema, using the shipped utils. Everything runs on the publ
 | `lib/wix-form-schema-utils.js` | **Reading the raw schema** — `orderedInputs`, `submitTextOf`, and per field `targetOf`, `labelOf`, `isRequired`, `validationOf`, `componentOf`, `optionsOf`, `inputTypeOf`, `componentTypeOf`, `choicesOf`, `addressPartsOf`, `phoneCountryOf`, `isMulti`/`isFile`/`isNumber`/`isAddress`. No React, no REST; the hook hands them back as `read`. |
 | `rest/wix-forms.js` | Schema transport: `getForm`, `listForms`, plus `phoneExample` (what a visitor is shown), `normalizePhone` (what goes on the wire), `setSiteCountry`. |
 | `rest/wix-forms-submissions.js` | Write transport: `toSubmissionValues`, `createSubmission`, `SUBMITTED_OK`, the file flow (`getMediaUploadUrl`, `uploadSubmissionFile`, `uploadFormFiles`), `submissionViolations`. |
-| `hooks/useWixForm.js` | The form's non-visual half: `useWixForm(formId)` → `{ form, values, setValues, submit, validate, errors, loading, read }`. Also exports `validateField`, `mapSubmissionErrors`, `FORM_ERROR`. Not on React? Those plus `lib/` are the load-bearing part; port the state around them. |
+| `hooks/useWixForm.js` | The form's non-visual half: `useWixForm(formId)` → `{ form, values, setValues, bind, submit, validate, errors, loading, read }`. Also exports `validateField`, `mapSubmissionErrors`, `FORM_ERROR`. Not on React? Those plus `lib/` are the load-bearing part; port the state around them. |
 | `wix-config.js` *(shared)* | the two ids, written by the install step. |
 | `wix-forms.config.js` *(generated)* | **the gate** — `WIX_FORMS`: each form's `formId` + read-back `targets`, written by the seed after verification. |
 | `WixManageBanner` *(shared)* | Dev-only manage banner — mount it in your Layout. |
@@ -39,14 +39,14 @@ field from the live schema, using the shipped utils. Everything runs on the publ
 
 ## Build the UI
 
-Render from the **live schema**, always: field set, order, labels, `required`, validation rules and
-choice options all come from it, so an owner's dashboard edit reaches the site with no code change
-and the submission map can't desync. A dropdown, tricky validation or several forms on a page are not
-reasons to hardcode — that's exactly what the schema carries.
+**The schema is the source of truth, whatever the markup looks like.** Every `target`, label,
+`required` flag, constraint and choice option comes from it, and so does the submission map — nothing
+about a field is yours to invent.
 
-*(The one exception: an explicitly design-led brief where the form is a fixed part of a hand-crafted
-layout and dashboard-editability is not a goal. Even then take the `target`s from
-`WIX_FORMS.<key>.targets` — a key that isn't an exact schema `target` 400s the whole submission.)*
+**The markup is yours to author.** Write a JSX element per field (step 5) when the layout matters,
+which on a designed page it usually does. Loop over `read.orderedInputs(form)` with a branch per
+control type instead when the owner will keep editing the form, and a dashboard change should reach
+the site with no code touch. The per-field wiring is identical either way.
 
 The JSDoc in `hooks/useWixForm.js` and `lib/wix-form-schema-utils.js` covers what each util does;
 this covers which control a field wants and where the obvious implementation is wrong. Markup and
@@ -61,7 +61,7 @@ import { WIX_FORMS } from "@/rest/wix-forms.config";   // written by the seed �
 const { form, values, setValues, submit, validate, errors, loading, read } =
   useWixForm(WIX_FORMS.contact.formId);
 
-const fields = read.orderedInputs(form);   // the raw fields to render, in the owner's layout order
+const fields = read.orderedInputs(form);   // what the form contains, in the owner's layout order
 ```
 
 | | |
@@ -69,6 +69,7 @@ const fields = read.orderedInputs(form);   // the raw fields to render, in the o
 | `form` | the Form exactly as Wix returned it (`null` until loaded). Nothing stripped or renamed. |
 | `values` | state, keyed by `target`: string for text/choice/date, **array** for multi-choice and files, **object** for an address. Seeded from the schema's defaults. |
 | `setValues` | plain React setter — `setValues((v) => ({ ...v, [name]: value }))`. |
+| `bind(target)` | the props a text-ish control needs, ready to spread: `name`, `value`, `onChange`, `onBlur`, `aria-describedby`, `aria-invalid`. |
 | `submit(event)` | use as `onSubmit`; resolves **`true`** only when the submission was created. |
 | `validate(target?)` | one field, one address subfield, or the whole form. Returns whether it passed. |
 | `errors` | control name → visitor-facing message; `errors[FORM_ERROR]` is form-level. |
@@ -95,19 +96,20 @@ setSiteCountry("GB");
 
 ### 2 · Render one control per field
 
-Map over `fields`. Every control carries the same four things:
+Author them or loop over them — every control carries the same four things, and `bind(target)` from
+the hook supplies the first three:
 
-1. **`name={read.targetOf(field)}`** — the immutable storage key, and also the state key, the error
+1. **`name` = the field's `target`** — the immutable storage key, and also the state key, the error
    key and the submission key. Keying everything by it makes the submission right by construction;
    it's how a blocked submit finds the control to focus, and it drives autofill.
-2. **`value` from `values[target]`, written back through `setValues`.** (A file input can't be
-   controlled — it takes only `onChange`.)
-3. **`onBlur={() => validate(target)}`** — not on the first keystroke of an untouched field, which
+2. **`value` from `values[target]`, written back through `setValues`.** (A choice group carries
+   `checked` instead; a file input can't be controlled at all and takes only `onChange`.)
+3. **`onBlur` → `validate(target)`** — not on the first keystroke of an untouched field, which
    reddens a required field before the visitor types. Once flagged, re-check as they type from an
    **effect on the value**: React hasn't committed the new value when `onChange` runs, so a check
    there judges the value they just replaced.
-4. **A real `<label>` from `read.labelOf(field)`, and an error node** — see step 6 for the wiring
-   both need.
+4. **A real `<label>`, and an error node** — see step 6 for the wiring both need. `bind` sets the
+   error node's `aria-describedby`/`id` pair (`err-${target}`); you render the node itself.
 
 **Stamp the schema's constraints as native attributes.** They reinforce the JS checks and drive
 mobile keyboards:
@@ -215,8 +217,8 @@ The hook's `submit` runs this before it sends anything:
 
 So `values[target]` holds `File` objects until submit, and validation checks the count (`required`,
 `fileLimit`) since no string rule applies. Three render consequences: the input can't be controlled
-(wire `onChange`, list the picked filenames yourself); clearing it after success needs a `key` bump,
-because resetting state leaves the browser's own "1 file selected" text; and uploads run inside
+(wire `onChange`, list the picked filenames yourself); clearing it after success needs a `key` you
+bump in `handleSubmit`, because resetting state leaves the browser's own "1 file selected" text; and uploads run inside
 `loading`, so the button's progress state matters more here.
 
 **A signature** shares `WIX_FILE`, so a file input accepts one — but the honest control is a canvas:
@@ -272,19 +274,20 @@ visitor a payment step: surface it **inside** the success state, never as a fail
 
 **No captcha** at the default protection level — don't add captcha plumbing speculatively.
 
-### 5 · The states around the form
+### 5 · The whole component
+
+Author one JSX element per field, using the `target`s the seed wrote and the constraints the schema
+states. `bind(target)` supplies the wiring every control shares — `name`, `value`, `onChange`,
+`onBlur`, `aria-describedby`, `aria-invalid` — so a field is a label, a control and its error node:
 
 ```jsx
 export default function ContactForm() {
-  const { form, values, setValues, submit, validate, errors, loading, read } =
+  const { form, values, bind, setValues, submit, validate, errors, loading, read } =
     useWixForm(WIX_FORMS.contact.formId);
   const [sent, setSent] = useState(false);
-  const [resetKey, setResetKey] = useState(0);   // bump on success to clear file inputs
 
   async function handleSubmit(event) {
-    const ok = await submit(event);
-    setSent(ok);
-    if (ok) setResetKey((k) => k + 1);
+    setSent(await submit(event));   // true only when the submission was created
   }
 
   if (loading && !form) return <p>Loading…</p>;
@@ -302,15 +305,36 @@ export default function ContactForm() {
     );
   }
 
-  const fields = read.orderedInputs(form);
-  if (fields.length === 0) return <p>This form has no fields yet — add them in your Wix dashboard.</p>;
-
   return (
     <form onSubmit={handleSubmit} noValidate>
-      {fields.map((field) => (
-        <Field key={read.targetOf(field)} field={field} values={values} setValues={setValues}
-               errors={errors} validate={validate} resetKey={resetKey} />
-      ))}
+      <label>
+        <span>Your email<span aria-hidden="true"> *</span></span>
+        <input {...bind("email_a1b2")} type="email" required autoComplete="email" />
+        <p className="error" id="err-email_a1b2" role="alert">{errors.email_a1b2}</p>
+      </label>
+
+      <label>
+        <span>How can we help?</span>
+        <textarea {...bind("message_c3d4")} rows={5} maxLength={500} />
+        <p className="error" id="err-message_c3d4" role="alert">{errors.message_c3d4}</p>
+      </label>
+
+      {/* A choice group carries `checked` rather than `value`, so wire it by hand — same name,
+          same onBlur, and the aria-* on the fieldset because no single radio can hold them. */}
+      <fieldset aria-describedby="err-budget_e5f6" aria-invalid={Boolean(errors.budget_e5f6) || undefined}>
+        <legend>Budget</legend>
+        {["Under £5k", "£5k–£20k", "Over £20k"].map((option) => (
+          <label key={option}>
+            <input type="radio" name="budget_e5f6" value={option}
+                   checked={values.budget_e5f6 === option}
+                   onChange={() => setValues((v) => ({ ...v, budget_e5f6: option }))}
+                   onBlur={() => validate("budget_e5f6")} />
+            {option}
+          </label>
+        ))}
+        <p className="error" id="err-budget_e5f6" role="alert">{errors.budget_e5f6}</p>
+      </fieldset>
+
       <p role="alert">{errors[FORM_ERROR]}</p>
       <button type="submit" disabled={loading}>
         {loading ? "Sending…" : (read.submitTextOf(form) || "Submit")}
@@ -320,8 +344,16 @@ export default function ContactForm() {
 }
 ```
 
-`Field` is yours — one branch per control (step 2). `noValidate` keeps your messages instead of the
-browser's bubbles; the native constraints still drive keyboards and assistive tech.
+The `target`s (`email_a1b2`, …) come from `WIX_FORMS.<key>.targets` — **never invent or shorten one**,
+since a key that isn't an exact schema `target` 400s the whole submission. Everything else on each
+control comes from that field's schema entry (step 2): its label, its `required`, its length/pattern
+bounds, its choice options. `noValidate` keeps your messages instead of the browser's bubbles; the
+native constraints still drive keyboards and assistive tech.
+
+**Authoring beats looping here**, because the layout is the point: a two-column name row, a budget
+group styled as cards, copy between sections. **Loop instead when the owner will keep editing the
+form** — `read.orderedInputs(form).map(...)` with a branch per control type keeps a dashboard change
+reaching the site with no code touch. Either way the wiring per field is what's above.
 
 Two things the shell doesn't show:
 
@@ -353,7 +385,8 @@ Don't reach for `role="form"`, an `aria-label` on an input that already has a `<
 
 - A visitor-fillable form is this vertical, not `cms`.
 - Read and write only through the shipped helpers — never hand-build a Wix Forms URL.
-- Never hardcode a field list; never detect a control by its `target` name.
+- Never invent a `target`, label, option or constraint — every one comes from the schema (authored
+  markup included). Never detect a control by its `target` name either.
 - Read fields through the accessors, not by reaching into `inputOptions` — the block names are enum
   derived, and the accessors map every one of them.
 - Key every control by `target`: `values[target]`, `errors[target]`, `name`. Address subfields use
@@ -421,7 +454,8 @@ Substitute the site's `metaSiteId`:
 
 - [ ] `wix-forms.config.js` exists; every `formId` comes from `WIX_FORMS`, none typed by hand.
 - [ ] `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Relabel a field in the dashboard, reload: the new label appears with no code change.
+- [ ] Looped form: relabel a field in the dashboard, reload, the new label appears with no code
+      change. Authored form: every `target` in the JSX matches `WIX_FORMS.<key>.targets` exactly.
 - [ ] Every field `read.orderedInputs(form)` returns has a control — long answer is a `<textarea>`,
       choice groups render their options, an address renders its subfields — or what you skipped
       isn't `required`.

--- a/skills/wix-vibe-headless/references/forms/app/hooks/useWixForm.js
+++ b/skills/wix-vibe-headless/references/forms/app/hooks/useWixForm.js
@@ -4,7 +4,7 @@
 // has a different field set and no "contact form" component could ship for it. You build the markup
 // — see `references/forms/INSTRUCTIONS.md`, "Build the UI".
 //
-//   const { form, values, setValues, submit, validate, errors, loading, read } =
+//   const { form, values, setValues, bind, submit, validate, errors, loading, read } =
 //     useWixForm(WIX_FORMS.contact.formId);
 //
 // The fields to render are the RAW field objects Wix returned — no projection, nothing hidden. Take
@@ -250,6 +250,9 @@ function focusControl(formEl, name) {
  *     // for a multi-choice field, an OBJECT for an address. Bind every control's `value` to it.
  *   setValues: (next: object | ((prev: object) => object)) => void,
  *     // The plain React setter — `setValues((v) => ({ ...v, [name]: value }))` from onChange.
+ *   bind: (target: string) => object,
+ *     // The props a text-ish control needs, ready to spread: name, value, onChange, onBlur and the
+ *     // two aria attributes. `<input {...bind(target)} type="email" required />`.
  *   submit: (event?: SubmitEvent) => Promise<boolean>,
  *     // Use as `onSubmit`. Validates, submits, and resolves TRUE when the submission was created —
  *     // that resolved true IS the success signal (a visitor can't read submissions back), so flip
@@ -353,6 +356,22 @@ export function useWixForm(formId) {
     [fields, values],
   );
 
+  // Everything a text-ish control needs, in one spread: `<input {...bind("email_a1b2")} type="email" />`.
+  // Covers input / textarea / select. A checkbox or radio group carries `checked` instead of `value`
+  // and a file input can't be controlled at all — wire those two by hand (INSTRUCTIONS.md, step 2),
+  // keeping the same `name`, `onBlur` and `aria-*` contract.
+  const bind = useCallback(
+    (target) => ({
+      name: target,
+      value: values[target] ?? "",
+      onChange: (event) => setValues((prev) => ({ ...prev, [target]: event.target.value })),
+      onBlur: () => validate(target),
+      "aria-describedby": `err-${target}`,
+      "aria-invalid": errors[target] ? true : undefined,
+    }),
+    [values, errors, validate],
+  );
+
   const submit = useCallback(
     async (event) => {
       event?.preventDefault?.();
@@ -402,5 +421,5 @@ export function useWixForm(formId) {
     [fields, form, values],
   );
 
-  return { form, values, setValues, submit, validate, errors, loading, read };
+  return { form, values, setValues, bind, submit, validate, errors, loading, read };
 }

--- a/skills/wix-vibe-headless/references/forms/app/hooks/useWixForm.js
+++ b/skills/wix-vibe-headless/references/forms/app/hooks/useWixForm.js
@@ -1,0 +1,406 @@
+// useWixForm — one form, minus the markup. It loads the LIVE schema, validates against it, submits,
+// and lands the server's violations on the right controls. What it does NOT do is render: this
+// vertical ships no UI, because a form is schema-driven (the owner picks the fields), so every form
+// has a different field set and no "contact form" component could ship for it. You build the markup
+// — see `references/forms/INSTRUCTIONS.md`, "Build the UI".
+//
+//   const { form, values, setValues, submit, validate, errors, loading, read } =
+//     useWixForm(WIX_FORMS.contact.formId);
+//
+// The fields to render are the RAW field objects Wix returned — no projection, nothing hidden. Take
+// them off `form` with the same accessors the hook uses internally (`read` is the module
+// `lib/wix-form-schema-utils.js`, handed back so the UI needs one import):
+//
+//   read.orderedInputs(form).map((field) => <label key={read.targetOf(field)}>{read.labelOf(field)}…</label>)
+//
+// The controls are CONTROLLED: `values` (keyed by each field's `target`) is the form's state, so
+// validate and submit read it directly — there is no FormData pass and no ref to hand over.
+//
+// Reading the live schema rather than a hardcoded field list is what makes an owner's dashboard edit
+// (add, relabel, reorder, require, constrain a field) show up on the site with no code change, and
+// what keeps the submission map from desyncing.
+//
+// Not on React? `validateField` below and everything in `lib/wix-form-schema-utils.js` are plain
+// functions — port the ~80 lines of state around them.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getForm, phoneExample, normalizePhone } from "@/rest/wix-forms";
+import {
+  uploadFormFiles,
+  toSubmissionValues,
+  createSubmission,
+  submissionViolations,
+} from "@/rest/wix-forms-submissions";
+import * as read from "@/lib/wix-form-schema-utils";
+import {
+  targetOf, labelOf, isRequired, isMulti, isFile, isNumber, isAddress,
+  addressPartsOf, validationOf, phoneCountryOf, orderedInputs,
+} from "@/lib/wix-form-schema-utils";
+
+/**
+ * The key in `errors` for a message that belongs to the FORM rather than one field — a schema that
+ * failed to load, or a submit rejection with no per-field violations. `@` can't appear in a Wix
+ * form `target`, so this can never collide with a field's own error.
+ */
+export const FORM_ERROR = "@form";
+
+/**
+ * The empty form: one entry per field, in the shape that field's control binds to — `[]` for a
+ * multi-choice field, `{}` for an address, and the owner's `default` prefill (else `""`) for the
+ * rest. Dropping `defaultValue` here would silently discard a dashboard setting.
+ */
+function defaultValues(fields) {
+  const values = {};
+  for (const field of fields) {
+    values[targetOf(field)] =
+      isAddress(field) ? {} :
+      isMulti(field) || isFile(field) ? [] : // a file field holds File objects
+      // The owner's prefill. Wix spells it `default` on most components and `defaultValue` on a
+      // rating, so read both — picking one silently drops a dashboard setting on the other.
+      read.componentOf(field).default ?? read.componentOf(field).defaultValue ?? "";
+  }
+  return values;
+}
+
+/**
+ * Client-side validation for one field — the rules behind `validate(target)`. It lives here rather
+ * than in `rest/` because nothing about it is a REST call: it's the UI's own read of the schema.
+ * Derives EVERY check from that schema — never from the field's name. (The classic mistake is keying the email check on `target === "email"`; doing it
+ * off `format` means an owner-added PHONE/URL/length rule is honored with no code change.)
+ *
+ * ⚠️ A client check LAXER than the server's is worse than none — the visitor then learns about the
+ * problem only after a round trip, in the server's wording rather than yours. Keep these at least
+ * as strict as the server, and submit the NORMALIZED value the check passed.
+ *
+ * @param {object} field  One raw field, from `fields`.
+ * @param {unknown} value  The control's current value.
+ * @returns {string}  A visitor-facing message, or "" when it passes.
+ */
+export function validateField(field, value) {
+  const rules = validationOf(field);
+  const label = labelOf(field);
+  const v = String(value ?? "").trim();
+  if (isRequired(field) && !v) return `${label} is required.`;
+  if (!v) return ""; // optional + empty → ok
+  if (rules.minLength && v.length < rules.minLength) return `${label} must be at least ${rules.minLength} characters.`;
+  if (rules.maxLength && v.length > rules.maxLength) return `${label} must be at most ${rules.maxLength} characters.`;
+  // A NUMBER field carries no `format`; its rules are the bounds, and the control hands back a
+  // string, so parse before comparing — `"9" > 10` is false but `"9" > "10"` is true.
+  if (isNumber(field)) {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return `${label} must be a number.`;
+    const min = minimumOf(field);
+    const max = maximumOf(field);
+    if (min != null && n < min) return `${label} must be ${min} or more.`;
+    if (max != null && n > max) return `${label} must be ${max} or less.`;
+    return "";
+  }
+  if (rules.format === "EMAIL" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return "Please enter a valid email address.";
+  if (rules.format === "URL" && !/^https?:\/\/.+/.test(v)) return "Please enter a valid URL.";
+  // PHONE is E.164 server-side: leading +, country code, digits only. Strip formatting first —
+  // visitors add spaces, dashes and parens, and rejecting those is a UX bug, not validation.
+  if (rules.format === "PHONE" && !/^\+[1-9]\d{6,14}$/.test(normalizePhone(v)))
+    return `Use international format, e.g. ${phoneExample(phoneCountryOf(field))}.`;
+  if (rules.pattern && !new RegExp(rules.pattern).test(v)) return `${label} is not in the expected format.`;
+  return "";
+}
+
+/**
+ * A NUMBER field's bounds. The validation block is JSON-Schema shaped everywhere else
+ * (`minLength`, `maxLength`, `pattern`, `format`, `enum`), so the numeric pair is `minimum` /
+ * `maximum`; `minValue` / `maxValue` are read too, since the public reference documents neither
+ * spelling and an older schema may carry them. Undefined when the owner set no bound.
+ */
+const minimumOf = (field) => validationOf(field).minimum ?? validationOf(field).minValue;
+const maximumOf = (field) => validationOf(field).maximum ?? validationOf(field).maxValue;
+
+/** `postalCode` → "Postal code" — an address subfield is a key, not a label the schema carries. */
+function humanizeSub(sub) {
+  const words = sub.replace(/([A-Z])|(\d+)/g, " $1$2").toLowerCase().trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * The error entries one field currently has, keyed by input NAME — the same keys the controls and
+ * the server's error paths use. (Distinct from `validateField` above, which judges a single VALUE
+ * against one field's rules and returns one message; this maps that onto the form's keys, and an
+ * address has several.) A plain field yields at most one entry (`target`); an ADDRESS
+ * yields one per failing subfield (`target/sub`).
+ *
+ * Every rule comes from the schema (`validateField` above): `required`,
+ * `minLength`/`maxLength`, `pattern`, and `format` — EMAIL, PHONE (E.164), URL. Nothing is keyed off
+ * a field's NAME, so an owner-added constraint is honored with no code change.
+ *
+ * An address subfield gets the `required` check only: `country` and `subdivision` are
+ * country-dependent enums the schema doesn't enumerate, so their content is the server's call.
+ */
+function errorsForField(field, values) {
+  const errors = {};
+  const target = targetOf(field);
+
+  if (isAddress(field)) {
+    const parts = values[target] ?? {};
+    for (const { sub, required } of addressPartsOf(field)) {
+      // Only `required` is checkable here: country/subdivision are country-dependent enums the
+      // schema doesn't enumerate, so their content is the server's call.
+      if (required && !String(parts[sub] ?? "").trim())
+        errors[`${target}/${sub}`] = `${humanizeSub(sub)} is required.`;
+    }
+    return errors;
+  }
+
+  // A file field holds File objects, which no string rule can judge — check the count instead.
+  if (isFile(field)) {
+    const limit = validationOf(field).fileLimit;
+    const picked = [].concat(values[target] ?? []).filter(Boolean);
+    if (isRequired(field) && !picked.length) errors[target] = `${labelOf(field)} is required.`;
+    else if (limit && picked.length > limit)
+      errors[target] = `Attach at most ${limit} file${limit === 1 ? "" : "s"}.`;
+    return errors;
+  }
+
+  const message = validateField(field, values[target]);
+  if (message) errors[target] = message;
+  return errors;
+}
+
+/** Every field's error entries, merged into one `name → message` map. */
+function errorsForForm(fields, values) {
+  const errors = {};
+  for (const field of fields) Object.assign(errors, errorsForField(field, values));
+  return errors;
+}
+
+/** `format` → the copy for a FORMAT_ERROR, since "wrong shape" means something different per format. */
+const FORMAT_COPY = {
+  EMAIL: () => "Enter a valid email address.",
+  PHONE: (f) => `Use international format, e.g. ${phoneExample(phoneCountryOf(f))}.`,
+  URL: () => "Enter a full URL starting with https://",
+  DATE: () => "Choose a valid date.",
+};
+
+/** errorType → visitor-facing copy, written from the field's own schema. */
+const ERROR_COPY = {
+  REQUIRED_VALUE_ERROR: (f) => `${labelOf(f)} is required.`,
+  MIN_LENGTH_ERROR: (f) => `${labelOf(f)} must be at least ${validationOf(f).minLength} characters.`,
+  MAX_LENGTH_ERROR: (f) => `${labelOf(f)} must be at most ${validationOf(f).maxLength} characters.`,
+  MIN_VALUE_ERROR: (f) => `${labelOf(f)} must be ${minimumOf(f) ?? "higher"} or more.`,
+  MAX_VALUE_ERROR: (f) => `${labelOf(f)} must be ${maximumOf(f) ?? "lower"} or less.`,
+  FORMAT_ERROR: (f) => FORMAT_COPY[validationOf(f).format]?.(f) ?? `Please check ${labelOf(f)}.`,
+  PATTERN_ERROR: (f) => `${labelOf(f)} is not in the expected format.`,
+  NOT_ALLOWED_VALUE_ERROR: (f) => `Choose one of the listed options for ${labelOf(f)}.`,
+  TYPE_ERROR: (f) => `Please check ${labelOf(f)}.`,
+  UNKNOWN_VALUE_ERROR: (f) => `Please check ${labelOf(f)}.`,
+};
+
+/**
+ * Turn a failed `createSubmission` into per-control messages, keyed by input NAME — so each message
+ * lands on its own control instead of only a form-level banner. An address subfield's server path
+ * (`address/subdivision`) is exactly how its control is named, so it maps straight through.
+ *
+ * The copy is written from `errorType` plus the field's own schema; Wix's `errorMessage` is the
+ * validator's internal wording, so it goes to `console.debug` only. An unmapped `errorType` degrades
+ * to safe copy — the enum grows, and MIN/MAX_VALUE_ERROR, MIN/MAX_ITEMS_ERROR and
+ * DISABLED_FORM_ERROR are all reachable without being listed above.
+ *
+ * ⚠️ Two rejections here are SEED bugs, not frontend bugs — do NOT mangle the key or the value to
+ * work around them (fix them in `seed/SEED.md`):
+ *   • `UNKNOWN_VALUE_ERROR` on a key that IS in the schema → the field was seeded with no
+ *     `validation` block, and that block is what registers the target as an accepted value.
+ *   • `NOT_ALLOWED_VALUE_ERROR` on a choice field → the seed's `options[].value` and its validation
+ *     enum disagree; the two declarations must match.
+ *
+ * @param {Error & { body?: object }} err
+ * @param {object[]} fields  The raw fields being rendered.
+ * @returns {Record<string, string>}  Empty when the failure wasn't a validation error.
+ */
+export function mapSubmissionErrors(err, fields) {
+  const byTarget = new Map(fields.map((f) => [targetOf(f), f]));
+  const errors = {};
+  for (const violation of submissionViolations(err)) {
+    const field = byTarget.get(violation.errorPath.split("/")[0]);
+    if (!field) continue;
+    console.debug("wix-forms: server violation", violation.errorPath, violation.errorType, violation.errorMessage);
+    errors[violation.errorPath] = ERROR_COPY[violation.errorType]?.(field) ?? `Please check ${labelOf(field)}.`;
+  }
+  return errors;
+}
+
+/**
+ * Move focus to a control by input name. ⚠️ `namedItem` returns a `RadioNodeList` for a radio or
+ * checkbox group and an element for everything else — a guard that checks only for an element
+ * silently skips every choice group.
+ */
+function focusControl(formEl, name) {
+  const control = formEl?.elements?.namedItem?.(name);
+  const node =
+    typeof RadioNodeList !== "undefined" && control instanceof RadioNodeList ? control[0] : control;
+  node?.focus?.();
+}
+
+/**
+ * @param {string} formId  The form's GUID — read it from `WIX_FORMS` in `rest/wix-forms.config.js`
+ *                         (written by the seed); never type a literal id into a component.
+ * @returns {{
+ *   form: object|null,
+ *     // The Form exactly as Wix returned it, once loaded. Nothing is stripped or renamed: the
+ *     // fields to render are `read.orderedInputs(form)`, the submit wording
+ *     // `read.submitTextOf(form)`. Never hardcode a field list.
+ *   values: Record<string, unknown>,
+ *     // The form's state, keyed by each field's `target`: a string for text/choice/date, an ARRAY
+ *     // for a multi-choice field, an OBJECT for an address. Bind every control's `value` to it.
+ *   setValues: (next: object | ((prev: object) => object)) => void,
+ *     // The plain React setter — `setValues((v) => ({ ...v, [name]: value }))` from onChange.
+ *   submit: (event?: SubmitEvent) => Promise<boolean>,
+ *     // Use as `onSubmit`. Validates, submits, and resolves TRUE when the submission was created —
+ *     // that resolved true IS the success signal (a visitor can't read submissions back), so flip
+ *     // your own thank-you state on it. FALSE means `errors` now says why.
+ *   validate: (target?: string) => boolean,
+ *     // `validate("email")` checks that one field, `validate("address/city")` one address subfield,
+ *     // `validate()` the whole form. Every rule comes from the schema — `required`,
+ *     // `minLength`/`maxLength`, `pattern`, `format` (EMAIL/PHONE/URL) — never from a field's name.
+ *     // Writes `errors` (clearing what now passes) and returns whether what it checked passed.
+ *   errors: Record<string, string>,
+ *     // input name → visitor-facing message. The name is the field's `target`, or `target/sub` for
+ *     // an address subfield. `errors[FORM_ERROR]` holds a form-level message (load or submit).
+ *   loading: boolean,
+ *     // Busy: loading the schema (`form` still null) or submitting (`form` set).
+ *   read: typeof import("@/lib/wix-form-schema-utils"),
+ *     // The schema accessors — functions, not data: `read.labelOf(field)`, `read.choicesOf(field)`,
+ *     // `read.submitTextOf(form)`, … Handed back so the UI needs one import.
+ * }}
+ */
+export function useWixForm(formId) {
+  const [form, setForm] = useState(null);
+  const [values, setValues] = useState({});
+  const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(true);
+  // The empty form to fall back to after a successful submit — the schema's own defaults.
+  const emptyRef = useRef({});
+
+  // Every visible INPUT the schema lays out, in the owner's order — the list the hook seeds values
+  // from, validates and submits. The UI gets it the same way (`read.orderedInputs(form)`), so there
+  // is no second copy to keep in sync and no filtered subset to explain.
+  const fields = useMemo(() => orderedInputs(form), [form]);
+
+  useEffect(() => {
+    let live = true;
+    if (!formId) {
+      setLoading(false);
+      setErrors({ [FORM_ERROR]: "No formId — pass one from WIX_FORMS (the seed writes it)." });
+      return;
+    }
+    setLoading(true);
+    getForm(formId)
+      .then((loaded) => {
+        if (!live) return;
+        setForm(loaded);
+        setErrors({});
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (!live) return;
+        // Fail loudly. A form that can't load is a setup problem (wrong id, Forms app missing) —
+        // never fall back to a hand-built form, which would drop real enquiries silently.
+        setErrors({ [FORM_ERROR]: e.message || "Could not load the form." });
+        setLoading(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, [formId]);
+
+  // Seed the controls once the schema is in: every control is controlled from the first render, so
+  // each `target` must hold a value of the right shape before any of them mount.
+  useEffect(() => {
+    const empty = defaultValues(fields);
+    emptyRef.current = empty;
+    setValues(empty);
+  }, [fields]);
+
+  const validate = useCallback(
+    (target) => {
+      // No target → the whole form. This is what `submit` runs before it sends anything.
+      if (!target) {
+        const all = errorsForForm(fields, values);
+        setErrors(all);
+        return Object.keys(all).length === 0;
+      }
+
+      const key = String(target);
+      const field = fields.find((f) => targetOf(f) === key.split("/")[0]);
+      if (!field) return true;
+
+      // The error keys this call owns, so a re-check CLEARS what it fixed as well as flagging what
+      // it didn't: one key for a plain field, or all of an address's subfields (`target/sub`) when
+      // the address itself is named. Naming a single subfield scopes it to that one.
+      const owned = key.includes("/")
+        ? [key]
+        : isAddress(field)
+          ? addressPartsOf(field).map(({ sub }) => `${targetOf(field)}/${sub}`)
+          : [targetOf(field)];
+
+      const found = errorsForField(field, values);
+      setErrors((prev) => {
+        const next = { ...prev };
+        for (const k of owned) {
+          delete next[k];
+          if (found[k]) next[k] = found[k];
+        }
+        return next;
+      });
+      return owned.every((k) => !found[k]);
+    },
+    [fields, values],
+  );
+
+  const submit = useCallback(
+    async (event) => {
+      event?.preventDefault?.();
+      // Capture the <form> now: React clears `currentTarget` once the handler returns, so reading it
+      // after the await below (to focus a server-rejected control) would come back null.
+      const formEl = event?.currentTarget ?? null;
+      if (!form) return false;
+
+      // Client pass first, so the visitor gets inline feedback in OUR wording before a round trip.
+      const clientErrors = errorsForForm(fields, values);
+      if (Object.keys(clientErrors).length) {
+        setErrors(clientErrors);
+        // FOCUS the first invalid control — `scrollIntoView` moves the viewport and nothing else,
+        // leaving a keyboard or screen-reader user where they were. The <form> comes from the event,
+        // and each control is found by its `name` (which is its `target`).
+        focusControl(formEl, Object.keys(clientErrors)[0]);
+        return false;
+      }
+
+      setLoading(true);
+      try {
+        // Any picked files go up FIRST — a `File` object is not something the submission API takes,
+        // and its value is the upload URL this hands back. No file fields → nothing happens here.
+        const uploaded = await uploadFormFiles(form.id, fields, values);
+        // Resolves on CONFIRMED, PENDING or PAYMENT_WAITING — all three are created submissions.
+        // There is nothing to read back, so this is the only confirmation there is. (A form that
+        // collects payment leaves the visitor a payment step; call createSubmission directly if you
+        // need its `status` to surface that inside your success state.)
+        await createSubmission(form.id, toSubmissionValues(fields, uploaded));
+        setErrors({});
+        setValues(emptyRef.current); // back to the schema's defaults, ready for another
+        return true;
+      } catch (e) {
+        // Per-field violations land on their controls; anything else is a form-level message.
+        const mapped = mapSubmissionErrors(e, fields);
+        if (Object.keys(mapped).length) {
+          setErrors(mapped);
+          focusControl(formEl, Object.keys(mapped)[0]);
+        } else {
+          setErrors({ [FORM_ERROR]: e.message || "Could not send the form. Please try again." });
+        }
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fields, form, values],
+  );
+
+  return { form, values, setValues, submit, validate, errors, loading, read };
+}

--- a/skills/wix-vibe-headless/references/forms/app/lib/wix-form-schema-utils.js
+++ b/skills/wix-vibe-headless/references/forms/app/lib/wix-form-schema-utils.js
@@ -162,9 +162,14 @@ export const phoneCountryOf = (field) =>
 export function orderedInputs(form) {
   const order = new Map(
     (form?.steps ?? [])
-      .flatMap((s) => s.layout?.large?.items ?? s.layout?.medium?.items ?? s.layout?.small?.items ?? [])
-      .slice()
-      .sort((a, b) => a.row - b.row || a.column - b.column)
+      // Sort WITHIN each step, then concatenate in step order: `row` restarts at 0 in every step,
+      // so one sort across the flattened list interleaves them — step 1's second field would land
+      // after step 2's first.
+      .flatMap((s) =>
+        (s.layout?.large?.items ?? s.layout?.medium?.items ?? s.layout?.small?.items ?? [])
+          .slice()
+          .sort((a, b) => a.row - b.row || a.column - b.column),
+      )
       .map((item, i) => [item.fieldId, i]),
   );
   return (form?.formFields ?? [])

--- a/skills/wix-vibe-headless/references/forms/app/lib/wix-form-schema-utils.js
+++ b/skills/wix-vibe-headless/references/forms/app/lib/wix-form-schema-utils.js
@@ -1,0 +1,182 @@
+// Reading a Wix Form schema — plain functions over the RAW `Form` and its `formFields[]`. No React,
+// no REST, no projection: the field object Wix returns IS the model the UI renders from, and these
+// are the accessors that make it readable.
+//
+//   import * as read from "@/lib/wix-form-schema-utils";
+//   read.orderedInputs(form).map((field) => <Field key={read.targetOf(field)} field={field} />)
+//
+// Nothing is guessed, and nothing is dropped — which matters because the schema nests a field's
+// settings TWO levels deep, under blocks named after its own enums:
+//
+//   inputOptions
+//     ├─ target / inputType / required        ← the field's identity
+//     └─ stringOptions | arrayOptions | …     ← named after `inputType`            (`optionsOf`)
+//          ├─ componentType / validation      ← the control, and its rules         (`validationOf`)
+//          └─ dropdownOptions | textInputOptions | …  ← named after `componentType` (`componentOf`)
+//               └─ label / placeholder / options / default
+//
+// ⚠️ Those two block names are the whole reason this file exists. They are looked up in the tables
+// below rather than hand-written at the call site, because `inputOptions.stringOptions.dropdownOptions`
+// spelled out in a component is one typo away from silently reading back no label at all.
+
+/**
+ * `inputType` → the block holding that type's `componentType`, `validation`, and component block.
+ * Every input type the Form Schemas API defines
+ * (https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields.md).
+ */
+const INPUT_BLOCK = {
+  STRING: "stringOptions",
+  NUMBER: "numberOptions",
+  BOOLEAN: "booleanOptions",
+  ARRAY: "arrayOptions",
+  ADDRESS: "addressOptions",
+  WIX_FILE: "wixFileOptions",
+  PAYMENT: "paymentOptions",
+  SCHEDULING: "schedulingOptions",
+};
+
+/**
+ * `componentType` → the block holding that control's `label`, `placeholder`, `options`, `default`.
+ * Note several fields share one component — short AND long answer are both `TEXT_INPUT`, image
+ * choice and multi choice are both `CHECKBOX_GROUP` — which is why the render branches on
+ * `identifier` too.
+ */
+const COMPONENT_BLOCK = {
+  TEXT_INPUT: "textInputOptions",
+  NUMBER_INPUT: "numberInputOptions",
+  RATING_INPUT: "ratingInputOptions",
+  PHONE_INPUT: "phoneInputOptions",
+  DATE_INPUT: "dateInputOptions",
+  DATE_PICKER: "datePickerOptions",
+  DATE_TIME: "dateTimeOptions",
+  TIME_INPUT: "timeInputOptions",
+  CHECKBOX: "checkboxOptions",
+  CHECKBOX_GROUP: "checkboxGroupOptions",
+  RADIO_GROUP: "radioGroupOptions",
+  DROPDOWN: "dropdownOptions",
+  TAGS: "tagsOptions",
+  MULTILINE_ADDRESS: "multilineAddressOptions",
+  FILE_UPLOAD: "fileUploadOptions",
+  SIGNATURE: "signatureOptions",
+  FIXED_PAYMENT: "fixedPaymentOptions",
+  PAYMENT_INPUT: "paymentInputOptions",
+  DONATION_INPUT: "donationInputOptions",
+  APPOINTMENT: "appointmentOptions",
+  SERVICES_DROPDOWN: "servicesDropdownOptions",
+  SERVICES_CHECKBOX_GROUP: "servicesCheckboxGroupOptions",
+};
+
+// An enum missing from a table means Wix added a type — say so ONCE (these run per field per
+// render) instead of quietly handing back an empty block and a field labelled by its target.
+const warned = new Set();
+function blockName(table, key, what) {
+  const name = table[key];
+  if (!name && key && !warned.has(key)) {
+    warned.add(key);
+    console.warn(
+      `wix-forms: no ${what} block mapped for "${key}" — that field will render without its label ` +
+        `or options. Add it to ${what === "inputType" ? "INPUT_BLOCK" : "COMPONENT_BLOCK"} in lib/wix-form-schema-utils.js.`,
+    );
+  }
+  return name;
+}
+
+/** The field's immutable storage key — the input's `name`, and THE submission key. */
+export const targetOf = (field) => field?.inputOptions?.target;
+
+/** STRING | NUMBER | ARRAY | ADDRESS | WIX_FILE | BOOLEAN | PAYMENT | SCHEDULING. */
+export const inputTypeOf = (field) => field?.inputOptions?.inputType;
+
+/** ⚠️ From `inputOptions`, not from `validation`. */
+export const isRequired = (field) => field?.inputOptions?.required ?? false;
+
+/** The input-type block: `componentType`, `validation`, and the component's own sub-block. */
+export const optionsOf = (field) =>
+  field?.inputOptions?.[blockName(INPUT_BLOCK, inputTypeOf(field), "inputType")] ?? {};
+
+/** DROPDOWN | RADIO_GROUP | CHECKBOX_GROUP | TEXT_INPUT | NUMBER_INPUT | FILE_UPLOAD | … */
+export const componentTypeOf = (field) => optionsOf(field).componentType;
+
+/** The component sub-block: `label`, `placeholder`, `options`, `default`, … */
+export const componentOf = (field) =>
+  optionsOf(field)[blockName(COMPONENT_BLOCK, componentTypeOf(field), "componentType")] ?? {};
+
+/** `format`, `minLength`, `maxLength`, `pattern`, `fields` (address), `fileLimit`, `phoneOptions`, … */
+export const validationOf = (field) => optionsOf(field).validation ?? {};
+
+/**
+ * The owner's label, falling back to the target so a control is never nameless.
+ *
+ * ⚠️ The fallback also covers a label that ISN'T A STRING: a BOOLEAN field (consent checkbox) labels
+ * itself with a Ricos rich-content object, which would otherwise reach the page — and any error copy
+ * built from it — as the text `[object Object]`. Render that field's label from
+ * `componentOf(field).label` yourself if you write a branch for it.
+ */
+export const labelOf = (field) => {
+  const label = componentOf(field).label;
+  return typeof label === "string" && label ? label : targetOf(field);
+};
+
+/** Multi-choice: submits an ARRAY of the checked option values. */
+export const isMulti = (field) => inputTypeOf(field) === "ARRAY";
+
+/** File upload or signature: holds `File` objects until submit swaps them for their upload URLs. */
+export const isFile = (field) => inputTypeOf(field) === "WIX_FILE";
+
+/** NUMBER covers both the number input and a rating — the value goes on the wire as a number. */
+export const isNumber = (field) => inputTypeOf(field) === "NUMBER";
+
+/** An ADDRESS submits a nested OBJECT, so its subfields are their own controls. */
+export const isAddress = (field) => inputTypeOf(field) === "ADDRESS";
+
+/** Choice options as `{ value, label }` — a label is optional in the schema, the value never is. */
+export const choicesOf = (field) =>
+  componentOf(field).options?.map((o) => ({ value: o.value, label: o.label ?? o.value })) ?? [];
+
+/**
+ * An ADDRESS field's subfields as `{ sub, required }`, in schema order. `validation.fields` lists
+ * them; only `addressLine2` carries a visibility setting, so this hides just that one when the owner
+ * turned it off.
+ */
+export const addressPartsOf = (field) =>
+  Object.entries(validationOf(field).fields ?? {})
+    .filter(([sub]) => componentOf(field).fieldSettings?.[sub]?.show !== false)
+    .map(([sub, cfg]) => ({ sub, required: cfg?.required ?? false }));
+
+/** The country a PHONE field's example should use — the FIELD's own before the site's. */
+export const phoneCountryOf = (field) =>
+  componentOf(field).defaultCountryCode ?? validationOf(field).phoneOptions?.allowedCountryCodes?.[0];
+
+/**
+ * Every visible INPUT field, in the order the owner laid out.
+ *
+ * ⚠️ Display order comes from `steps[].layout`, NOT from `formFields[]` array order. Take the order
+ * only — the geometry (`row`/`column`/`width`) is Wix's editor layout, which your own design
+ * replaces. A field the owner never placed sorts LAST; it still stores values.
+ *
+ * The submit button is `fieldType: "DISPLAY"`, so filtering to INPUT drops it automatically.
+ *
+ * @param {object} form  A Form from `getForm` / `listForms`.
+ * @returns {object[]}  Raw field objects — read them with the accessors above.
+ */
+export function orderedInputs(form) {
+  const order = new Map(
+    (form?.steps ?? [])
+      .flatMap((s) => s.layout?.large?.items ?? s.layout?.medium?.items ?? s.layout?.small?.items ?? [])
+      .slice()
+      .sort((a, b) => a.row - b.row || a.column - b.column)
+      .map((item, i) => [item.fieldId, i]),
+  );
+  return (form?.formFields ?? [])
+    .filter((f) => f.fieldType === "INPUT" && !f.hidden)
+    .sort((a, b) => (order.get(a.id) ?? Infinity) - (order.get(b.id) ?? Infinity));
+}
+
+/**
+ * The owner's submit-button wording, or "" when they didn't set one. It lives on the SUBMIT_BUTTON —
+ * a DISPLAY field, so it never appears in `orderedInputs` — and nests under `pageNavigationOptions`
+ * because one control drives both multi-page navigation and the final submit.
+ */
+export const submitTextOf = (form) =>
+  (form?.formFields ?? []).find((f) => f.identifier === "SUBMIT_BUTTON")
+    ?.displayOptions?.pageNavigationOptions?.submitText ?? "";

--- a/skills/wix-vibe-headless/references/forms/app/rest/wix-forms-submissions.js
+++ b/skills/wix-vibe-headless/references/forms/app/rest/wix-forms-submissions.js
@@ -1,0 +1,238 @@
+import { wixApiRequest } from "./wix-client.js";
+import { normalizePhone } from "./wix-forms.js";
+import { targetOf, inputTypeOf, isMulti, isFile, isAddress, addressPartsOf, validationOf } from "@/lib/wix-form-schema-utils";
+
+/**
+ * Wix Forms — the SUBMISSION: turn the form's values into the shape the API expects, create the
+ * submission, and map the server's per-field violations back onto controls. Same plain anonymous
+ * visitor token as the schema read in `wix-forms.js` — no SDK, no backend, no elevate.
+ *
+ * ⚠️ CRITICAL — the visitor token creates the submission, despite the spec. `CreateSubmission` is
+ * listed under the owner scope `SCOPE.DC-FORMS.MANAGE-SUBMISSIONS`, and in practice returns 200 on
+ * an anonymous visitor token: Wix grants implicit visitor access so a published site can submit its
+ * own forms. Reaching for a backend here is the most common wrong turn on this vertical.
+ *
+ * ⚠️ SUBMISSIONS ARE WRITE-ONLY FROM THE BROWSER. Reading them back
+ * (`querySubmissionsByNamespace`, `getSubmission`, `countSubmission`) genuinely requires the owner
+ * scope `WIX_FORMS.SUBMISSION_READ_ANY` and 403s for a visitor. The resolved `createSubmission`
+ * promise IS the success signal — show a thank-you; the submission appears in the owner's dashboard.
+ * A site that must LIST what visitors submitted needs the `cms` vertical instead.
+ *
+ * Submit values: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values.md
+ * Upload URL:    https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/get-media-upload-url.md
+ * Create:        https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/create-submission.md
+ */
+
+/**
+ * Submission statuses that mean the submission EXISTS — show the thank-you. `CONFIRMED` is recorded,
+ * `PENDING` is created but not recorded yet, and `PAYMENT_WAITING` is created on a form that also
+ * collects payment. See `createSubmission` for why this is an allowlist rather than a catch-all.
+ */
+export const SUBMITTED_OK = new Set(["CONFIRMED", "PENDING", "PAYMENT_WAITING"]);
+
+/**
+ * Get a signed URL to upload one file for a form submission — the FORMS-scoped wrapper around the
+ * Media Manager's upload URL, so a visitor can attach a file without the Manage-Media credential a
+ * direct `site-media` call would demand (that one 403s for a visitor; this one is listed under the
+ * same `SCOPE.FORMS.VIEW-FORM` as the schema read).
+ * Reference: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/get-media-upload-url.md
+ *
+ * @param {string} formId
+ * @param {string} filename  Including the extension — Wix reads the type from it.
+ * @param {string} mimeType  e.g. "image/png". A browser gives you `file.type`.
+ * @returns {Promise<string>}  The signed upload URL.
+ */
+export async function getMediaUploadUrl(formId, filename, mimeType) {
+  const res = await wixApiRequest("/form-submission-service/v4/submissions/media-upload-url", {
+    method: "POST",
+    body: { formId, filename, mimeType },
+  });
+  if (!res?.uploadUrl) throw new Error(`Could not get an upload URL for "${filename}".`);
+  return res.uploadUrl;
+}
+
+/**
+ * Upload one `File` and return the value to submit for its field.
+ *
+ * ⚠️ The submission value IS the generated `uploadUrl` — not the CDN URL the upload responds with,
+ * and not a file id. That's Wix's own contract (see the "media file" example on Create Submission
+ * and the "Submit a form with media" sample flow): get the URL, PUT the bytes to it, then send that
+ * same URL as the field's value.
+ *
+ * The PUT goes straight to Wix's upload host on a signed URL, so it uses plain `fetch` — NOT
+ * `wixApiRequest`: adding the visitor's Authorization header to a pre-signed URL is what turns a
+ * working upload into a 400.
+ *
+ * @param {string} formId
+ * @param {File} file  From an `<input type="file">`.
+ * @returns {Promise<string>}  The value to put in the submission for this field.
+ */
+export async function uploadSubmissionFile(formId, file) {
+  // A browser leaves `type` empty for extensions it doesn't recognize; the generic type keeps the
+  // upload-URL call valid (Media Manager rejects a mime type that contradicts the extension).
+  const mimeType = file.type || "application/octet-stream";
+  const uploadUrl = await getMediaUploadUrl(formId, file.name, mimeType);
+  const res = await fetch(`${uploadUrl}?filename=${encodeURIComponent(file.name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": mimeType },
+    body: file,
+  });
+  if (!res.ok) {
+    // Media Manager's own codes land here: FILE_SIZE_OVER_LIMIT, UNSUPPORTED_FILE_FORMAT,
+    // MISMATCH_MIME_TYPE, ZERO_FILE_SIZE, SITE_QUOTA_EXCEEDED.
+    throw new Error(`Could not upload "${file.name}" (${res.status}). Check its size and file type.`);
+  }
+  return uploadUrl;
+}
+
+/**
+ * Upload every `File` sitting in the form's state and return a copy of `values` with each file
+ * field replaced by its submitted value(s). Run this BEFORE `toSubmissionValues` — a `File` object
+ * is not something the submission API accepts.
+ *
+ * @param {string} formId
+ * @param {object[]} fields  The render model.
+ * @param {Record<string, unknown>} values
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function uploadFormFiles(formId, fields, values) {
+  const next = { ...values };
+  for (const field of fields) {
+    if (!isFile(field)) continue;
+    const target = targetOf(field);
+    const picked = [].concat(values[target] ?? []).filter((f) => f instanceof File);
+    const uploaded = [];
+    // Sequential on purpose: a visitor's uplink is the bottleneck, and a failed file should stop
+    // the submit rather than race three more uploads it will throw away.
+    for (const file of picked) uploaded.push(await uploadSubmissionFile(formId, file));
+    next[target] = uploaded;
+  }
+  return next;
+}
+
+/**
+ * Turn the form's state into the `submissions` map `createSubmission` expects — keyed by each
+ * field's `target`, which is the same key the controls are bound to, so the keys come out right by
+ * construction with no hand-maintained list to drift.
+ *
+ * Walks the SCHEMA, not the state object: a stray key in `values` can never reach the API, and a
+ * field the owner added shows up the moment the schema does.
+ *
+ * The three value shapes and their per-`inputType` rules
+ * (https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values.md):
+ *   • flat value  — text / dropdown / radio / date / time. NUMBER submits a number and PHONE the
+ *                   normalized E.164 string, never the raw control text.
+ *   • ARRAY       — a multi-choice field, holding the checked option values.
+ *   • OBJECT      — an ADDRESS, keyed by subfield (`city`, `country`, …), which is also the shape
+ *                   behind the server's nested `address/city` error paths.
+ * An empty optional field is OMITTED rather than sent as "" — the server validates what it's given.
+ *
+ * @param {object[]} fields  The render model, from `hooks/useWixForm.js`.
+ * @param {Record<string, unknown>} values  The form's state, keyed by `target`.
+ * @returns {Record<string, unknown>}
+ */
+export function toSubmissionValues(fields, values) {
+  const filled = (v) => v !== undefined && v !== null && String(v).trim() !== "";
+  const out = {};
+  for (const field of fields) {
+    const target = targetOf(field);
+    const raw = values?.[target];
+
+    if (isAddress(field)) {
+      const parts = {};
+      for (const { sub } of addressPartsOf(field)) {
+        if (filled(raw?.[sub])) parts[sub] = String(raw[sub]).trim();
+      }
+      if (Object.keys(parts).length) out[target] = parts;
+      continue;
+    }
+
+    if (isMulti(field)) {
+      const picked = (Array.isArray(raw) ? raw : []).filter(filled);
+      if (picked.length) out[target] = picked;
+      continue;
+    }
+
+    // A file field carries what `uploadFormFiles` produced — the upload URL(s). One file submits the
+    // bare string (the shape Wix's own example uses); several submit an array. A stray `File` that
+    // never went through the upload is dropped rather than sent, since it would 400 the whole form.
+    if (isFile(field)) {
+      const urls = [].concat(raw ?? []).filter((v) => typeof v === "string" && v);
+      if (urls.length) out[target] = urls.length === 1 ? urls[0] : urls;
+      continue;
+    }
+
+    if (!filled(raw)) continue;
+    const value = typeof raw === "string" ? raw.trim() : raw;
+    out[target] =
+      inputTypeOf(field) === "NUMBER" ? Number(value) :
+      validationOf(field).format === "PHONE" ? normalizePhone(value) : value;
+  }
+  return out;
+}
+
+/**
+ * Create a submission. This is the write — and the ONLY confirmation you get, since a visitor can't
+ * read submissions back.
+ * Reference: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/create-submission.md
+ *
+ * ⚠️ EVERY status this resolves on is a created submission — `CONFIRMED` (recorded), `PENDING`
+ * (created, not recorded yet) and `PAYMENT_WAITING` (created on a form that also collects payment).
+ * Show the thank-you for all three. Treating one as a failure invites the visitor to submit again,
+ * which costs the owner duplicate entries for a submission that already exists.
+ *
+ * `PAYMENT_WAITING` still leaves the visitor a payment step, but the SUBMIT succeeded — surface the
+ * payment inside the success state, never as a failed submission. A form only reaches this status if
+ * the UI rendered a PAYMENT field, so read the returned `status` when you build one.
+ * Success stays an ALLOWLIST rather than a catch-all, so a status added to the enum later can't
+ * silently render a thank-you for something that isn't a submission.
+ *
+ * ⚠️ REST returns `submission.id` — the SDK's normalized `_id` does not exist here.
+ *
+ * @param {string} formId
+ * @param {Record<string, unknown>} values  Map of `target` → value, from `toSubmissionValues`.
+ * @returns {Promise<{ id: string, status: string }>}
+ */
+export async function createSubmission(formId, values) {
+  const res = await wixApiRequest("/form-submission-service/v4/submissions", {
+    method: "POST",
+    body: { submission: { formId, submissions: values } },
+  });
+  const submission = res?.submission;
+  if (!submission?.id) throw new Error("Submission failed (no submission returned).");
+  if (!SUBMITTED_OK.has(submission.status)) {
+    throw new Error(
+      `Submission status is "${submission.status}" — not one of the statuses that mean the ` +
+        `submission was created (${[...SUBMITTED_OK].join(", ")}), so don't show a success state. ` +
+        `Check the Submission status docs before adding it to SUBMITTED_OK.`,
+    );
+  }
+  return { id: submission.id, status: submission.status };
+}
+
+/**
+ * Pull the per-field violations out of a failed `createSubmission`.
+ *
+ * The documented entries (`errorPath`, `errorType`, `errorMessage`, `params`) arrive under
+ * `details.validationError.fieldViolations[]`, each with its own nested `data.errors[]` array —
+ * two levels deeper than the docs' shape. This flattens that; turning a violation into words a
+ * visitor should read is the UI's job (`mapSubmissionErrors` in `hooks/useWixForm.js`).
+ *
+ * `errorPath` is the field's `target`, or a nested path like `address/subdivision` or
+ * `attachments/0/fileId` — which is exactly how the controls are named, so it maps straight across.
+ *
+ * Reference: https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction#validation-errors
+ *
+ * @param {Error & { body?: object }} err  From `createSubmission`; the REST body is on `err.body`.
+ * @returns {{ errorPath: string, errorType: string, errorMessage?: string }[]}  Empty when the
+ *   failure wasn't a validation error at all (a network drop, a 500).
+ */
+export function submissionViolations(err) {
+  const violations =
+    err?.body?.details?.validationError?.fieldViolations ??
+    err?.details?.validationError?.fieldViolations ??
+    [];
+  return violations
+    .flatMap((violation) => violation.data?.errors ?? [violation])
+    .filter((entry) => entry?.errorPath);
+}

--- a/skills/wix-vibe-headless/references/forms/app/rest/wix-forms.js
+++ b/skills/wix-vibe-headless/references/forms/app/rest/wix-forms.js
@@ -1,0 +1,108 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Forms — the form SCHEMA: read a form, on the plain anonymous visitor token this skill already
+ * mints. No SDK, no backend, no elevate. **The write path lives next door in
+ * `wix-forms-submissions.js`.**
+ *
+ * WHY THIS VERTICAL EXISTS: a visitor-fillable form is Wix Forms, not a CMS collection. The owner
+ * edits fields in the Wix dashboard, submissions land in their Forms inbox with spam protection
+ * and notifications, and the frontend re-renders from the live schema with no code change.
+ * Use `cms` only for content the app itself stores and READS BACK (listings, galleries, "my items").
+ *
+ * ⚠️ CRITICAL — the visitor token is enough, and the docs say otherwise. The API spec lists every
+ * schema read (`GetForm`/`ListForms`) under the owner scope `SCOPE.FORMS.VIEW-FORM`. In practice
+ * they return 200 on an anonymous visitor token — Wix grants implicit visitor access so a published
+ * site can render its own forms. Trust the live 200, not the permission table. Do NOT add a backend,
+ * a connector token, or any elevated credential to make a form work.
+ *
+ * READING the schema is `lib/wix-form-schema-utils.js` (plain accessors over the raw fields) and checking
+ * values against it is `hooks/useWixForm.js`. This file stays the transport, plus the phone helpers
+ * both sides need — `normalizePhone` for the value that goes on the wire, `phoneExample` for the one
+ * shown to a visitor.
+ *
+ * Form object: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md
+ * Form fields: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields.md
+ */
+
+/** The Wix Forms app namespace. Every form this vertical touches lives here. */
+export const FORMS_NAMESPACE = "wix.form_app.form";
+
+/**
+ * Read one form schema by id. Returns the `Form` directly (the REST envelope's `form` is unwrapped
+ * for you), or throws — a 404 `FORM_NOT_FOUND` means the id is wrong or the form was deleted.
+ * Reference: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/get-form.md
+ *
+ * @param {string} formId  The form's GUID (from the seed's `seeded.forms[].formId`).
+ * @returns {Promise<object>}  The Form: `{ id, formFields[], steps[], … }`.
+ */
+export async function getForm(formId) {
+  const res = await wixApiRequest(`/form-schema-service/v4/forms/${encodeURIComponent(formId)}`, {
+    method: "GET",
+  });
+  const form = res?.form;
+  if (!form) throw new Error(`Form "${formId}" not found.`);
+  return form;
+}
+
+/**
+ * List form schemas in the namespace. Use ONE call for several forms on a page rather than one
+ * `getForm` each; pass no `formIds` to discover every form the site has.
+ * Reference: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms.md
+ *
+ * ⚠️ Returns only ENABLED forms by default — a form the owner disabled silently vanishes from a
+ * discovery listing rather than erroring. That's usually right for a public site.
+ *
+ * @param {{ formIds?: string[], namespace?: string }} [options]  `formIds` takes up to 100 ids.
+ * @returns {Promise<object[]>}  Array of Form objects (the envelope's `forms`, unwrapped).
+ */
+export async function listForms({ formIds, namespace = FORMS_NAMESPACE } = {}) {
+  const res = await wixApiRequest("/form-schema-service/v4/forms", {
+    method: "GET",
+    query: { namespace, ...(formIds?.length ? { formIds } : {}) },
+  });
+  return res?.forms ?? [];
+}
+
+/**
+ * Phone examples shown to visitors (placeholder + error copy). Every value is a regulator-RESERVED
+ * fictional number for that country, so no real subscriber is ever printed.
+ *
+ * ⚠️ Never hardcode a user-visible example to one locale — a `+44`- or US-shaped example on a site
+ * in another market is a locale bug. Add a market only after verifying its reserved range in the
+ * national numbering plan; never invent a number. Never SUBMIT one either: a reserved number is
+ * rejected (see `validateField` in `hooks/useWixForm.js`), so these are display-only.
+ */
+export const PHONE_EXAMPLE = {
+  US: "+1 201 555 0123", CA: "+1 416 555 0123", // NANP 555-0100–0199 reserved for fiction
+  GB: "+44 7700 900123",                        // Ofcom drama range 07700 900xxx
+  IE: "+353 20 910 0001",                       // ComReg reserved 020 91x xxxx
+  AU: "+61 491 570 006",                        // ACMA reserved mobile range
+  FR: "+33 1 99 00 00 01",                      // ARCEP Île-de-France 01 99 00 xx xx reserved
+  DE: "+49 30 23125 000",                       // BNetzA Berlin 030 23125 xxx reserved
+  SE: "+46 70 174 06 05",                       // PTS reserved 070 174 06xx
+  KR: "+82 2 540 0000",                         // Seoul 02-540-xxxx reserved
+};
+
+/**
+ * The site's country (ISO-3166 alpha-2), used for any locale-derived example. Set it once from the
+ * business you're building for — the browser's own locale is the VISITOR's, not the site's.
+ * @type {string}
+ */
+export let SITE_COUNTRY = "US";
+/** Set the site's country once at app start, e.g. `setSiteCountry("GB")`. */
+export function setSiteCountry(code) {
+  if (code) SITE_COUNTRY = code.toUpperCase();
+}
+
+/**
+ * The example phone number for a country (ISO-3166 alpha-2), falling back to the site's and then to
+ * the US. Pass a PHONE field's own country when it has one — `phoneCountryOf(field)` in
+ * `lib/wix-form-schema-utils.js` reads it — so the example shown is one that field would accept.
+ */
+export function phoneExample(country) {
+  return PHONE_EXAMPLE[country ?? SITE_COUNTRY] ?? PHONE_EXAMPLE[SITE_COUNTRY] ?? PHONE_EXAMPLE.US;
+}
+
+/** Strip visitor-added formatting from a phone number — submit this, not the raw value. */
+export const normalizePhone = (v) => String(v ?? "").replace(/[\s()\-.]/g, "");

--- a/skills/wix-vibe-headless/references/forms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/forms/seed/SEED.md
@@ -1,0 +1,1781 @@
+# Forms — seeding (Form Schemas v4 REST)
+
+Creating a form is an **admin/build-time** job, in six sequential steps. Each has a section below.
+
+1. **Authenticate** — get an elevated credential; the public client ID cannot write.
+2. **Install the Wix Forms app** — idempotent, and nothing works until it's there.
+3. **Author the form body** — adapt the every-field payload to what the request asks for.
+4. **Create the form** — POST each body; a `200` here means almost nothing.
+5. **Verify it works** — read the form back, and **submit to it once** for real.
+6. **Hand off** — the verified `formId` + field `target`s are written to a file the UI imports.
+
+## API reference
+
+Wix Forms is a **CRM** API, not Business Solutions. Read the page before writing a call you don't
+find here — never guess a shape. For anything these pages don't settle — a response shape you didn't
+expect, or an operation this doc doesn't cover — use the **`wix-docs`** skill to search + read the
+live Wix API reference.
+
+| step | title | page | what it settles |
+|---|---|---|---|
+| 3 | About Form Fields | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields.md | every field-level rule: the identifier/inputType/componentType table, validation, choice fields, contact mapping, layout |
+| 3 | Create Form | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form.md | the create call, plus 10 complete request examples — the source of the payload below |
+| 3 | Form object | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md | each property individually, incl. form-level settings this doc doesn't cover |
+| 4 | Form Schemas API | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md | every schema method (get, list, delete, enable/disable) |
+| 4 | Update Form | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form.md | revising a form without losing its `formId` |
+| 4 | List Forms Providers Configs | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms-providers-configs.md | the Forms **app's** ceiling on fields and forms — **not** the site's plan cap, which this call cannot tell you (see step 4) |
+| 5 | Create Submission | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/create-submission.md | the submission call used to prove the form accepts data |
+| 5 | About Submission Values | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values.md | the value shape each `inputType` submits — string, array, address object, … |
+| 5 | Validation errors | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction.md#validation-errors | what a rejected submission is telling you |
+| — | Form Submissions API | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions.md | every submission method, incl. delete (used to clean up the test submission) |
+
+**⛔ Additive only — never delete, reset, or overwrite existing forms**, even ones that look like the
+install's own sample.
+
+**⚠️ Seed BEFORE the form's UI.** Forms is the one vertical that does not run in parallel with the
+client: its inputs bind to the schema's field `target`s, so nothing may be built against a form that
+hasn't been created *and verified*.
+
+## 1 · Authenticate
+
+Every call in this doc needs an **elevated credential** — a connector/OAuth access token, or a Wix
+API key. The public `WIX_CLIENT_ID` cannot write; see the platform doc's seed-auth step. There is
+**no helper module** — you make each call yourself with the shapes below.
+
+**Never inline the raw token/API key** into a command — it would end up in the transcript, exec logs,
+and shell history. Keep it in a variable and reference it. On Base44 (and any exec-tool platform),
+take it from the connector and call with `fetch()` rather than shelling out to curl:
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // stays in memory
+```
+
+On any other platform, load it into an env var from your secret manager and don't echo it. Either
+way, every call below sends the same three **standard headers** — referred to as such from here on:
+
+```
+Authorization: Bearer <token>     // a Wix API key goes in RAW, with no "Bearer"
+wix-site-id:   <METASITE_ID>
+Content-Type:  application/json
+```
+
+## 2 · Install the Wix Forms app
+
+```
+POST https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+{
+  "tenant":      { "tenantType": "SITE", "id": "<METASITE_ID>" },
+  "appInstance": { "appDefId": "225dd912-7dea-4738-8688-4b8c6955ffc2", "enabled": true }
+}
+```
+
+`225dd912-7dea-4738-8688-4b8c6955ffc2` is the Wix Forms app. Until it is installed **every** Form
+Schemas call fails with `UNSUPPORTED_FORM_NAMESPACE`, so run this before step 4. The call is
+idempotent — re-installing returns `200` — and Base44 sites often don't have the app, so re-running
+costs nothing.
+
+## 3 · Author the form body — every field type
+
+There is **one** create call:
+`POST https://www.wixapis.com/form-schema-service/v4/forms` with `{ "form": { … } }`.
+**You author that body**, starting from the payload below and adapting it to the request.
+
+The payload is one form holding **every field type Wix Forms supports**. Each field block is copied
+verbatim from the official Create Form examples, so the `identifier` / `inputType` / `componentType`
+triple, the options objects and the validation shapes are the ones Wix actually accepts. (Two
+exceptions: **Donation** comes from About Form Fields, and **Custom price** is the one field with no
+shipped example — it is composed from the property reference.)
+
+| field                             | `identifier`            | `inputType`  | `componentType`           | submits | requires            |
+|-----------------------------------|-------------------------|--------------|---------------------------|---------|---------------------|
+| **Text & number**                 |                         |              |                           |         |                     |
+| Short answer                      | `TEXT_INPUT`            | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Long answer                       | `TEXT_AREA`             | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Number                            | `NUMBER_INPUT`          | `NUMBER`     | `NUMBER_INPUT`            | number  |                     |
+| Rating                            | `RATING_INPUT`          | `NUMBER`     | `RATING_INPUT`            | number  |                     |
+| Link                              | `URL_INPUT`             | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Password                          | `PASSWORD`              | `STRING`     | `PASSWORD`                | string  |                     |
+| **Choice**                        |                         |              |                           |         |                     |
+| Dropdown                          | `DROPDOWN`              | `STRING`     | `DROPDOWN`                | string  |                     |
+| Single choice                     | `RADIO_GROUP`           | `STRING`     | `RADIO_GROUP`             | string  |                     |
+| Multi choice                      | `CHECKBOX_GROUP`        | `ARRAY`      | `CHECKBOX_GROUP`          | array   |                     |
+| Tag picker                        | `TAGS`                  | `ARRAY`      | `TAGS`                    | array   |                     |
+| Image choice                      | `IMAGE_CHOICE`          | `ARRAY`      | `CHECKBOX_GROUP`          | array   |                     |
+| Checkbox                          | `CHECKBOX`              | `BOOLEAN`    | `CHECKBOX`                | boolean |                     |
+| **Date & time**                   |                         |              |                           |         |                     |
+| Date                              | `DATE_INPUT`            | `STRING`     | `DATE_INPUT`              | string  |                     |
+| Date picker                       | `DATE_PICKER`           | `STRING`     | `DATE_PICKER`             | string  |                     |
+| Date and time                     | `DATE_TIME_INPUT`       | `STRING`     | `DATE_TIME`               | string  |                     |
+| Time                              | `TIME_INPUT`            | `STRING`     | `TIME_INPUT`              | string  |                     |
+| **Contact-mapped**                |                         |              |                           |         |                     |
+| First name                        | `CONTACTS_FIRST_NAME`   | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Last name                         | `CONTACTS_LAST_NAME`    | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Email                             | `CONTACTS_EMAIL`        | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Phone                             | `CONTACTS_PHONE`        | `STRING`     | `PHONE_INPUT`             | string  |                     |
+| Company                           | `CONTACTS_COMPANY`      | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Position                          | `CONTACTS_POSITION`     | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Tax ID → contact `VAT_ID`         | `CONTACTS_TAX_ID`       | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Birthdate                         | `CONTACTS_BIRTHDATE`    | `STRING`     | `DATE_INPUT`              | string  |                     |
+| Subscribe checkbox                | `CONTACTS_SUBSCRIBE`    | `BOOLEAN`    | `CHECKBOX`                | boolean |                     |
+| Address (single line)             | `CONTACTS_ADDRESS`      | `STRING`     | `TEXT_INPUT`              | string  |                     |
+| Address (multi-line)              | `MULTILINE_ADDRESS`     | `ADDRESS`    | `MULTILINE_ADDRESS`       | object  |                     |
+| **File (premium)**                |                         |              |                           |         |                     |
+| File upload                       | `FILE_UPLOAD`           | `WIX_FILE`   | `FILE_UPLOAD`             | file    | Premium             |
+| Signature                         | `SIGNATURE`             | `WIX_FILE`   | `SIGNATURE`               | file    | Premium             |
+| **Payment (premium + eCommerce)** |                         |              |                           |         |                     |
+| Product                           | `PRODUCT_LIST`          | `PAYMENT`    | `CHECKBOX_GROUP`          | payment | Premium + eCommerce |
+| Fixed price                       | `FIXED_PAYMENT`         | `PAYMENT`    | `FIXED_PAYMENT`           | payment | Premium + eCommerce |
+| Custom price                      | `PAYMENT_INPUT`         | `PAYMENT`    | `PAYMENT_INPUT`           | payment | Premium + eCommerce |
+| Donation                          | `DONATION`              | `PAYMENT`    | `DONATION_INPUT`          | payment | Premium + eCommerce |
+| **Scheduling (other Wix apps)**   |                         |              |                           |         |                     |
+| Appointment                       | `APPOINTMENT`           | `SCHEDULING` | `APPOINTMENT`             | booking | Wix Meetings        |
+| Service picker                    | `SERVICES_DROPDOWN`     | `STRING`     | `SERVICES_DROPDOWN`       | string  | Wix Services        |
+| Multi-service picker              | `SERVICES_MULTI_CHOICE` | `ARRAY`      | `SERVICES_CHECKBOX_GROUP` | array   | Wix Services        |
+| **Display (collects nothing)**    |                         |              |                           |         |                     |
+| Rich content                      | `RICH_TEXT`             | —            | `RICH_CONTENT` *          | —       |                     |
+| Submit button                     | `SUBMIT_BUTTON`         | —            | `PAGE_NAVIGATION` *       | —       |                     |
+
+\* A display field sets `fieldType: "DISPLAY"` and has neither an input type nor a
+component type — the value shown is its `displayOptions.displayFieldType`.
+
+### **Non-negotiable** rules for adapting the payload
+
+Change the fields, labels, options and targets freely — these seven rules **must** still hold in
+whatever you send. Break one and the create still returns `200`; the damage shows up in the
+owner's dashboard, or on the first real submission.
+
+- **Every `id` is a lowercase UUID v4, unique within the form** — generate it for each field and every choice `option`.
+  Then use those UUIDs where reference to a field or an option is required.
+- Use only **form.formFields** for fields, **never `form.fields` - that's legacy API**
+- **`steps` must reference every field, including the `SUBMIT_BUTTON`.** Field that is not referenced in any 
+  step will not be visible in the business manager.
+- **`required` lives at `inputOptions.required`**, never inside a validation block.
+- **`validation` is always present**, even as `{}`, and nests under the **`inputType`** options
+  object — not the `componentType` one.
+- **A choice field declares its options twice** — the component's `options[]` and the validation
+  `enum` (`STRING`) or `items.stringOptions.enum` + `itemType` (`ARRAY`) — and the two must agree.
+  Get it wrong and the create still returns `200`: the field is created as a **plain text box**,
+  losing its choices. Only the 5a component check catches it.
+- **`target` is the immutable submission key**: starts with an ASCII letter, letters/digits/`_`
+  only, no `__`, unique within the form. Use field's label converted to snake_case with _ and 6 random alphanumeric  
+  characters as the field target, e.g. "First name" -> `first_name_a689be`.
+
+```json
+{
+  "form": {
+    "name": "Every field type",
+    "namespace": "wix.form_app.form",
+    "formFields": [
+      {
+        "id": "4add0e51-a168-4ab6-76ff-834d782fb4d9",
+        "identifier": "TEXT_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "improve_e62b",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "What is one thing we could improve?",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "bbecbd37-ca52-4fa6-a92c-90e70aa4ec2a",
+        "identifier": "TEXT_AREA",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "message_7634",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Your message",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "7e2a15c8-0b34-49df-86a1-c40f9d73e526",
+        "identifier": "NUMBER_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "team_size_9b47",
+          "inputType": "NUMBER",
+          "numberOptions": {
+            "componentType": "NUMBER_INPUT",
+            "numberInputOptions": {
+              "label": "Team size",
+              "showLabel": true
+            },
+            "validation": {}
+          }
+        }
+      },
+      {
+        "id": "a5f82c31-7d09-4e6b-b384-0c15fe739a2d",
+        "identifier": "RATING_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "overall_rating_8c46",
+          "inputType": "NUMBER",
+          "numberOptions": {
+            "componentType": "RATING_INPUT",
+            "ratingInputOptions": {
+              "label": "How would you rate your overall experience?",
+              "showLabel": true,
+              "defaultValue": 3
+            },
+            "validation": {}
+          }
+        }
+      },
+      {
+        "id": "4913d7ab-352a-481b-831f-ee8beb895b64",
+        "identifier": "URL_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "portfolio_d31f",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "URL"
+            },
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Portfolio link",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "a0d72e94-6f18-4c3b-85d0-e21739bc6a48",
+        "identifier": "PASSWORD",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "portal_password_8a25",
+          "pii": true,
+          "required": true,
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "minLength": 8
+            },
+            "componentType": "PASSWORD",
+            "passwordOptions": {
+              "label": "Client portal password",
+              "showLabel": true,
+              "placeholder": "At least 8 characters"
+            }
+          }
+        }
+      },
+      {
+        "id": "3b6d9e21-84c7-4f05-a913-2e7d0c5b48f1",
+        "identifier": "DROPDOWN",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "project_type_5c1a",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "enum": [
+                "Brand identity",
+                "Website redesign"
+              ]
+            },
+            "componentType": "DROPDOWN",
+            "dropdownOptions": {
+              "label": "Project type",
+              "showLabel": true,
+              "options": [
+                {
+                  "id": "32d1d5a1-0ecf-4cff-eb22-c9334fb2f5f8",
+                  "label": "Brand identity",
+                  "value": "Brand identity"
+                },
+                {
+                  "id": "ff79e749-c49e-4db8-eebb-6062e7aed6c6",
+                  "label": "Website redesign",
+                  "value": "Website redesign"
+                }
+              ],
+              "customOption": {
+                "label": "Other",
+                "placeholder": "Tell us about your project"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "50de5707-06aa-49e7-ba63-cabf0b8bc7e2",
+        "identifier": "RADIO_GROUP",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "heard_about_us_3978",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "enum": [
+                "Search engine",
+                "Social media",
+                "A friend"
+              ]
+            },
+            "componentType": "RADIO_GROUP",
+            "radioGroupOptions": {
+              "label": "How did you hear about us?",
+              "showLabel": true,
+              "numberOfColumns": "ONE",
+              "options": [
+                {
+                  "id": "89955e02-2f29-4fca-85a9-d026854ec72d",
+                  "label": "Search engine",
+                  "value": "Search engine"
+                },
+                {
+                  "id": "e6b43c3c-0224-4946-c4cf-5ef4fb34fd37",
+                  "label": "Social media",
+                  "value": "Social media"
+                },
+                {
+                  "id": "7a1c4d92-8f63-4b05-9e27-3d80fa15c6b4",
+                  "label": "A friend",
+                  "value": "A friend"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "7fe8d8a5-6075-4c81-6678-662fe3ca48e4",
+        "identifier": "CHECKBOX_GROUP",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "services_used_21e8",
+          "inputType": "ARRAY",
+          "arrayOptions": {
+            "validation": {
+              "items": {
+                "itemType": "STRING",
+                "stringOptions": {
+                  "enum": [
+                    "Online store",
+                    "Support",
+                    "Consultation"
+                  ]
+                }
+              }
+            },
+            "componentType": "CHECKBOX_GROUP",
+            "checkboxGroupOptions": {
+              "label": "Which services did you use?",
+              "showLabel": true,
+              "numberOfColumns": "ONE",
+              "options": [
+                {
+                  "id": "fbcb7e1f-3280-4808-affc-8336efd3e2bf",
+                  "label": "Online store",
+                  "value": "Online store"
+                },
+                {
+                  "id": "b8a9a269-c622-4de5-2606-3046a3974238",
+                  "label": "Support",
+                  "value": "Support"
+                },
+                {
+                  "id": "c40e8b17-6a95-42d3-b8f1-05e7d2934ac6",
+                  "label": "Consultation",
+                  "value": "Consultation"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "8c5b3d47-e109-42fa-b6c8-71e4a03f9d52",
+        "identifier": "TAGS",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "services_7f30",
+          "inputType": "ARRAY",
+          "arrayOptions": {
+            "validation": {
+              "items": {
+                "itemType": "STRING",
+                "stringOptions": {
+                  "enum": [
+                    "Logo design",
+                    "Copywriting"
+                  ]
+                }
+              }
+            },
+            "componentType": "TAGS",
+            "tagsOptions": {
+              "label": "Services you need",
+              "showLabel": true,
+              "numberOfColumns": "ZERO",
+              "options": [
+                {
+                  "id": "91cbad08-66a2-41dd-f88f-1fad48883076",
+                  "label": "Logo design",
+                  "value": "Logo design"
+                },
+                {
+                  "id": "451a65af-596b-41be-865f-5e98ce21178f",
+                  "label": "Copywriting",
+                  "value": "Copywriting"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "d419f6b0-5c82-4e17-93ad-6f108b2c7e34",
+        "identifier": "IMAGE_CHOICE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "design_styles_2d68",
+          "inputType": "ARRAY",
+          "arrayOptions": {
+            "validation": {
+              "items": {
+                "itemType": "STRING",
+                "stringOptions": {
+                  "enum": [
+                    "Minimal",
+                    "Editorial"
+                  ]
+                }
+              }
+            },
+            "componentType": "CHECKBOX_GROUP",
+            "checkboxGroupOptions": {
+              "label": "Preferred design styles",
+              "showLabel": true,
+              "numberOfColumns": "TWO",
+              "options": [
+                {
+                  "id": "06a38503-b5a7-4499-c46b-a93c3b305104",
+                  "label": "Minimal",
+                  "value": "Minimal",
+                  "media": {
+                    "image": {
+                      "id": "8fc025_3ec045fddc7248b0836eed30b4ed1929~mv2.jpg",
+                      "url": "https://static.wixstatic.com/media/8fc025_3ec045fddc7248b0836eed30b4ed1929~mv2.jpg",
+                      "altText": "Minimal design style"
+                    }
+                  }
+                },
+                {
+                  "id": "3802532c-6899-40ea-5e30-a3256ad0a1c6",
+                  "label": "Editorial",
+                  "value": "Editorial",
+                  "media": {
+                    "image": {
+                      "id": "8fc025_b71e4a09cd8f4c1e93b7d05a26fc8e37~mv2.jpg",
+                      "url": "https://static.wixstatic.com/media/8fc025_b71e4a09cd8f4c1e93b7d05a26fc8e37~mv2.jpg",
+                      "altText": "Editorial design style"
+                    }
+                  }
+                }
+              ],
+              "optionsMediaSettings": {
+                "imageAlignment": "CENTER",
+                "imageFit": "COVER"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "62e0c8f5-9a34-4d61-b7fe-05c9138d24a7",
+        "identifier": "CHECKBOX",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "terms_b613",
+          "required": true,
+          "inputType": "BOOLEAN",
+          "booleanOptions": {
+            "componentType": "CHECKBOX",
+            "checkboxOptions": {
+              "label": {
+                "nodes": [
+                  {
+                    "type": "PARAGRAPH",
+                    "id": "ipl8z25",
+                    "nodes": [
+                      {
+                        "type": "TEXT",
+                        "id": "",
+                        "nodes": [],
+                        "textData": {
+                          "text": "I accept the studio terms and conditions.",
+                          "decorations": []
+                        }
+                      }
+                    ],
+                    "paragraphData": {
+                      "textStyle": {
+                        "textAlignment": "AUTO"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "validation": {}
+          }
+        }
+      },
+      {
+        "id": "76976adf-3cc4-453e-863b-577cbb619a45",
+        "identifier": "DATE_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "available_from_4784",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "DATE"
+            },
+            "componentType": "DATE_INPUT",
+            "dateInputOptions": {
+              "label": "Available from",
+              "showLabel": true,
+              "showPlaceholder": false,
+              "showDateLabels": true
+            }
+          }
+        }
+      },
+      {
+        "id": "b7c4bc3b-62a7-4746-33bd-c6d46e39ce33",
+        "identifier": "DATE_PICKER",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "delivery_date_abfa",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "DATE"
+            },
+            "componentType": "DATE_PICKER",
+            "datePickerOptions": {
+              "label": "Preferred delivery date",
+              "showLabel": true,
+              "firstDayOfWeek": "MONDAY"
+            }
+          }
+        }
+      },
+      {
+        "id": "15fa8e6c-3d71-4b09-a2e5-9c86d4170fb3",
+        "identifier": "DATE_TIME_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "kickoff_call_4e91",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "DATE_TIME"
+            },
+            "componentType": "DATE_TIME",
+            "dateTimeOptions": {
+              "label": "Kickoff call date and time",
+              "showLabel": true,
+              "showPlaceholder": false,
+              "showDateLabels": true,
+              "use24HourFormat": true
+            }
+          }
+        }
+      },
+      {
+        "id": "905345fa-e7fe-44c0-e114-4999a6e89f79",
+        "identifier": "TIME_INPUT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "delivery_time_b37e",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "TIME"
+            },
+            "componentType": "TIME_INPUT",
+            "timeInputOptions": {
+              "label": "Preferred delivery time",
+              "showLabel": true,
+              "showPlaceholder": false,
+              "use24HourFormat": true
+            }
+          }
+        }
+      },
+      {
+        "id": "d7665e98-a7c4-4829-c104-fb856883e043",
+        "identifier": "CONTACTS_FIRST_NAME",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "first_name_f409",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "FIRST_NAME"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "First name",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "740e294e-6ee4-4cda-c902-823002064985",
+        "identifier": "CONTACTS_LAST_NAME",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "last_name_b88c",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "LAST_NAME"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Last name",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "19768973-65be-4a6f-b3de-57cfb1da48db",
+        "identifier": "CONTACTS_EMAIL",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "email_673d",
+          "pii": true,
+          "required": true,
+          "contactMapping": {
+            "contactField": "EMAIL",
+            "emailInfo": {
+              "tag": "UNTAGGED"
+            }
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "EMAIL"
+            },
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Email",
+              "showLabel": true,
+              "placeholder": "Enter your email"
+            }
+          }
+        }
+      },
+      {
+        "id": "95d528a8-8f3d-4692-7363-44db1f96ca18",
+        "identifier": "CONTACTS_PHONE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "phone_6a4b",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "PHONE",
+            "phoneInfo": {
+              "tag": "UNTAGGED"
+            }
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "PHONE",
+              "phoneOptions": {
+                "allowedCountryCodes": [
+                  "US",
+                  "GB",
+                  "CA",
+                  "AU",
+                  "DE",
+                  "FR",
+                  "IL"
+                ]
+              }
+            },
+            "componentType": "PHONE_INPUT",
+            "phoneInputOptions": {
+              "label": "Phone",
+              "showLabel": true,
+              "placeholder": "Enter your phone number"
+            }
+          }
+        }
+      },
+      {
+        "id": "7b21e4d6-0a93-4c58-8f37-15d0ba69c284",
+        "identifier": "CONTACTS_COMPANY",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "company_5a1c",
+          "pii": true,
+          "required": true,
+          "contactMapping": {
+            "contactField": "COMPANY"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Company name",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "e8d3f907-b26a-4715-9c04-3a7e15bd6f82",
+        "identifier": "CONTACTS_POSITION",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "position_9f3e",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "POSITION"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Current job title",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "1d64b5c8-3e70-42a9-8b15-c9f207a4e631",
+        "identifier": "CONTACTS_TAX_ID",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "tax_id_2b7d",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "VAT_ID"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "VAT or tax ID",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "26ce91ce-8ee4-4aa6-2158-7169bcde9b32",
+        "identifier": "CONTACTS_BIRTHDATE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "birthdate_1808",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "BIRTHDATE"
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "format": "DATE"
+            },
+            "componentType": "DATE_INPUT",
+            "dateInputOptions": {
+              "label": "Date of birth",
+              "showLabel": true,
+              "showPlaceholder": false,
+              "showDateLabels": true
+            }
+          }
+        }
+      },
+      {
+        "id": "b6c64d1d-f759-40b7-f0ec-3e5cf20ec929",
+        "identifier": "CONTACTS_SUBSCRIBE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "subscribe_d888",
+          "contactMapping": {
+            "contactField": "SUBSCRIPTION",
+            "subscriptionInfo": {
+              "subscriptionChannels": [
+                "EMAIL"
+              ]
+            }
+          },
+          "inputType": "BOOLEAN",
+          "booleanOptions": {
+            "componentType": "CHECKBOX",
+            "checkboxOptions": {
+              "label": {
+                "nodes": [
+                  {
+                    "type": "PARAGRAPH",
+                    "id": "u7g8s24",
+                    "nodes": [
+                      {
+                        "type": "TEXT",
+                        "id": "",
+                        "nodes": [],
+                        "textData": {
+                          "text": "Yes, subscribe me to your newsletter.",
+                          "decorations": []
+                        }
+                      }
+                    ],
+                    "paragraphData": {
+                      "textStyle": {
+                        "textAlignment": "AUTO"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "validation": {}
+          }
+        }
+      },
+      {
+        "id": "2ad42412-8663-4b12-4104-05a65db8a4b1",
+        "identifier": "CONTACTS_ADDRESS",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "delivery_address_d210",
+          "pii": true,
+          "required": true,
+          "contactMapping": {
+            "contactField": "ADDRESS",
+            "addressInfo": {
+              "tag": "UNTAGGED"
+            }
+          },
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {},
+            "componentType": "TEXT_INPUT",
+            "textInputOptions": {
+              "label": "Delivery address",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "eadbbac7-b883-463f-b205-9b8ffb03a4be",
+        "identifier": "MULTILINE_ADDRESS",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "billing_address_bb91",
+          "pii": true,
+          "contactMapping": {
+            "contactField": "ADDRESS",
+            "addressInfo": {
+              "tag": "UNTAGGED"
+            }
+          },
+          "inputType": "ADDRESS",
+          "addressOptions": {
+            "validation": {
+              "fields": {
+                "country": {
+                  "required": true
+                },
+                "addressLine": {
+                  "required": true
+                },
+                "addressLine2": {
+                  "required": false
+                },
+                "city": {
+                  "required": true
+                },
+                "postalCode": {
+                  "required": false
+                },
+                "subdivision": {
+                  "required": false
+                },
+                "streetName": {
+                  "required": false
+                },
+                "streetNumber": {
+                  "required": false
+                }
+              }
+            },
+            "componentType": "MULTILINE_ADDRESS",
+            "multilineAddressOptions": {
+              "label": "Billing address",
+              "showLabel": true,
+              "autocompleteEnabled": false,
+              "fieldSettings": {
+                "addressLine2": {
+                  "show": false
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "6051872d-a37d-4486-5138-e2dd6532cb21",
+        "identifier": "FILE_UPLOAD",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "photo_id_2eae",
+          "required": true,
+          "inputType": "WIX_FILE",
+          "wixFileOptions": {
+            "componentType": "FILE_UPLOAD",
+            "validation": {
+              "uploadFileFormats": [
+                "IMAGE"
+              ],
+              "fileLimit": 1
+            },
+            "fileUploadOptions": {
+              "label": "Upload a photo ID",
+              "showLabel": true,
+              "buttonText": "Upload File",
+              "explanationText": "Image files only"
+            }
+          }
+        }
+      },
+      {
+        "id": "cba6b17a-b19c-4c9d-8e37-0e69cb17bbca",
+        "identifier": "SIGNATURE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "signature_3d48",
+          "pii": true,
+          "required": true,
+          "inputType": "WIX_FILE",
+          "wixFileOptions": {
+            "componentType": "SIGNATURE",
+            "validation": {
+              "uploadFileFormats": [
+                "IMAGE"
+              ],
+              "fileLimit": 1
+            },
+            "signatureOptions": {
+              "label": "Signature",
+              "showLabel": true,
+              "imageUploadEnabled": false
+            }
+          }
+        }
+      },
+      {
+        "id": "9d868f4b-bf4c-42da-c18e-72de43337033",
+        "identifier": "PRODUCT_LIST",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "products_e817",
+          "inputType": "PAYMENT",
+          "paymentOptions": {
+            "componentType": "CHECKBOX_GROUP",
+            "validation": {
+              "products": [
+                {
+                  "id": "db698a17-fa29-47a2-fb96-7b1dc75e2792",
+                  "priceType": "FIXED_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "fixedPriceOptions": {
+                    "price": "25"
+                  }
+                },
+                {
+                  "id": "4f2c9a86-31be-4d70-8e15-6b0c73da29f4",
+                  "priceType": "FIXED_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "fixedPriceOptions": {
+                    "price": "40"
+                  }
+                }
+              ]
+            },
+            "checkboxGroupOptions": {
+              "label": "Choose your items",
+              "showLabel": true,
+              "options": [
+                {
+                  "id": "e2a84fa5-8ed3-4feb-f30a-bb6c129d37ad",
+                  "label": "Digital guide",
+                  "value": "db698a17-fa29-47a2-fb96-7b1dc75e2792"
+                },
+                {
+                  "id": "8c317b40-95df-4e26-a103-2f6b8d047e59",
+                  "label": "Video course",
+                  "value": "4f2c9a86-31be-4d70-8e15-6b0c73da29f4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "8f7023d6-eee0-4288-16c2-87a2aa2c990b",
+        "identifier": "FIXED_PAYMENT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "handling_fee_6abe",
+          "required": true,
+          "inputType": "PAYMENT",
+          "paymentOptions": {
+            "componentType": "FIXED_PAYMENT",
+            "validation": {
+              "products": [
+                {
+                  "id": "e934c5cb-779c-40f1-f60f-ec58aa5a6657",
+                  "priceType": "FIXED_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "fixedPriceOptions": {
+                    "price": "5"
+                  }
+                }
+              ]
+            },
+            "fixedPaymentOptions": {
+              "label": "Handling fee",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "1f0a5c74-3e2b-4a91-8d67-0c5b9e2fa314",
+        "fieldType": "INPUT",
+        "identifier": "PAYMENT_INPUT",
+        "inputOptions": {
+          "target": "custom_amount_5c74",
+          "inputType": "PAYMENT",
+          "paymentOptions": {
+            "componentType": "PAYMENT_INPUT",
+            "validation": {
+              "products": [
+                {
+                  "id": "5b3d9f21-7c48-4e06-9a1d-8f2c4b70de95",
+                  "priceType": "DYNAMIC_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "dynamicPriceOptions": {
+                    "minPrice": "5"
+                  }
+                }
+              ]
+            },
+            "paymentInputOptions": {
+              "label": "Amount",
+              "showLabel": true
+            }
+          }
+        }
+      },
+      {
+        "id": "b7e7755e-fe11-4546-c29d-20d51007b164",
+        "fieldType": "INPUT",
+        "identifier": "DONATION",
+        "inputOptions": {
+          "target": "donation_4dee",
+          "inputType": "PAYMENT",
+          "paymentOptions": {
+            "componentType": "DONATION_INPUT",
+            "validation": {
+              "products": [
+                {
+                  "id": "b66b1c6c-ec2e-4a69-abb9-37d6bbacc706",
+                  "priceType": "FIXED_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "fixedPriceOptions": {
+                    "price": "10"
+                  }
+                },
+                {
+                  "id": "df5faf1a-4b00-4e94-0b64-b4b1f94fc09a",
+                  "priceType": "FIXED_PRICE",
+                  "productType": "DIGITAL",
+                  "quantityLimit": {
+                    "minimum": 1,
+                    "maximum": 1
+                  },
+                  "fixedPriceOptions": {
+                    "price": "20"
+                  }
+                }
+              ]
+            },
+            "donationInputOptions": {
+              "label": "Donation",
+              "showLabel": true,
+              "numberOfColumns": "THREE",
+              "options": [
+                {
+                  "value": "b66b1c6c-ec2e-4a69-abb9-37d6bbacc706"
+                },
+                {
+                  "value": "df5faf1a-4b00-4e94-0b64-b4b1f94fc09a"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "218260f0-e9b3-4aee-2aed-267cd8f6460f",
+        "identifier": "APPOINTMENT",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "consultation_4146",
+          "inputType": "SCHEDULING",
+          "schedulingOptions": {
+            "componentType": "APPOINTMENT",
+            "appointmentOptions": {
+              "label": "Pick a time for your consultation",
+              "showLabel": true,
+              "name": "Consultation",
+              "durationInMinutes": 30,
+              "staffIds": [
+                "8cd69332-ea08-45a1-8333-526b623bcec2"
+              ],
+              "manualApprovalRequired": false,
+              "format": "PHONE",
+              "phoneOptions": {
+                "description": "Phone call"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "ca7a4f22-31fa-40d3-635b-baad47d53344",
+        "identifier": "SERVICES_DROPDOWN",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "service_7374",
+          "inputType": "STRING",
+          "stringOptions": {
+            "validation": {
+              "enum": [
+                "ecadb257-0be6-4011-a575-a17d2232e278"
+              ]
+            },
+            "componentType": "SERVICES_DROPDOWN",
+            "servicesDropdownOptions": {
+              "label": "Choose a service",
+              "showLabel": true,
+              "placeholder": "Select a service",
+              "options": [
+                {
+                  "id": "ecadb257-0be6-4011-a575-a17d2232e278",
+                  "label": "Initial consultation",
+                  "value": "ecadb257-0be6-4011-a575-a17d2232e278"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "02ecf77a-018c-4bb5-202c-58c9e2bb87b2",
+        "identifier": "SERVICES_MULTI_CHOICE",
+        "fieldType": "INPUT",
+        "inputOptions": {
+          "target": "add_ons_406f",
+          "inputType": "ARRAY",
+          "arrayOptions": {
+            "validation": {
+              "items": {
+                "itemType": "STRING",
+                "stringOptions": {
+                  "enum": [
+                    "7d19f3a5-4c82-4e06-b573-91a0dc2e685f"
+                  ]
+                }
+              }
+            },
+            "componentType": "SERVICES_CHECKBOX_GROUP",
+            "servicesCheckboxGroupOptions": {
+              "label": "Add-on services",
+              "showLabel": true,
+              "numberOfColumns": "ONE",
+              "options": [
+                {
+                  "id": "7d19f3a5-4c82-4e06-b573-91a0dc2e685f",
+                  "label": "Follow-up session",
+                  "value": "7d19f3a5-4c82-4e06-b573-91a0dc2e685f"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "9e5b1c73-2f48-4a06-b91d-73c0e8452fa1",
+        "identifier": "RICH_TEXT",
+        "fieldType": "DISPLAY",
+        "displayOptions": {
+          "displayFieldType": "RICH_CONTENT",
+          "richContentOptions": {
+            "richContent": {
+              "nodes": [
+                {
+                  "type": "PARAGRAPH",
+                  "id": "wvr3b41",
+                  "nodes": [
+                    {
+                      "type": "TEXT",
+                      "id": "",
+                      "nodes": [],
+                      "textData": {
+                        "text": "I confirm that I am participating voluntarily and accept the risks involved.",
+                        "decorations": []
+                      }
+                    }
+                  ],
+                  "paragraphData": {
+                    "textStyle": {
+                      "textAlignment": "AUTO"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "2e56791e-926e-48fd-37d0-0ad60a27736d",
+        "identifier": "SUBMIT_BUTTON",
+        "fieldType": "DISPLAY",
+        "displayOptions": {
+          "displayFieldType": "PAGE_NAVIGATION",
+          "pageNavigationOptions": {
+            "submitText": "Pay"
+          }
+        }
+      }
+    ],
+    "steps": [
+      {
+        "id": "0f0e6cfd-3e1a-4a1e-9a3a-4e2b5c6d7e8f",
+        "name": "Page 1",
+        "layout": {
+          "large": {
+            "items": [
+              {
+                "fieldId": "4add0e51-a168-4ab6-76ff-834d782fb4d9",
+                "row": 0,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "bbecbd37-ca52-4fa6-a92c-90e70aa4ec2a",
+                "row": 1,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "7e2a15c8-0b34-49df-86a1-c40f9d73e526",
+                "row": 2,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "a5f82c31-7d09-4e6b-b384-0c15fe739a2d",
+                "row": 3,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "4913d7ab-352a-481b-831f-ee8beb895b64",
+                "row": 4,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "a0d72e94-6f18-4c3b-85d0-e21739bc6a48",
+                "row": 5,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "3b6d9e21-84c7-4f05-a913-2e7d0c5b48f1",
+                "row": 6,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "50de5707-06aa-49e7-ba63-cabf0b8bc7e2",
+                "row": 7,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "7fe8d8a5-6075-4c81-6678-662fe3ca48e4",
+                "row": 8,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "8c5b3d47-e109-42fa-b6c8-71e4a03f9d52",
+                "row": 9,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "d419f6b0-5c82-4e17-93ad-6f108b2c7e34",
+                "row": 10,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "62e0c8f5-9a34-4d61-b7fe-05c9138d24a7",
+                "row": 11,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "76976adf-3cc4-453e-863b-577cbb619a45",
+                "row": 12,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "b7c4bc3b-62a7-4746-33bd-c6d46e39ce33",
+                "row": 13,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "15fa8e6c-3d71-4b09-a2e5-9c86d4170fb3",
+                "row": 14,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "905345fa-e7fe-44c0-e114-4999a6e89f79",
+                "row": 15,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "d7665e98-a7c4-4829-c104-fb856883e043",
+                "row": 16,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "740e294e-6ee4-4cda-c902-823002064985",
+                "row": 17,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "19768973-65be-4a6f-b3de-57cfb1da48db",
+                "row": 18,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "95d528a8-8f3d-4692-7363-44db1f96ca18",
+                "row": 19,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "7b21e4d6-0a93-4c58-8f37-15d0ba69c284",
+                "row": 20,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "e8d3f907-b26a-4715-9c04-3a7e15bd6f82",
+                "row": 21,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "1d64b5c8-3e70-42a9-8b15-c9f207a4e631",
+                "row": 22,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "26ce91ce-8ee4-4aa6-2158-7169bcde9b32",
+                "row": 23,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "b6c64d1d-f759-40b7-f0ec-3e5cf20ec929",
+                "row": 24,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "2ad42412-8663-4b12-4104-05a65db8a4b1",
+                "row": 25,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "eadbbac7-b883-463f-b205-9b8ffb03a4be",
+                "row": 26,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "6051872d-a37d-4486-5138-e2dd6532cb21",
+                "row": 27,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "cba6b17a-b19c-4c9d-8e37-0e69cb17bbca",
+                "row": 28,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "9d868f4b-bf4c-42da-c18e-72de43337033",
+                "row": 29,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "8f7023d6-eee0-4288-16c2-87a2aa2c990b",
+                "row": 30,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "1f0a5c74-3e2b-4a91-8d67-0c5b9e2fa314",
+                "row": 31,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "b7e7755e-fe11-4546-c29d-20d51007b164",
+                "row": 32,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "218260f0-e9b3-4aee-2aed-267cd8f6460f",
+                "row": 33,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "ca7a4f22-31fa-40d3-635b-baad47d53344",
+                "row": 34,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "02ecf77a-018c-4bb5-202c-58c9e2bb87b2",
+                "row": 35,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "9e5b1c73-2f48-4a06-b91d-73c0e8452fa1",
+                "row": 36,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              },
+              {
+                "fieldId": "2e56791e-926e-48fd-37d0-0ad60a27736d",
+                "row": 37,
+                "column": 0,
+                "width": 12,
+                "height": 1
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+## 4 · Create the form
+
+One POST per form body, to the **Form Schemas v4** endpoint — a **CRM** API, not Business Solutions,
+always on the public host, never `/_api/`:
+
+```
+POST https://www.wixapis.com/form-schema-service/v4/forms
+{ "form": { … the body from step 3 … } }
+```
+
+Read **`form.id`** from the response — that's the `formId` the rest of the run carries. **Record it
+the moment it comes back**, before anything else: it is the only way a later attempt can tell a form
+this run created from one the owner already had. Forms are independent (no shared revision), so
+create them in any order.
+
+**Three things to check before you POST.** The API accepts the first two and loses the field; the
+third leaves you with a second form:
+
+- the body has at least one `INPUT` field — a form of nothing but a submit button collects nothing;
+- **no two fields share a `target`**. The server keeps one; every other field with that key silently
+  stores nothing.
+- **no form of this name exists yet** —
+  `GET https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form`, comparing
+  `name` exactly. Wix does **not** reject a duplicate name; it silently appends a counter (`"Contact"`
+  → `"Contact 1"`), so create is **not idempotent** and nothing tells you a retry duplicated a form.
+  A name matching a form **this run** created (per the id you recorded above) → reuse that `formId`
+  rather than creating again. A name you have no record of creating is the **owner's**: additive
+  only, so leave it alone and pick a different name or ask.
+
+An orphan *you* created in this run is yours to clear — `DELETE .../v4/forms/<formId>` is a soft
+delete to the trash bin, so it is recoverable. Anything you did not create stays untouched.
+
+**A `200` here proves almost nothing.** Most mistakes in a form body are accepted at create and
+surface only in the owner's dashboard or on the first real submission — step 5 is what actually
+proves the form works. Two failures worth recognizing before you retry:
+
+- A transient `5xx`, an identity/propagation error right after install, or a timeout leaves you not
+  knowing whether the create landed. **Re-list by name before retrying** — never blind-retry the
+  POST, because the duplicate it may create is silent. One retry once the list comes back empty;
+  never a loop.
+- **Plan gates are a hard block, not a note-and-continue.** `FIELDS_COUNT_RESTRICTIONS_ERROR`
+  (per-form field cap), `FILE_UPLOAD_RESTRICTIONS_ERROR` (upload/signature/payment below Core) and
+  `FORMS_COUNT_RESTRICTIONS_ERROR` (site form cap) each mean **reduce or upgrade** — put the choice
+  to the user with their dashboard link and wait for an answer. Never split a form across schemas to
+  dodge the field cap, never inline a file as base64, and never create throwaway forms to probe the
+  shape.
+
+  **The field cap cannot be read in advance.** `listFormsProvidersConfigs` reports the Forms app's
+  ceiling, not the site's plan cap — on a free site it returns `maxFields: 150` while the create is
+  rejected with `"Field count reached its limit of 10"`. The cap is per plan, not per app. Treat the
+  create as the only authority on the number: budget conservatively while authoring step 3 rather
+  than discovering the limit after a full authoring pass, and count every entry in `formFields`, the
+  `SUBMIT_BUTTON` included.
+
+**Revising a form later** — add a field, relabel one, tighten a rule:
+
+```
+PATCH https://www.wixapis.com/form-schema-service/v4/forms/<formId>
+{ "form": { …, "revision": "<the form's current revision>" } }
+```
+
+Never delete-and-recreate: a `PATCH` keeps the `formId` the UI already holds and spends no extra slot
+against the site's form cap. Re-run step 5 afterwards — an update regresses a layout exactly as a
+create can.
+
+## 5 · Verify it works
+
+**All four calls are yours to make**, and the last one needs a submission you compose from *this*
+form's schema. All four use the standard headers from step 1.
+
+**A `200` on create means the body parsed — nothing more.** Every mistake below returns `200` and
+surfaces only in the owner's dashboard or on the first real submission.
+
+### 5a · Read the form back
+
+```
+GET https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds=<formId>
+```
+
+`formIds` narrows the listing to exactly what you created, so you assert against it directly. Then,
+against the returned `form.formFields`:
+
+- **Every `target` you sent is there.** One that isn't means the field didn't persist — usually an
+  `identifier` Wix doesn't recognize, which is dropped without an error.
+- **Every `inputOptions.required` reads back as you sent it.** A `required` key placed inside a
+  validation block is accepted and then discarded, so the form ships with nothing mandatory. This
+  diff is the only signal you will ever get.
+- **Every choice field is still a choice field.** For each `DROPDOWN` / `RADIO_GROUP` /
+  `CHECKBOX_GROUP` / `TAGS` you sent, assert the read-back still carries that `componentType`, that
+  its `options[]` is non-empty, and that it agrees with the validation `enum`. A malformed options
+  block is accepted at create and comes back as a plain text input — `target` intact, `required`
+  intact — so every other check in step 5 passes and the field silently loses its choices.
+- **Keep the read-back `target`s.** These, not the ones you authored, are what goes into step 6.
+
+### 5b · Check the dashboard view
+
+```
+GET https://www.wixapis.com/form-schema-service/v4/forms/<formId>/summary
+```
+
+Assert `formSummary.fields` is **non-empty**, with one entry per input field you sent (everything in
+`formFields` except the `SUBMIT_BUTTON`). The summary is exactly what the Wix dashboard renders, so a
+short or empty count means the form is blank — or partly blank — **for the owner**, even while the
+public site submits fine. Non-contact fields count too; don't expect only the contact-mapped ones.
+
+### 5c · Submit to it once, for real
+
+This is the check the other two can't stand in for. An ARRAY field whose `validation.items` is
+missing `itemType` passes 5a and 5b and then `400`s **form-wide** — every field, every visitor.
+Submitting once is the only proof the form can receive data at all.
+
+**What it does not catch:** a STRING choice field does **not** enforce its `validation.enum` on
+submit. A dropdown whose enum and options both read back correctly still accepts `"Not an option"`
+with a `200`. So the probe proves the form *receives* data; it will not tell you a choice field's
+two declarations have drifted apart. Get those right in step 3 — nothing downstream will catch it
+for you.
+
+```
+POST https://www.wixapis.com/form-submission-service/v4/submissions
+{ "submission": { "formId": "<formId>", "submissions": { "<target>": <value> } } }
+```
+
+**Rules for composing `submissions`** — get one wrong and the whole submission fails, not just that
+value:
+
+- **Keys are field `target`s from the 5a read-back.** Never a label, never a field `id`. A key that
+  isn't a target in the schema fails the entire submission.
+- **Include every `required` field** — the server rejects the submission without them — **plus every
+  ARRAY field whether required or not**, since the ARRAY shape is the thing you're testing.
+- **The value's shape follows the field's `inputType`, not its component:**
+
+  | `inputType` | value | example |
+  |---|---|---|
+  | `STRING` | a string, formatted per `validation.format` | `"seed-probe@example.com"`, `"2030-01-01"`, `"10:00:00"` |
+  | `NUMBER` | a number | `1` |
+  | `BOOLEAN` | a boolean | `true` |
+  | `ARRAY` | an array of **option values** | `["Option 1"]` |
+  | `ADDRESS` | an object, only the subfields the form shows | `{"country":"US","subdivision":"US-NY","city":"New York","postalCode":"10011","addressLine":"235 West 23rd Street"}` |
+  | `PAYMENT` | an array of `{productId, price, quantity}` | `[{"productId":"<from validation.products>","price":"25","quantity":1}]` |
+  | `SCHEDULING` | `{startDate, endDate, timeZone}` | `{"startDate":"2030-07-02T14:00:00","endDate":"2030-07-02T14:30:00","timeZone":"America/New_York"}` |
+
+- **Use one of the field's own option `value`s** — copy it from the schema rather than retyping the
+  label. The server won't reject a value outside the enum (see above), so a typo here quietly proves
+  nothing.
+- **`country` and `subdivision` are validated against each other**, so send a matching pair or omit
+  `subdivision`.
+- **A `WIX_FILE` field can't be faked.** If a file upload or signature is `required`, this check
+  can't run — say so and have the user submit once through the published site instead of recording a
+  pass that never happened.
+
+Assert `200`. A **`400 SUBMISSION_VALIDATION` is a schema bug, not a submission bug** — fix the form
+body and re-create it; never bend the value to get through. The error names the field and the reason
+under `details.validationError.fieldViolations[].data.errors[]`, each with an `errorPath` (the
+`target`) and an `errorType` — `UNKNOWN_VALUE_ERROR` means the key isn't a `target` in this form.
+
+### 5d · Delete the test submission
+
+```
+DELETE https://www.wixapis.com/form-submission-service/v4/submissions/<id>
+```
+
+The id comes from the 5c response as **`submission.id`**: REST returns `id`, not the `_id` the
+reference schema shows (that's the SDK's shape). Do this every time — the owner's inbox is a real
+business inbox, and a probe left in it looks like a real enquiry. If a probe ever escapes, find it
+with `POST /form-submission-service/v4/submissions/namespace/query` filtered by `formId` +
+`namespace`.
+
+## 6 · Hand off
+
+Only once step 5 has passed for every form, write `src/rest/wix-forms.config.js` — one entry per
+form, keyed by the form's name lowercased with each run of non-alphanumerics collapsed to a single
+`_` (`"Quote request"` → `quote_request`):
+
+```js
+// Written by the seed run once step 5 passed. Do not hand-edit, and do not create it early:
+// its existence is what proves the form schemas were created AND verified.
+export const WIX_FORMS = {
+  contact: { formId: "…", name: "Contact", targets: { email: true, message: true } },
+};
+```
+
+**That file is the handoff, and the gate.** The UI imports `WIX_FORMS` from it; no file means the
+seed did not succeed, so nothing may be built against the form yet. So **never write it before step 5
+passes**, and never invent a `formId`. If the app's `src/` layout puts its REST layer elsewhere, write
+it there instead — the path matters less than the file existing before the UI step.
+
+`targets` is the **read-back** map of immutable submission keys — the one from 5a, not the one you
+authored in step 3. Everything else — labels, order, options, validation — the client reads **live
+from the schema**, so an owner's dashboard edit shows on the site with no code change.

--- a/skills/wix-vibe-headless/references/forms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/forms/seed/SEED.md
@@ -86,6 +86,10 @@ triple, the options objects and the validation shapes are the ones Wix actually 
 exceptions: **Donation** comes from About Form Fields, and **Custom price** is the one field with no
 shipped example — it is composed from the property reference.)
 
+*(Authoring side: which JSON creates each field. The rendering side — which control each one wants
+and what its value looks like — is the matching table in `INSTRUCTIONS.md`; they join on
+`identifier`.)*
+
 | field                             | `identifier`            | `inputType`  | `componentType`           | submits | requires            |
 |-----------------------------------|-------------------------|--------------|---------------------------|---------|---------------------|
 | **Text & number**                 |                         |              |                           |         |                     |
@@ -94,7 +98,6 @@ shipped example — it is composed from the property reference.)
 | Number                            | `NUMBER_INPUT`          | `NUMBER`     | `NUMBER_INPUT`            | number  |                     |
 | Rating                            | `RATING_INPUT`          | `NUMBER`     | `RATING_INPUT`            | number  |                     |
 | Link                              | `URL_INPUT`             | `STRING`     | `TEXT_INPUT`              | string  |                     |
-| Password                          | `PASSWORD`              | `STRING`     | `PASSWORD`                | string  |                     |
 | **Choice**                        |                         |              |                           |         |                     |
 | Dropdown                          | `DROPDOWN`              | `STRING`     | `DROPDOWN`                | string  |                     |
 | Single choice                     | `RADIO_GROUP`           | `STRING`     | `RADIO_GROUP`             | string  |                     |
@@ -250,28 +253,6 @@ owner's dashboard, or on the first real submission.
             "textInputOptions": {
               "label": "Portfolio link",
               "showLabel": true
-            }
-          }
-        }
-      },
-      {
-        "id": "a0d72e94-6f18-4c3b-85d0-e21739bc6a48",
-        "identifier": "PASSWORD",
-        "fieldType": "INPUT",
-        "inputOptions": {
-          "target": "portal_password_8a25",
-          "pii": true,
-          "required": true,
-          "inputType": "STRING",
-          "stringOptions": {
-            "validation": {
-              "minLength": 8
-            },
-            "componentType": "PASSWORD",
-            "passwordOptions": {
-              "label": "Client portal password",
-              "showLabel": true,
-              "placeholder": "At least 8 characters"
             }
           }
         }


### PR DESCRIPTION
Builds the client half of the `forms` vertical in `wix-vibe-headless`, on top of the seed doc that landed earlier on this branch.

## What this ships

A form is schema-driven — the owner picks the fields in their dashboard — so no "contact form" component can ship for it. This ships the non-visual half and lets the agent write the markup:

| file | what it is |
|---|---|
| `lib/wix-form-schema-utils.js` | accessors over the **raw** field Wix returns (`orderedInputs`, `labelOf`, `validationOf`, `choicesOf`, `addressPartsOf`, …). No projection to keep in sync, nothing the schema carries hidden. The two options blocks are named after the field's own enums, which is what the lookup tables in here resolve. |
| `hooks/useWixForm.js` | controlled `values` seeded from the schema's defaults, `bind(target)` for per-control wiring, schema-driven `validate(target?)`, `submit`, and visitor-facing copy for server violations. |
| `rest/wix-forms.js` / `rest/wix-forms-submissions.js` | schema read and submission write, including the file flow: Forms-scoped upload URL → `PUT` the bytes → submit that same URL as the value. |
| `references/forms/INSTRUCTIONS.md` | guidelines, not a component to copy: which control each field kind wants, which schema key feeds which attribute, and the traps. 73 of 471 lines are code. |

## Verified

Schema projection, layout ordering, label resolution through derived option blocks, all three submission value shapes, phone E.164 normalization, numeric bounds, address subfield errors, `bind()` output, and the file-upload flow were each exercised against fixtures built from the seed's own field JSON.

Two things are inferred rather than observed, and are flagged as such in the doc: no live 200 confirmed for `media-upload-url` on an anonymous visitor token (same scope listing as the schema read, which does work anonymously), and the multi-file array shape is extrapolated from Wix's single-file example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)