### PR TITLE
Fix coupon creation scope and missing-input handling

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
@@ -12,10 +12,25 @@ description: "PREFERRED recipe for converting a COUPON recommendation (mechanism
 
 ## Required APIs
 
-- [Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon) — `POST /v2/coupons`
-- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update-a-coupon) — `PATCH /v2/coupons/{id}`
-- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query-coupons) — `POST /v2/coupons/query`
-- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete-a-coupon) — `DELETE /v2/coupons/{id}`
+- [Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon) — `POST /stores/v2/coupons`
+- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update-a-coupon) — `PATCH /stores/v2/coupons/{id}`
+- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query-coupons) — `POST /stores/v2/coupons/query`
+- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete-a-coupon) — `DELETE /stores/v2/coupons/{id}`
+
+---
+
+## Collect the required coupon details before creating
+
+A coupon code and usage limit are not enough to define a coupon. Before any mutation, make sure the user has supplied:
+
+- The coupon code.
+- Exactly one coupon type and its required value: percentage off, money off, fixed price, free shipping, or Buy X Get Y.
+- What the coupon applies to: all items in a Wix app, one specific item/collection, or a minimum subtotal.
+- Any requested schedule. If no future start is requested, treat an explicit create request as immediate and calculate `startTime` from the current time; never copy an example timestamp.
+
+Use a supplied campaign name as `name`; if the user supplies only a code, the code itself is an acceptable deterministic display name. Never invent a discount type, discount amount, target scope, or future schedule as a “sensible default.” If any required business choice is missing, ask one concise question that collects the missing values and stop before calling the API. For example, for “Create coupon code LIMIT100 with 100 total uses,” ask what discount it should give and what it should apply to.
+
+An explicit request to create the coupon authorizes the mutation once all required details are settled; do not add a redundant confirmation step.
 
 ---
 
@@ -47,10 +62,7 @@ Before creating a coupon, check for code conflicts and existing promotions on th
         "code": "SUMMER20",
         "percentOffRate": 20,
         "scope": {
-          "namespace": "stores",
-          "group": {
-            "name": "product"
-          }
+          "namespace": "stores"
         },
         "startTime": 1717200000000,
         "expirationTime": 1719792000000,
@@ -91,10 +103,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SPRING15",
     "percentOffRate": 15,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "usageLimit": 200,
@@ -167,10 +176,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SAVE10",
     "moneyOffAmount": 10,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "active": true
@@ -232,9 +238,11 @@ Instead of targeting a scope, you can require a minimum cart subtotal. This is a
 
 | Scope target | `namespace` | `group.name` | `group.entityId` |
 |---|---|---|---|
-| All store products | `"stores"` | `"product"` | Omit (applies to all) |
+| All store products | `"stores"` | Omit | Omit |
 | Specific product | `"stores"` | `"product"` | Product UUID |
 | Specific collection | `"stores"` | `"collection"` | Collection UUID |
+
+For Wix Stores, if `group` is present, `group.entityId` is required. Therefore `{ "namespace": "stores", "group": { "name": "product" } }` is invalid; use `{ "namespace": "stores" }` for all products.
 
 ---
 
@@ -246,7 +254,7 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Recommendation `scope` | Coupon `scope` |
 |---|---|
-| `SITE` | `{ "namespace": "stores", "group": { "name": "product" } }` (all products, no entityId) |
+| `SITE` | `{ "namespace": "stores" }` (all products; omit `group`) |
 | `CATEGORY` | `{ "namespace": "stores", "group": { "name": "collection", "entityId": "<first categoryId>" } }` |
 | `ITEMS` | `{ "namespace": "stores", "group": { "name": "product", "entityId": "<first productId>" } }` |
 
@@ -268,7 +276,7 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 |---|---|
 | `minSubTotal > 0` | Use `minimumSubtotal` instead of `scope` (they are oneOf — cannot use both) |
 | `minItemQuantity > 0` | **Not natively supported by Coupons API**. Mention in the coupon name (e.g., "Buy 3+, use code BUNDLE15") but the API cannot enforce item quantity. |
-| `startDate` | Convert to UNIX epoch milliseconds: `Date.parse("2026-06-01") → 1748736000000`. Set as `startTime`. |
+| `startDate` | Convert to UNIX epoch milliseconds: `Date.parse("2026-06-01T00:00:00Z") → 1780272000000`. Set as `startTime`. Never copy a timestamp from an example. |
 | `endDate` | Convert to UNIX epoch milliseconds. Set as `expirationTime`. |
 
 ### Code generation
@@ -314,8 +322,8 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
         "entityId": "electronics-collection-uuid"
       }
     },
-    "startTime": 1748736000000,
-    "expirationTime": 1751328000000,
+    "startTime": 1780272000000,
+    "expirationTime": 1782777600000,
     "usageLimit": 100,
     "limitPerCustomer": 1,
     "active": true
@@ -340,7 +348,8 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Error | Cause | Fix |
 |---|---|---|
-| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores", "group": { "name": "product" } }` for site-wide, or set `minimumSubtotal` |
+| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores" }` for all Wix Stores products, or set `minimumSubtotal` |
+| `"The provided combination of scope and coupon type is invalid"` with `group=product, entityId=empty` | A Stores `group` was supplied without its required entity ID | Omit `group` for all products, or add the specific product/collection `entityId` |
 | Duplicate code | Another coupon uses the same code | Generate a different code |
 | Invalid startTime | Value too low (must be epoch ms, not seconds) | Multiply by 1000 if in seconds |
 | Both scope and minimumSubtotal set | These are oneOf — cannot use both | Choose scope OR minimumSubtotal |

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-missing-discount.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-missing-discount.yml
@@ -1,0 +1,26 @@
+name: ecommerce/pricing-promotions/create-coupon-missing-discount
+description: Require the agent to collect missing coupon semantics instead of inventing a discount and making a failing mutation.
+triggerPrompt: |
+  Create a coupon code LIMIT100 that can only be used 100 times in total.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user supplied only a coupon code and total usage limit. Those values do not define the required coupon type/value or what the coupon applies to.
+
+      Pass if the agent asks one concise follow-up question that collects the missing discount type/value and target scope or minimum subtotal, and does not claim that the coupon was created.
+
+      Fail if the agent invents any discount type or value (for example, 10% off or free shipping), invents a scope, calls a coupon mutation before the user answers, or claims success.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate the quality of the tool-call path. Score 0-10 (10 = the recipe was loaded and the agent stopped for the missing business choices without attempting a mutation). Penalize and LIST any of: a Create Coupon API call; any non-2xx response; guessed coupon type, amount, scope, or schedule; multiple repetitive clarification questions; unnecessary API or docs calls after the missing inputs were identified. Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected docs/skill gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon.yml
@@ -38,10 +38,16 @@ assertions:
 
       Pass if ALL of these are true:
         1. The agent loaded the `pricing-create-coupon` recipe (NOT the legacy `setup-coupons` slug).
-        2. The create payload correctly maps recommendation fields: `percentOffRate: 20`, `code: "TECH20"`, `usageLimit: 100`, `limitPerCustomer: 1`, and `expirationTime` in UNIX milliseconds for 2026-06-30 (value ~1782777600000, ending in three zeros).
-        3. It applied the recommendation's `scope: "SITE"` — no category filter.
+        2. The create payload correctly maps recommendation fields: `percentOffRate: 20`, `code: "TECH20"`, `usageLimit: 100`, `limitPerCustomer: 1`, `startTime: 1780272000000` for 2026-06-01, and `expirationTime: 1782777600000` for 2026-06-30.
+        3. It maps `scope: "SITE"` to exactly `scope: { "namespace": "stores" }`. The payload must omit `scope.group`, because a Stores group requires an entity ID.
 
       Fail if ANY of these are true:
         - The agent used the legacy `setup-coupons` slug or its content.
-        - `expirationTime` was sent in seconds (ten-digit integer) instead of milliseconds.
+        - Either timestamp was sent in seconds, used the recipe's old 2025 values, or otherwise did not represent the supplied 2026 dates.
+        - The site-wide scope included `group: { "name": "product" }` without an entity ID.
         - The agent ignored the recommendation fields and invented its own coupon parameters.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the Wix MCP let the agent convert the fully specified coupon recommendation. Examine the tool-call trace. Score 0-10 (10 = direct and correct on the first mutation call). Penalize and LIST any of: a non-2xx API response even if recovered; a Stores site-wide scope containing a group without an entity ID; a timestamp copied from an example instead of calculated from the supplied date; invented coupon parameters; redundant API calls or repeated docs discovery. Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected docs/skill gap, or 'clean path' if none>"}.


### PR DESCRIPTION
## Summary
- use `{ "namespace": "stores" }` for all-products coupons and document that grouped Stores scopes require an entity ID
- require discount type/value and target scope before mutation instead of inventing defaults
- calculate immediate start times at runtime and correct the 2026 timestamp examples
- add regression coverage for the malformed-scope 400 and underspecified `LIMIT100` request

## Validation
- `yarn test` in `.github/actions/evalforge-yaml-gate` (76 tests)
- parsed all 88 wix-manage eval scenarios with the repository schema
- `git diff --check`

The unrelated pre-existing working-tree changes were not included.