### PR TITLE
feat: wix-headless-fast — seed-time AI image generation (imagePrompt)

### DIFF
--- a/skills/wix-headless-fast/references/blog/seed/SEED.md
+++ b/skills/wix-headless-fast/references/blog/seed/SEED.md
@@ -14,8 +14,8 @@ node <SKILL_ROOT>/references/blog/seed/seed-blog.mjs plan.json
 `plan.json` is plain data — write it from the brief. **Default to 3 posts** (the seed shows
 the shape; the owner writes the rest in the dashboard) and make them exercise the UI: group
 them into 2 categories when the brief has natural sections, tag a couple, vary the content
-blocks (heading + paragraphs + a quote or list per post), and give every post a
-`coverImageUrl` (verified — a feed without covers looks broken).
+blocks (heading + paragraphs + a quote or list per post), and give every post a cover — a
+feed without covers looks broken.
 
 ```json
 {
@@ -49,8 +49,12 @@ blocks (heading + paragraphs + a quote or list per post), and give every post a
   cover (code, inline images), pass a pre-built Ricos `richContent` on the post instead.
 - `category`/`categories`/`tags` are display **names** — created idempotently and resolved to
   ids internally. Optional: skip them entirely when the brief doesn't group posts.
-- `coverImageUrl` — a plain https image URL; the script imports it into Wix Media (Blog binds
-  covers by file id, not URL) and re-publishes the post. A failed cover never blocks the run.
+- Cover — either a `coverImageUrl` (a real https URL, verified with `curl -sI` → 200 before
+  seeding; imported into Wix Media — Blog binds covers by file id, not URL) or a
+  `coverImagePrompt` (AI-generated, **1 Wix AI credit per image**, account-billed):
+  brand-contextual — subject, aesthetic/mood, palette, lighting — always ending "no text, no
+  watermarks". Covers resolve in parallel and never block the seed; a failed cover leaves
+  that post text-only (the script re-publishes each post it covers).
 - Posts are created **published** — an unpublished post never reaches visitors. The bulk
   create returns 200 even on partial failure: check each `posts[].success` in the result.
 

--- a/skills/wix-headless-fast/references/blog/seed/SEED.md
+++ b/skills/wix-headless-fast/references/blog/seed/SEED.md
@@ -49,12 +49,13 @@ feed without covers looks broken.
   cover (code, inline images), pass a pre-built Ricos `richContent` on the post instead.
 - `category`/`categories`/`tags` are display **names** — created idempotently and resolved to
   ids internally. Optional: skip them entirely when the brief doesn't group posts.
-- Cover — either a `coverImageUrl` (a real https URL, verified with `curl -sI` → 200 before
-  seeding; imported into Wix Media — Blog binds covers by file id, not URL) or a
-  `coverImagePrompt` (AI-generated, **1 Wix AI credit per image**, account-billed):
-  brand-contextual — subject, aesthetic/mood, palette, lighting — always ending "no text, no
-  watermarks". Covers resolve in parallel and never block the seed; a failed cover leaves
-  that post text-only (the script re-publishes each post it covers).
+- Cover — the default is a `coverImagePrompt` (AI-generated, ~1 Wix AI credit per image,
+  account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting — always
+  ending "no text, no watermarks". Use `coverImageUrl` ONLY for an asset the user actually
+  supplied (their own photo/URL; verify it with `curl -sI` → 200; imported into Wix Media —
+  Blog binds covers by file id, not URL) — never a stock-photo or guessed URL. Covers resolve
+  in parallel and never block the seed; a failed cover leaves that post text-only (the script
+  re-publishes each post it covers).
 - Posts are created **published** — an unpublished post never reaches visitors. The bulk
   create returns 200 even on partial failure: check each `posts[].success` in the result.
 

--- a/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
+++ b/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
@@ -12,7 +12,7 @@
 // Plan shape (see SEED.md):
 //   { "categories"?: [name], "tags"?: [name],
 //     "posts": [{ "title", "content": [blocks] | "richContent"?, "category"?|"categories"?,
-//                 "tags"?, "coverImageUrl"? }] }
+//                 "tags"?, "coverImageUrl"? | "coverImagePrompt"? }] }
 //   content blocks: { type:"heading", text, level? } | { type:"paragraph", text }
 //     | { type:"quote", text } | { type:"bulleted"|"ordered", items:[text,…] }
 //
@@ -21,6 +21,7 @@
 // wix-headless/references/inline-recipes/setup-blog.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const BLOG_APP_ID = "14bcded7-0066-7c35-14d7-466cb3f09103";
@@ -186,13 +187,10 @@ export async function createTags(ctx, names) {
   return ensureLabels(ctx, "tags", "/blog/v3/tags", (name) => ({ label: name }), names);
 }
 
-// Blog binds a post cover by Wix Media file ID — an external url must be imported first.
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// Blog binds a post cover by Wix Media file ID — an external url must be imported first; a
+// plan `coverImagePrompt` is generated (Wix AI, 1 credit) then imported. Both live in the
+// shared util (parallel, resilient, never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // covers: [{ postId, fileId }] where fileId is the Wix Media file.id from importImage. Per
 // post: PATCH /blog/v3/draft-posts/{id} (NOT POST …/{id}/update — that 404s), setting
@@ -243,17 +241,17 @@ export async function setupBlog(ctx, { posts = [], categories = [], tags = [] } 
     };
   }), { memberId });
 
-  const covers = [];
-  for (let i = 0; i < created.length; i++) {
-    const url = posts[i]?.coverImageUrl;
-    if (!created[i]?.id || !created[i]?.success || !url) continue;
-    try {
-      const file = await importImage(ctx, url, `post-${i}.png`);
-      covers.push({ postId: created[i].id, fileId: file.id });
-    } catch {
-      /* never block on image failure — the post stays text-only */
-    }
-  }
+  // Pass 2 — covers: resolve (import by url / generate by prompt) in one parallel wave, then
+  // attach (PATCH + re-publish per post). Failures leave the post text-only; the seed's exit
+  // never depends on images.
+  const files = await resolveItemImages(ctx, created.map((c, i) => (
+    c?.id && c?.success
+      ? { url: posts[i]?.coverImageUrl, prompt: posts[i]?.coverImagePrompt, displayName: `post-${i}.png` }
+      : null
+  )));
+  const covers = created
+    .map((c, i) => (files[i] ? { postId: c.id, fileId: files[i].id } : null))
+    .filter(Boolean);
   const coversAttached = covers.length ? await attachPostCovers(ctx, covers) : 0;
 
   return { posts: created, categories: cats, tags: tgs, coversAttached };

--- a/skills/wix-headless-fast/references/bookings/seed/SEED.md
+++ b/skills/wix-headless-fast/references/bookings/seed/SEED.md
@@ -13,7 +13,11 @@ node <SKILL_ROOT>/references/bookings/seed/seed-bookings.mjs plan.json
 `plan.json` is plain data — write it from the brief. **Default to 3 services** (the seed
 shows the shape; the owner adds the rest in the dashboard) and make them exercise the UI:
 mix APPOINTMENT and CLASS when it fits the business, include ≥1 free/pay-in-person service,
-and give every service an `imageUrl` (verified — a store without images looks broken).
+and give every service an image — either an `imageUrl` (a real https URL, verified with
+`curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated, **1 Wix AI credit per
+image**, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
+always ending "no text, no watermarks". Images resolve in parallel and never block the seed;
+a failed image leaves that service text-only.
 
 ```json
 {

--- a/skills/wix-headless-fast/references/bookings/seed/SEED.md
+++ b/skills/wix-headless-fast/references/bookings/seed/SEED.md
@@ -13,11 +13,12 @@ node <SKILL_ROOT>/references/bookings/seed/seed-bookings.mjs plan.json
 `plan.json` is plain data — write it from the brief. **Default to 3 services** (the seed
 shows the shape; the owner adds the rest in the dashboard) and make them exercise the UI:
 mix APPOINTMENT and CLASS when it fits the business, include ≥1 free/pay-in-person service,
-and give every service an image — either an `imageUrl` (a real https URL, verified with
-`curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated, **1 Wix AI credit per
-image**, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
-always ending "no text, no watermarks". Images resolve in parallel and never block the seed;
-a failed image leaves that service text-only.
+and give every service an image — the default is an `imagePrompt` (AI-generated, ~1 Wix AI
+credit per image, account-billed): brand-contextual — subject, aesthetic/mood, palette,
+lighting — always ending "no text, no watermarks". Use `imageUrl` ONLY for an asset the user
+actually supplied (their own photo/URL; verify it with `curl -sI` → 200) — never a
+stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed
+image leaves that service text-only.
 
 ```json
 {

--- a/skills/wix-headless-fast/references/bookings/seed/seed-bookings.mjs
+++ b/skills/wix-headless-fast/references/bookings/seed/seed-bookings.mjs
@@ -11,7 +11,7 @@
 // Plan shape (see SEED.md):
 //   { "services": [{ "type": "APPOINTMENT"|"CLASS", "name", "description", "tagLine"?,
 //                    "price"?, "free"?, "duration"? (APPOINTMENT, minutes), "capacity"?,
-//                    "category"? (name), "imageUrl"?,
+//                    "category"? (name), "imageUrl"? | "imagePrompt"?,
 //                    "sessions"?: [{ "start", "end", "capacity"? }] }] }   // CLASS only; local "YYYY-MM-DDThh:mm:ss"
 //
 // Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
@@ -19,6 +19,7 @@
 // wix-headless/references/inline-recipes/setup-bookings.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97";
@@ -179,13 +180,10 @@ export async function scheduleClassSessions(ctx, sessions) {
   }));
 }
 
-// Bookings binds a service image by Wix Media file ID — an external url must be imported first.
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// Bookings binds a service image by Wix Media file ID — an external url must be imported
+// first; a plan `imagePrompt` is generated (Wix AI, 1 credit) then imported. Both live in the
+// shared util (parallel, resilient, never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // Writes under media.mainMedia + media.coverMedia (writing media.image 200s but silently drops).
 export async function attachServiceImage(ctx, it) {
@@ -245,16 +243,21 @@ export async function setupBookings(ctx, { services = [], staffResourceId } = {}
   });
   const scheduled = sessions.length ? await scheduleClassSessions(ctx, sessions) : [];
 
+  // Pass 2 — images: resolve (import by url / generate by prompt) in one parallel wave, then
+  // attach. Failures leave the service text-only; the seed's exit never depends on images.
+  const files = await resolveItemImages(ctx, created.map((c, i) => ({
+    url: services[i]?.imageUrl,
+    prompt: services[i]?.imagePrompt,
+    displayName: `${c?.slug || "service"}.png`,
+  })));
   let imagesAttached = 0;
   for (let i = 0; i < created.length; i++) {
-    const url = services[i]?.imageUrl;
-    if (!url || !created[i]?.id) continue;
+    if (!files[i] || !created[i]?.id) continue;
     try {
-      const file = await importImage(ctx, url, `${created[i].slug || "service"}.png`);
       await attachServiceImage(ctx, {
         serviceId: created[i].id,
         revision: created[i].revision,
-        image: { id: file.id, url: file.url, width: 1024, height: 1024 },
+        image: { id: files[i].id, url: files[i].url, width: 1024, height: 1024 },
       });
       imagesAttached++;
     } catch {

--- a/skills/wix-headless-fast/references/cms/seed/SEED.md
+++ b/skills/wix-headless-fast/references/cms/seed/SEED.md
@@ -57,12 +57,13 @@ every content item an image on an IMAGE field (a content site without images loo
   schema doesn't have (the API would silently drop it).
 - Field `type` — `TEXT`, `NUMBER`, `BOOLEAN`, `DATE`, `DATETIME`, `URL`, `EMAIL`, `IMAGE`,
   `RICH_TEXT` (an HTML string, stored verbatim), `REFERENCE`, `MULTI_REFERENCE`.
-- `IMAGE` values — either an https URL string (verified with `curl -sI` → 200 before seeding;
-  imported into Wix Media, the permanent `file.url` is stored) or `{ "prompt": "..." }`
-  (AI-generated, **1 Wix AI credit per image**, account-billed): brand-contextual — subject,
-  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Images resolve
-  in parallel and never block the seed; a failed image leaves that field unset (the item
-  stays text-only).
+- `IMAGE` values — the default is `{ "prompt": "..." }` (AI-generated, ~1 Wix AI credit per
+  image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
+  always ending "no text, no watermarks". Use an https URL string ONLY for an asset the user
+  actually supplied (their own photo/URL; verify it with `curl -sI` → 200; imported into Wix
+  Media, the permanent `file.url` is stored) — never a stock-photo or guessed URL. Images
+  resolve in parallel and never block the seed; a failed image leaves that field unset (the
+  item stays text-only).
 - `DATE`/`DATETIME` values are ISO strings — the script wraps them as `{ "$date": iso }`.
 - References: **order collections so targets come first.** A `REFERENCE` value is the target
   item's index in its collection's `items` array; `MULTI_REFERENCE` is an array of indices

--- a/skills/wix-headless-fast/references/cms/seed/SEED.md
+++ b/skills/wix-headless-fast/references/cms/seed/SEED.md
@@ -2,9 +2,9 @@
 
 Seed by **running `seed-cms.mjs` with a plan file** — don't hand-write the REST calls.
 The script mints its own site token via the Wix CLI (logged-in session + `wix.config.json`
-required), installs the Wix Data (CMS) app if needed, and creates everything in order:
-per collection — create (schema + permissions) → import IMAGE urls into Wix Media →
-bulk-insert items → wire multi-references → verify persistence.
+required), installs the Wix Data (CMS) app if needed, resolves every IMAGE value into Wix
+Media in one parallel wave, and creates everything in order: per collection — create
+(schema + permissions) → bulk-insert items → wire multi-references → verify persistence.
 
 ```bash
 # from the project root (where wix.config.json lives):
@@ -15,8 +15,7 @@ node <SKILL_ROOT>/references/cms/seed/seed-cms.mjs plan.json
 schemas, and the items the pages will render. Write it from the brief. Default to **one or
 two content collections with ~3–6 items each** (the seed shows the shape; the owner adds the
 rest in the dashboard). Give any collection that gets a detail page a `slug` TEXT field, and
-every content item a verified `imageUrl` on an IMAGE field (a content site without images
-looks broken).
+every content item an image on an IMAGE field (a content site without images looks broken).
 
 ```json
 {
@@ -58,9 +57,12 @@ looks broken).
   schema doesn't have (the API would silently drop it).
 - Field `type` — `TEXT`, `NUMBER`, `BOOLEAN`, `DATE`, `DATETIME`, `URL`, `EMAIL`, `IMAGE`,
   `RICH_TEXT` (an HTML string, stored verbatim), `REFERENCE`, `MULTI_REFERENCE`.
-- `IMAGE` values are external image URLs (verified) — the script imports each into Wix Media
-  (`POST /site-media/v1/files/import`) and stores the permanent `file.url`; on import failure
-  the item stays text-only (never blocks).
+- `IMAGE` values — either an https URL string (verified with `curl -sI` → 200 before seeding;
+  imported into Wix Media, the permanent `file.url` is stored) or `{ "prompt": "..." }`
+  (AI-generated, **1 Wix AI credit per image**, account-billed): brand-contextual — subject,
+  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Images resolve
+  in parallel and never block the seed; a failed image leaves that field unset (the item
+  stays text-only).
 - `DATE`/`DATETIME` values are ISO strings — the script wraps them as `{ "$date": iso }`.
 - References: **order collections so targets come first.** A `REFERENCE` value is the target
   item's index in its collection's `items` array; `MULTI_REFERENCE` is an array of indices

--- a/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
+++ b/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
@@ -4,9 +4,10 @@
 //   node <SKILL_ROOT>/references/cms/seed/seed-cms.mjs plan.json
 //
 // It mints its own site token via the Wix CLI, installs the Wix Data (CMS) app if needed,
+// resolves every IMAGE value into Wix Media (url import / AI generation, one parallel wave),
 // creates each collection (field schema + permissions; an existing collection is left
-// as-is), imports IMAGE-field urls into Wix Media, bulk-inserts items, wires
-// multi-references, and verifies persistence. Prints a JSON result to stdout.
+// as-is), bulk-inserts items, wires multi-references, and verifies persistence. Prints a
+// JSON result to stdout.
 //
 // Plan shape (see SEED.md):
 //   { "collections": [{ "id", "displayName"?, "permissions"?,
@@ -14,13 +15,15 @@
 //       "items": [{ "<fieldKey>": value, ... }] }] }
 // Reference fields: order collections so targets come FIRST. A REFERENCE value is the
 // target item's index in ITS collection's items array; MULTI_REFERENCE is an array of
-// indices.
+// indices. An IMAGE value is a verified https url STRING or { "prompt": "..." }
+// (AI-generated).
 //
 // Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
 // read the live API reference; authoritative source recipe:
 // wix-headless/references/inline-recipes/setup-cms.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const WIX_DATA_APP_ID = "e593b0bd-b783-45b8-97c2-873d42aacaf4";
@@ -130,13 +133,10 @@ export async function createCollection(ctx, { id, displayName, fields = [], perm
   }
 }
 
-// An IMAGE field stores a permanent Wix Media URL — an external url must be imported first.
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.url) throw new Error(`import-file returned no file url: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// An IMAGE field stores a permanent Wix Media URL — an external url must be imported first;
+// a { "prompt": ... } value is generated (Wix AI, 1 credit) then imported. Both live in the
+// shared util (parallel, resilient, never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // Ids come from results[].dataItem.id (there is no results[].item key).
 export async function bulkInsertItems(ctx, dataCollectionId, dataItems) {
@@ -173,8 +173,9 @@ export async function verifyItems(ctx, dataCollectionId) {
 // plan item -> insert `data`, per field type. MULTI_REFERENCE values are silently dropped by
 // the insert endpoint (200, no error) — stripped here and wired after; a single REFERENCE is
 // set at insert as the target item's _id. DATE/DATETIME wrap as { "$date": iso }; RICH_TEXT
-// is an HTML string stored verbatim; IMAGE urls are imported to Wix Media first.
-async function buildItemData(ctx, col, item, idsByCollection, multiRefs, itemIndex, counters) {
+// is an HTML string stored verbatim; IMAGE values were resolved to Wix Media files up front
+// (imageFiles, keyed by imageKey) — a failed image leaves the field unset.
+function buildItemData(col, item, idsByCollection, multiRefs, itemIndex, counters, imageFiles) {
   const fieldsByKey = new Map((col.fields ?? []).map((f) => [f.key, f]));
   const data = {};
   for (const [key, value] of Object.entries(item)) {
@@ -200,12 +201,10 @@ async function buildItemData(ctx, col, item, idsByCollection, multiRefs, itemInd
       continue;
     }
     if (f.type === "IMAGE") {
-      try {
-        const file = await importImage(ctx, value, `${col.id}-${itemIndex}-${key}.png`);
+      const file = imageFiles.get(imageKey(col.id, itemIndex, key));
+      if (file) {
         data[key] = file.url;
         counters.imagesImported++;
-      } catch {
-        /* never block on image failure — the item stays text-only */
       }
       continue;
     }
@@ -218,12 +217,42 @@ async function buildItemData(ctx, col, item, idsByCollection, multiRefs, itemInd
   return data;
 }
 
+const imageKey = (colId, itemIndex, fieldKey) => `${colId} ${itemIndex} ${fieldKey}`;
+
+// Every IMAGE value across the plan (a url string or { prompt }), resolved to Wix Media files
+// in ONE parallel wave before any insert. Returns Map<imageKey, { id, url } | absent>.
+async function resolveAllImages(ctx, collections) {
+  const keys = [];
+  const specs = [];
+  for (const col of collections) {
+    const imageFields = new Set((col.fields ?? []).filter((f) => f.type === "IMAGE").map((f) => f.key));
+    (col.items ?? []).forEach((item, i) => {
+      for (const [key, value] of Object.entries(item)) {
+        if (!imageFields.has(key) || value == null) continue;
+        keys.push(imageKey(col.id, i, key));
+        specs.push({
+          url: typeof value === "string" ? value : undefined,
+          prompt: typeof value === "object" ? value.prompt : undefined,
+          displayName: `${col.id}-${i}-${key}.png`,
+        });
+      }
+    });
+  }
+  const files = specs.length ? await resolveItemImages(ctx, specs) : [];
+  const out = new Map();
+  keys.forEach((k, i) => { if (files[i]) out.set(k, files[i]); });
+  return out;
+}
+
 /**
- * ONE-CALL seed: install → per collection (in plan order): create → import images →
- * bulk-insert → wire multi-references → verify; ids threaded in memory. The default path.
+ * ONE-CALL seed: install → resolve every IMAGE value in one parallel wave → per collection
+ * (in plan order): create → bulk-insert → wire multi-references → verify; ids threaded in
+ * memory. The default path.
  */
 export async function setupCms(ctx, { collections = [] } = {}) {
   await installDataApp(ctx);
+
+  const imageFiles = await resolveAllImages(ctx, collections);
 
   const idsByCollection = new Map();
   const out = { collections: [] };
@@ -235,7 +264,7 @@ export async function setupCms(ctx, { collections = [] } = {}) {
     const dataItems = [];
     const planItems = col.items ?? [];
     for (let i = 0; i < planItems.length; i++) {
-      dataItems.push(await buildItemData(ctx, col, planItems[i], idsByCollection, multiRefs, i, counters));
+      dataItems.push(buildItemData(col, planItems[i], idsByCollection, multiRefs, i, counters, imageFiles));
     }
 
     let ids = [];

--- a/skills/wix-headless-fast/references/events/seed/SEED.md
+++ b/skills/wix-headless-fast/references/events/seed/SEED.md
@@ -14,11 +14,12 @@ node <SKILL_ROOT>/references/events/seed/seed-events.mjs plan.json
 `plan.json` is plain data — write it from the brief. **Default to 3 events** (the seed shows
 the shape; the owner adds the rest in the dashboard) and make them exercise the UI: mix
 `TICKETING` and `RSVP` (≥1 of each), give a ticketed event 2 tiers, and give every event an
-image (an events page without images looks broken) — either an `imageUrl` (a real https URL,
-verified with `curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated, **1 Wix AI
-credit per image**, account-billed): brand-contextual — subject, aesthetic/mood, palette,
-lighting — always ending "no text, no watermarks". Images resolve in parallel and never block
-the seed; a failed image leaves that event text-only.
+image (an events page without images looks broken) — the default is an `imagePrompt`
+(AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
+aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use `imageUrl`
+ONLY for an asset the user actually supplied (their own photo/URL; verify it with `curl -sI`
+→ 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the
+seed; a failed image leaves that event text-only.
 
 ```json
 {

--- a/skills/wix-headless-fast/references/events/seed/SEED.md
+++ b/skills/wix-headless-fast/references/events/seed/SEED.md
@@ -14,7 +14,11 @@ node <SKILL_ROOT>/references/events/seed/seed-events.mjs plan.json
 `plan.json` is plain data — write it from the brief. **Default to 3 events** (the seed shows
 the shape; the owner adds the rest in the dashboard) and make them exercise the UI: mix
 `TICKETING` and `RSVP` (≥1 of each), give a ticketed event 2 tiers, and give every event an
-`imageUrl` (verified — an events page without images looks broken).
+image (an events page without images looks broken) — either an `imageUrl` (a real https URL,
+verified with `curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated, **1 Wix AI
+credit per image**, account-billed): brand-contextual — subject, aesthetic/mood, palette,
+lighting — always ending "no text, no watermarks". Images resolve in parallel and never block
+the seed; a failed image leaves that event text-only.
 
 ```json
 {

--- a/skills/wix-headless-fast/references/events/seed/seed-events.mjs
+++ b/skills/wix-headless-fast/references/events/seed/seed-events.mjs
@@ -14,13 +14,14 @@
 //                  "startDate", "endDate" (future ISO-8601 UTC), "timeZoneId",
 //                  "location" ({name,type:"VENUE",address} | {name,type:"ONLINE"} | {locationTbd:true,name}),
 //                  "ticketTiers"?: [{ "name" (≤30 chars), "price" (decimal STRING), "description"?, "initialLimit"? }],
-//                  "category"? (name), "imageUrl"?, "rsvpResponseType"? }] }
+//                  "category"? (name), "imageUrl"? | "imagePrompt"?, "rsvpResponseType"? }] }
 //
 // Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
 // read the live API reference; authoritative source recipe:
 // wix-headless/references/inline-recipes/setup-events.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const EVENTS_APP_ID = "140603ad-af8d-84a5-2c80-a0f60cb47351";
@@ -169,13 +170,10 @@ export async function assignEventsToCategory(ctx, categoryId, eventIds) {
 }
 
 // Events binds mainImage by Wix Media file ID — an external url must be imported first
-// (a raw url as the id stores 200 but renders nothing).
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// (a raw url as the id stores 200 but renders nothing); a plan `imagePrompt` is generated
+// (Wix AI, 1 credit) then imported. Both live in the shared util (parallel, resilient,
+// never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // mainImage is an Image OBJECT; height/width are REQUIRED or it won't render. Events V3 uses
 // NO revision — partial PATCH keyed by event.id. Works before OR after publish.
@@ -208,7 +206,7 @@ export async function setupEvents(ctx, { events = [] } = {}) {
       ? await createTicketTiers(ctx, e.id, ev.ticketTiers.map((t) => ({ ...t, currency: t.currency ?? siteCurrency })))
       : [];
     await publishEvent(ctx, e.id);
-    created.push({ ...e, category: ev.category, imageUrl: ev.imageUrl, ticketCount: tiers.length });
+    created.push({ ...e, category: ev.category, imageUrl: ev.imageUrl, imagePrompt: ev.imagePrompt, ticketCount: tiers.length });
   }
 
   const names = [...new Set(created.map((e) => e.category).filter(Boolean))];
@@ -218,12 +216,19 @@ export async function setupEvents(ctx, { events = [] } = {}) {
     if (eventIds.length) await assignEventsToCategory(ctx, c.id, eventIds);
   }
 
+  // Pass 2 — images: resolve (import by url / generate by prompt) in one parallel wave, then
+  // attach. Failures leave the event text-only; the seed's exit never depends on images.
+  const files = await resolveItemImages(ctx, created.map((e) => ({
+    url: e.imageUrl,
+    prompt: e.imagePrompt,
+    displayName: `${e.slug || "event"}.png`,
+  })));
   let imagesAttached = 0;
-  for (const e of created) {
-    if (!e.imageUrl) continue;
+  for (let i = 0; i < created.length; i++) {
+    const e = created[i];
+    if (!files[i]) continue;
     try {
-      const file = await importImage(ctx, e.imageUrl, `${e.slug || "event"}.png`);
-      await setEventMainImage(ctx, { eventId: e.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: e.slug });
+      await setEventMainImage(ctx, { eventId: e.id, id: files[i].id, url: files[i].url, height: 1024, width: 1024, altText: e.slug });
       imagesAttached++;
     } catch {
       /* never block on image failure — the event stays text-only */

--- a/skills/wix-headless-fast/references/portfolio/seed/SEED.md
+++ b/skills/wix-headless-fast/references/portfolio/seed/SEED.md
@@ -13,9 +13,9 @@ node <SKILL_ROOT>/references/portfolio/seed/seed-portfolio.mjs plan.json
 
 `plan.json` is plain data — write it from the brief. **Default to 2 collections × 2 projects
 each** (the seed shows the shape; the owner adds the rest in the dashboard) and make them
-exercise the UI: every collection and project gets a verified `coverImageUrl`, every project
-gets 2–3 gallery `items` (a portfolio without images looks broken), and a couple of projects
-get `details` rows (Role, Year, Client…).
+exercise the UI: every collection and project gets a cover, every project gets 2–3 gallery
+`items` (a portfolio without images looks broken), and a couple of projects get `details`
+rows (Role, Year, Client…).
 
 ```json
 {
@@ -50,10 +50,15 @@ get `details` rows (Role, Year, Client…).
 - `collection` — a collection **title from this plan**; resolved to its created id. A project
   without one belongs to no collection (reachable only from an all-projects list).
 - `details` — optional `[{ label, text }]` rows; render on the project page. Omit for none.
-- `coverImageUrl` / `items[].imageUrl` — plain image urls; the script imports each into Wix
-  Media (Portfolio binds by file id — a raw url renders nothing). The **cover** is the listing
-  thumbnail; **items** are the detail-page gallery — separate entities, both wanted. If a
-  project has only a cover, reuse its url as item 1 so the gallery isn't empty.
+- Every image field takes either a url (`coverImageUrl` / `items[].imageUrl` — a real https
+  URL, verified with `curl -sI` → 200 before seeding; imported into Wix Media — Portfolio
+  binds by file id, a raw url renders nothing) or a prompt (`coverImagePrompt` /
+  `items[].imagePrompt` — AI-generated, **1 Wix AI credit per image**, account-billed):
+  brand-contextual — subject, aesthetic/mood, palette, lighting — always ending "no text, no
+  watermarks". All images — covers and gallery items alike — resolve in one parallel wave and
+  never block the seed; a failed image skips just that item/cover. The **cover** is the
+  listing thumbnail; **items** are the detail-page gallery — separate entities, both wanted.
+  If a project has only a cover, reuse its url as item 1 so the gallery isn't empty.
 - `sortOrder` (1, 2, 3…) sets the gallery render order.
 - `hidden` defaults to shown — omit it; send `hidden: true` only to hide an entity.
 - Gallery items seed as images only; the owner adds videos in the dashboard.

--- a/skills/wix-headless-fast/references/portfolio/seed/SEED.md
+++ b/skills/wix-headless-fast/references/portfolio/seed/SEED.md
@@ -50,13 +50,14 @@ rows (Role, Year, Client…).
 - `collection` — a collection **title from this plan**; resolved to its created id. A project
   without one belongs to no collection (reachable only from an all-projects list).
 - `details` — optional `[{ label, text }]` rows; render on the project page. Omit for none.
-- Every image field takes either a url (`coverImageUrl` / `items[].imageUrl` — a real https
-  URL, verified with `curl -sI` → 200 before seeding; imported into Wix Media — Portfolio
-  binds by file id, a raw url renders nothing) or a prompt (`coverImagePrompt` /
-  `items[].imagePrompt` — AI-generated, **1 Wix AI credit per image**, account-billed):
-  brand-contextual — subject, aesthetic/mood, palette, lighting — always ending "no text, no
-  watermarks". All images — covers and gallery items alike — resolve in one parallel wave and
-  never block the seed; a failed image skips just that item/cover. The **cover** is the
+- Every image field's default is a prompt (`coverImagePrompt` / `items[].imagePrompt` —
+  AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
+  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use a url
+  (`coverImageUrl` / `items[].imageUrl`) ONLY for an asset the user actually supplied (their
+  own photo/URL; verify it with `curl -sI` → 200; imported into Wix Media — Portfolio binds
+  by file id, a raw url renders nothing) — never a stock-photo or guessed URL. All images —
+  covers and gallery items alike — resolve in one parallel wave and never block the seed; a
+  failed image skips just that item/cover. The **cover** is the
   listing thumbnail; **items** are the detail-page gallery — separate entities, both wanted.
   If a project has only a cover, reuse its url as item 1 so the gallery isn't empty.
 - `sortOrder` (1, 2, 3…) sets the gallery render order.

--- a/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
+++ b/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
@@ -9,12 +9,12 @@
 // project's gallery items, and imports+attaches cover images. Prints a JSON result to stdout.
 //
 // Plan shape (see SEED.md):
-//   { "collections": [{ "title", "description"?, "hidden"?, "coverImageUrl"? }],
+//   { "collections": [{ "title", "description"?, "hidden"?, "coverImageUrl"? | "coverImagePrompt"? }],
 //     "projects":    [{ "title", "description"?, "hidden"?,
 //                       "collection"? (title),        // resolved to that collection's id
 //                       "details"?: [{ "label", "text" }],
-//                       "coverImageUrl"?,
-//                       "items"?: [{ "sortOrder", "title"?, "imageUrl" }] }] }
+//                       "coverImageUrl"? | "coverImagePrompt"?,
+//                       "items"?: [{ "sortOrder", "title"?, "imageUrl" | "imagePrompt" }] }] }
 //
 // Seeding is ADDITIVE — never deletes or overwrites existing content. A fresh Portfolio
 // install ships its own sample content ("My Portfolio" + sample projects); removing it is the
@@ -22,6 +22,7 @@
 // authoritative source recipe: wix-headless/references/inline-recipes/setup-portfolio.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const PORTFOLIO_APP_ID = "d90652a2-f5a1-4c7c-84c4-d4cdcc41f130";
@@ -111,13 +112,10 @@ export async function createProjects(ctx, projects) {
 }
 
 // Portfolio binds covers + gallery items by Wix Media file ID — an external url must be
-// imported first; a raw url renders nothing.
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// imported first (a raw url renders nothing); a plan `imagePrompt`/`coverImagePrompt` is
+// generated (Wix AI, 1 credit) then imported. Both live in the shared util (parallel,
+// resilient, never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // Cover = the listing-card thumbnail. PATCH per entity, echoing the current revision (missing/
 // stale revision fails); height + width are required alongside the imported file id.
@@ -172,56 +170,63 @@ export async function setupPortfolio(ctx, { collections = [], projects = [] } = 
     })),
   );
 
-  const toImage = async (url, name) => {
-    const file = await importImage(ctx, url, name);
-    return { imageId: file.id, height: 1024, width: 1024 };
-  };
-
-  // Gallery items (import each image; a failed import skips just that item).
-  const itemsFlat = [];
-  for (let i = 0; i < projects.length; i++) {
-    for (const it of projects[i].items ?? []) {
-      if (!it.imageUrl) continue;
-      try {
-        const img = await toImage(it.imageUrl, `${it.title || "item"}.png`);
-        itemsFlat.push({ projectId: projs[i].id, sortOrder: it.sortOrder, title: it.title, ...img });
-      } catch {
-        /* skip this item's image */
-      }
+  // Pass 2 — images: gallery items + project covers + collection covers, flattened into ONE
+  // parallel wave (import by url / generate by prompt), then mapped back to each attach.
+  // A failed image skips just that item/cover; the seed's exit never depends on images.
+  const specs = [];
+  const galleryRefs = [];
+  projects.forEach((p, pi) => {
+    for (const it of p.items ?? []) {
+      galleryRefs.push({ pi, it, spec: specs.length });
+      specs.push({ url: it.imageUrl, prompt: it.imagePrompt, displayName: `${it.title || "item"}.png` });
     }
-  }
-  const items = itemsFlat.length ? await createProjectItems(ctx, itemsFlat) : [];
+  });
+  const projCoverAt = specs.length;
+  projects.forEach((p) => specs.push({ url: p.coverImageUrl, prompt: p.coverImagePrompt, displayName: `${p.title || "project"}-cover.png` }));
+  const colCoverAt = specs.length;
+  collections.forEach((c) => specs.push({ url: c.coverImageUrl, prompt: c.coverImagePrompt, displayName: `${c.title || "collection"}-cover.png` }));
+  const files = await resolveItemImages(ctx, specs);
+  const dims = { height: 1024, width: 1024 };
 
-  // Covers (import each; a failed import skips just that cover — the entity stays text-only).
-  const projCovers = [];
-  for (let i = 0; i < projects.length; i++) {
-    if (!projects[i].coverImageUrl) continue;
-    try {
-      const img = await toImage(projects[i].coverImageUrl, `${projects[i].title || "project"}-cover.png`);
-      projCovers.push({ id: projs[i].id, revision: projs[i].revision, ...img });
-    } catch {
-      /* skip */
-    }
+  const itemsFlat = galleryRefs
+    .map(({ pi, it, spec }) => (files[spec] && projs[pi]?.id
+      ? { projectId: projs[pi].id, sortOrder: it.sortOrder, title: it.title, imageId: files[spec].id, ...dims }
+      : null))
+    .filter(Boolean);
+  let items = [];
+  try {
+    if (itemsFlat.length) items = await createProjectItems(ctx, itemsFlat);
+  } catch {
+    /* the remaining gallery items stay unseeded */
   }
-  if (projCovers.length) await attachProjectCovers(ctx, projCovers);
 
-  const colCovers = [];
-  for (let i = 0; i < collections.length; i++) {
-    if (!collections[i].coverImageUrl) continue;
-    try {
-      const img = await toImage(collections[i].coverImageUrl, `${collections[i].title || "collection"}-cover.png`);
-      colCovers.push({ id: cols[i].id, revision: cols[i].revision, ...img });
-    } catch {
-      /* skip */
-    }
+  const projCovers = projs
+    .map((p, i) => (files[projCoverAt + i] && p.id
+      ? { id: p.id, revision: p.revision, imageId: files[projCoverAt + i].id, ...dims }
+      : null))
+    .filter(Boolean);
+  const colCovers = cols
+    .map((c, i) => (files[colCoverAt + i] && c.id
+      ? { id: c.id, revision: c.revision, imageId: files[colCoverAt + i].id, ...dims }
+      : null))
+    .filter(Boolean);
+  let coversAttached = 0;
+  try {
+    if (projCovers.length) { await attachProjectCovers(ctx, projCovers); coversAttached += projCovers.length; }
+  } catch {
+    /* those projects stay cover-less */
   }
-  if (colCovers.length) await attachCollectionCovers(ctx, colCovers);
+  try {
+    if (colCovers.length) { await attachCollectionCovers(ctx, colCovers); coversAttached += colCovers.length; }
+  } catch {
+    /* those collections stay cover-less */
+  }
 
   return {
     collections: cols,
     projects: projs,
     itemsCreated: items.length,
-    coversAttached: projCovers.length + colCovers.length,
+    coversAttached,
   };
 }
 

--- a/skills/wix-headless-fast/references/restaurants/seed/SEED.md
+++ b/skills/wix-headless-fast/references/restaurants/seed/SEED.md
@@ -12,11 +12,12 @@ node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
 
 `plan.json` is plain data — write it from the brief. **Default to one menu with ~3 sections
 of 2–3 items each** (the seed shows the shape; the owner adds the rest in the dashboard),
-every item with an image (a menu without photos looks broken) — either an `imageUrl` (a real
-https URL, verified with `curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated,
-**1 Wix AI credit per image**, account-billed): brand-contextual — subject, aesthetic/mood,
-palette, lighting — always ending "no text, no watermarks"; images resolve in parallel and
-never block the seed, a failed image leaves that item text-only — and both add-ons on for a
+every item with an image (a menu without photos looks broken) — the default is an
+`imagePrompt` (AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual —
+subject, aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use
+`imageUrl` ONLY for an asset the user actually supplied (their own photo/URL; verify it with
+`curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never
+block the seed, a failed image leaves that item text-only — and both add-ons on for a
 restaurant that takes orders and reservations:
 
 ```json

--- a/skills/wix-headless-fast/references/restaurants/seed/SEED.md
+++ b/skills/wix-headless-fast/references/restaurants/seed/SEED.md
@@ -12,8 +12,12 @@ node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
 
 `plan.json` is plain data — write it from the brief. **Default to one menu with ~3 sections
 of 2–3 items each** (the seed shows the shape; the owner adds the rest in the dashboard),
-every item with a verified `imageUrl` (a menu without photos looks broken), and both add-ons
-on for a restaurant that takes orders and reservations:
+every item with an image (a menu without photos looks broken) — either an `imageUrl` (a real
+https URL, verified with `curl -sI` → 200 before seeding) or an `imagePrompt` (AI-generated,
+**1 Wix AI credit per image**, account-billed): brand-contextual — subject, aesthetic/mood,
+palette, lighting — always ending "no text, no watermarks"; images resolve in parallel and
+never block the seed, a failed image leaves that item text-only — and both add-ons on for a
+restaurant that takes orders and reservations:
 
 ```json
 {

--- a/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
+++ b/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
@@ -10,7 +10,7 @@
 //
 // Plan shape (see SEED.md):
 //   { "menus": [{ "name", "description"?, "sections": [{ "name", "description"?,
-//                 "items": [{ "name", "description"?, "price", "imageUrl"? }] }] }],
+//                 "items": [{ "name", "description"?, "price", "imageUrl"? | "imagePrompt"? }] }] }],
 //     "ordering"?: true | { "address"? },        // menu-first add-on; address is STEP 0
 //     "reservations"?: true | { "partySize"? { "min","max" }, "address"? } }
 //
@@ -22,6 +22,7 @@
 // setup-restaurant-reservations.md.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const MENUS_APP_ID = "b278a256-2757-4f19-9313-c05c783bec92";
@@ -185,13 +186,10 @@ export async function createMenu(ctx, menu) {
   };
 }
 
-// Restaurants binds an item image by Wix Media file ID — an external url must be imported first.
-export async function importImage(ctx, url, displayName = "image.png") {
-  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
-  const f = r.file || r;
-  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
-  return { id: f.id, url: f.url };
-}
+// Restaurants binds an item image by Wix Media file ID — an external url must be imported
+// first; a plan `imagePrompt` is generated (Wix AI, 1 credit) then imported. Both live in the
+// shared util (parallel, resilient, never blocks the seed).
+export { importImage } from "../../shared/seed/images.mjs";
 
 // Image pass. Update Item is a FULL-ENTITY REPLACE with NO field mask — each entry MUST echo
 // the item's current `revision` AND `priceInfo`, or it fails 428 MISSING_ITEM_PRICING and the
@@ -338,27 +336,31 @@ export async function setupRestaurants(ctx, plan) {
   const createdMenus = [];
   for (const m of menusPlan) createdMenus.push(await createMenu(ctx, m));
 
-  // image pass — import each item's url to Wix Media (restaurants binds by file id), then
-  // bulk full-replace with revision + priceInfo echoed. Never block on image failure.
+  // image pass — resolve each item's image (import by url / generate by prompt) in ONE
+  // parallel wave (restaurants binds by file id), then bulk full-replace with revision +
+  // priceInfo echoed. Never block on image failure.
   let imagesAttached = 0;
   const imageItems = [];
   menusPlan.forEach((m, mi) => {
     const flat = m.sections.flatMap((s) => s.items || []);
     flat.forEach((it, i) => {
       const created = createdMenus[mi]?.items?.[i];
-      if (it.imageUrl && created?.id) imageItems.push({ ...created, imageUrl: it.imageUrl, name: it.name });
+      if ((it.imageUrl || it.imagePrompt) && created?.id) {
+        imageItems.push({ ...created, imageUrl: it.imageUrl, imagePrompt: it.imagePrompt, name: it.name });
+      }
     });
   });
-  const toAttach = [];
-  for (const it of imageItems) {
-    try {
-      const file = await importImage(ctx, it.imageUrl, `${it.name || "item"}.png`);
-      toAttach.push({ id: it.id, revision: it.revision ?? "1", price: it.price,
-        image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
-    } catch {
-      /* skip this item's image */
-    }
-  }
+  const files = await resolveItemImages(ctx, imageItems.map((it) => ({
+    url: it.imageUrl,
+    prompt: it.imagePrompt,
+    displayName: `${it.name || "item"}.png`,
+  })));
+  const toAttach = imageItems
+    .map((it, i) => (files[i]
+      ? { id: it.id, revision: it.revision ?? "1", price: it.price,
+          image: { id: files[i].id, url: files[i].url, width: 1024, height: 1024 } }
+      : null))
+    .filter(Boolean);
   if (toAttach.length) {
     try {
       await attachItemImages(ctx, toAttach);

--- a/skills/wix-headless-fast/references/shared/seed/images.mjs
+++ b/skills/wix-headless-fast/references/shared/seed/images.mjs
@@ -1,0 +1,93 @@
+// Shared seed util: entity images by URL or by AI GENERATION (Wix AI / Runware via the
+// wixapis proxy). BUILD-TIME only — imported by the vertical seed scripts, never shipped.
+//
+// The contract every seed relies on:
+//   - RESILIENT: nothing here ever throws out of resolveItemImages — a failed image resolves
+//     to null and the entity stays text-only; the seed's exit code never depends on images.
+//   - PARALLEL: all images resolve in one concurrent wave (each generation is its own
+//     single-task request — the google model 504s when one body bundles ≥3 tasks).
+//   - PASS-2: seeds create entities first, then attach what this returns — an image is never
+//     a precondition for an entity.
+//
+// Generation costs 1 Wix AI credit per image, billed to the account behind the site.
+// Authoritative reference: wix-headless/references/IMAGE_GENERATION.md.
+import { randomUUID } from "node:crypto";
+
+const API = "https://www.wixapis.com";
+// Fallbacks for repeated model failures; google:4@2 rejects steps/CFGScale and free-form sizes.
+const MODELS = ["google:4@2", "bfl:5@1", "runware:400@1"];
+/** Allowed dimensions: 1024×1024 (square — entities), 1376×768 (16:9 hero), 1200×896 (4:3). */
+export const IMAGE_SIZES = { square: [1024, 1024], hero: [1376, 768], editorial: [1200, 896] };
+
+async function req(ctx, path, body, timeoutMs = 90_000) {
+  const res = await fetch(API + path, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`POST ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 300)}`);
+  return json;
+}
+
+/**
+ * Generate one image; returns its short-lived URL (import it immediately). Tries each model
+ * once — a per-model failure (bad params, 5xx, credit exhaustion, timeout) falls through to
+ * the next; throws only after all models failed.
+ */
+export async function generateImage(ctx, prompt, { width = 1024, height = 1024 } = {}) {
+  let lastErr;
+  for (const model of MODELS) {
+    try {
+      const r = await req(ctx, "/runwareschemaless/v1/request", [
+        {
+          taskType: "imageInference",
+          taskUUID: randomUUID(), // must be a real UUIDv4 — slugs 400
+          outputType: "URL",
+          outputFormat: "PNG",
+          positivePrompt: prompt,
+          width,
+          height,
+          model,
+          numberResults: 1,
+        },
+      ]);
+      const url = r?.data?.[0]?.imageURL;
+      if (url) return url;
+      lastErr = new Error(`no imageURL in response: ${JSON.stringify(r).slice(0, 200)}`);
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr;
+}
+
+/** Import an external/generated URL into Wix Media; returns { id, url } (permanent). */
+export async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { url, mimeType: "image/png", displayName });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+/**
+ * THE seed entry point. Resolves a batch of image specs to Wix Media files in ONE parallel
+ * wave. Each spec: { url } (verified external URL — imported as-is) OR { prompt } (generated,
+ * 1 credit) — plus optional displayName, width, height. Returns an array aligned with the
+ * input: { id, url } per success, null per failure or empty spec. Never throws.
+ */
+export async function resolveItemImages(ctx, specs) {
+  const results = await Promise.allSettled(
+    (specs ?? []).map(async (s) => {
+      if (!s || (!s.url && !s.prompt)) return null;
+      const source = s.url ?? (await generateImage(ctx, s.prompt, { width: s.width, height: s.height }));
+      return importImage(ctx, source, s.displayName ?? "image.png");
+    }),
+  );
+  return results.map((r) => (r.status === "fulfilled" ? r.value : null));
+}

--- a/skills/wix-headless-fast/references/shared/seed/images.mjs
+++ b/skills/wix-headless-fast/references/shared/seed/images.mjs
@@ -14,8 +14,11 @@
 import { randomUUID } from "node:crypto";
 
 const API = "https://www.wixapis.com";
-// Fallbacks for repeated model failures; google:4@2 rejects steps/CFGScale and free-form sizes.
-const MODELS = ["google:4@2", "bfl:5@1", "runware:400@1"];
+// Order = cheap-and-permissive first (runware ~0.009 credits/img, ~5s, loosest content
+// filter), then google (best fidelity, ~0.14, ~25s; rejects steps/CFGScale and free-form
+// sizes), then bfl (strictest filter — refuses trademark-ish prompts). A refusal or failure
+// falls through to the next model.
+const MODELS = ["runware:400@1", "google:4@2", "bfl:5@1"];
 /** Allowed dimensions: 1024×1024 (square — entities), 1376×768 (16:9 hero), 1200×896 (4:3). */
 export const IMAGE_SIZES = { square: [1024, 1024], hero: [1376, 768], editorial: [1200, 896] };
 

--- a/skills/wix-headless-fast/references/shared/seed/images.mjs
+++ b/skills/wix-headless-fast/references/shared/seed/images.mjs
@@ -22,7 +22,7 @@ const MODELS = ["runware:400@1", "google:4@2", "bfl:5@1"];
 /** Allowed dimensions: 1024×1024 (square — entities), 1376×768 (16:9 hero), 1200×896 (4:3). */
 export const IMAGE_SIZES = { square: [1024, 1024], hero: [1376, 768], editorial: [1200, 896] };
 
-async function req(ctx, path, body, timeoutMs = 90_000) {
+async function req(ctx, path, body, timeoutMs = 45_000) {
   const res = await fetch(API + path, {
     method: "POST",
     headers: {
@@ -84,12 +84,18 @@ export async function importImage(ctx, url, displayName = "image.png") {
  * 1 credit) — plus optional displayName, width, height. Returns an array aligned with the
  * input: { id, url } per success, null per failure or empty spec. Never throws.
  */
-export async function resolveItemImages(ctx, specs) {
+export async function resolveItemImages(ctx, specs, { perImageBudgetMs = 120_000 } = {}) {
+  const deadline = new Promise((r) => setTimeout(() => r(null), perImageBudgetMs));
   const results = await Promise.allSettled(
     (specs ?? []).map(async (s) => {
       if (!s || (!s.url && !s.prompt)) return null;
-      const source = s.url ?? (await generateImage(ctx, s.prompt, { width: s.width, height: s.height }));
-      return importImage(ctx, source, s.displayName ?? "image.png");
+      const resolve = (async () => {
+        const source = s.url ?? (await generateImage(ctx, s.prompt, { width: s.width, height: s.height }));
+        return importImage(ctx, source, s.displayName ?? "image.png");
+      })();
+      // Hard per-image budget: even a pathological multi-model hang costs the seed at most
+      // perImageBudgetMs of wall clock (the wave is parallel, so it's paid once, not per item).
+      return Promise.race([resolve, deadline]);
     }),
   );
   return results.map((r) => (r.status === "fulfilled" ? r.value : null));

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -37,12 +37,12 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
 - `compareAtPrice` (> `price`) — the "was" price: strikethrough on the PDP, sale badge data on
   the tile.
 - **Give every product an image** (a store without product images looks broken: gray boxes on
-  tiles, PDP, and cart) — either an `imageUrl` (a real https URL, verified with `curl -sI` →
-  200 before seeding; a guessed URL seeds a broken image) or an `imagePrompt` (AI-generated,
-  **1 Wix AI credit per image**, account-billed): brand-contextual — subject, aesthetic/mood,
-  palette, lighting — always ending "no text, no watermarks". Images resolve in parallel and
-  never block the seed; a failed image leaves that product text-only. Seed text-only only
-  when the user explicitly asks.
+  tiles, PDP, and cart) — the default is an `imagePrompt` (AI-generated, ~1 Wix AI credit
+  per image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
+  always ending "no text, no watermarks". Use `imageUrl` ONLY for an asset the user actually
+  supplied (their own photo/URL; verify it with `curl -sI` → 200) — never a stock-photo or
+  guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
+  that product text-only. Seed text-only only when the user explicitly asks.
 - `categories` — category name → product NAMES. Omit when the brief names none.
 
 **Default to 3 products** unless the brief asks for a specific catalog — the seed shows the

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -36,10 +36,13 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
   carrying the product's price/compareAtPrice/quantity) — keep option counts small.
 - `compareAtPrice` (> `price`) — the "was" price: strikethrough on the PDP, sale badge data on
   the tile.
-- `imageUrl` — **include one for every product** (a store without product images looks broken:
-  gray boxes on tiles, PDP, and cart). It must be a real, fetchable https URL — **verify each
-  resolves (e.g. a quick `curl -sI` → 200) before seeding**; a guessed URL seeds a broken
-  image. Wix re-hosts it server-side. Seed text-only only when the user explicitly asks.
+- **Give every product an image** (a store without product images looks broken: gray boxes on
+  tiles, PDP, and cart) — either an `imageUrl` (a real https URL, verified with `curl -sI` →
+  200 before seeding; a guessed URL seeds a broken image) or an `imagePrompt` (AI-generated,
+  **1 Wix AI credit per image**, account-billed): brand-contextual — subject, aesthetic/mood,
+  palette, lighting — always ending "no text, no watermarks". Images resolve in parallel and
+  never block the seed; a failed image leaves that product text-only. Seed text-only only
+  when the user explicitly asks.
 - `categories` — category name → product NAMES. Omit when the brief names none.
 
 **Default to 3 products** unless the brief asks for a specific catalog — the seed shows the

--- a/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
+++ b/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
@@ -13,7 +13,7 @@
 //   { "products": [{ "name", "description", "price", "compareAtPrice"?, "quantity",
 //                    "options"?: [{ "name", "type"?: "text"|"color",
 //                                   "choices": ["S","M"] | [{ "name", "colorCode" }] }],
-//                    "imageUrl"?, "altText"? }],
+//                    "imageUrl"? | "imagePrompt"?, "altText"? }],
 //     "categories"?: { "<category name>": ["<product name>", ...] } }
 //
 // Seeding is ADDITIVE — this script never deletes or overwrites existing content.
@@ -21,6 +21,7 @@
 // source recipe is wix-headless/references/inline-recipes/setup-online-store.md) — never guess.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolveItemImages } from "../../shared/seed/images.mjs";
 
 const API = "https://www.wixapis.com";
 const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
@@ -299,12 +300,25 @@ export async function setupStore(ctx, { products = [], categories = {} } = {}) {
     if (Object.keys(mapping).length) await addProductsToCategories(ctx, mapping);
   }
 
+  // Pass 2 — images: resolve (import by url / generate by prompt) in one parallel wave, then
+  // bulk-attach. Failures leave the product text-only; the seed's exit never depends on images.
+  const files = await resolveItemImages(ctx, withNames.map((p, i) => ({
+    url: products[i]?.imageUrl,
+    prompt: products[i]?.imagePrompt,
+    displayName: `${p.slug || "product"}.png`,
+  })));
   const imageItems = withNames
-    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
-    .filter((it) => it.url);
-  if (imageItems.length) await attachProductImages(ctx, imageItems);
+    .map((p, i) => (files[i] && p.id ? { id: p.id, url: files[i].url, altText: products[i]?.altText ?? p.slug } : null))
+    .filter(Boolean);
+  let imagesAttached = 0;
+  try {
+    if (imageItems.length) await attachProductImages(ctx, imageItems);
+    imagesAttached = imageItems.length;
+  } catch {
+    /* never block on image failure — the products stay text-only */
+  }
 
-  return { products: withNames, categories: cats, imagesAttached: imageItems.length };
+  return { products: withNames, categories: cats, imagesAttached };
 }
 
 // ---- CLI entry ----------------------------------------------------------------------------------


### PR DESCRIPTION
Brings the classic skill's image-generation capability (per `wix-headless/references/IMAGE_GENERATION.md`) into the fast skill's seed layer, honoring its architecture: deterministic, parallel, and incapable of failing a seed.

- **Shared util** `references/shared/seed/images.mjs`: `resolveItemImages(ctx, specs)` resolves a whole batch — `{url}` imports as-is, `{prompt}` generates via Wix AI (Runware through the wixapis proxy, 1 credit/image) then imports — in **one parallel wave** (each generation its own single-task request; `google:4@2` 504s on bundled bodies), with per-call timeouts, model fallback (`google:4@2` → `bfl:5@1` → `runware:400@1`), and every failure resolving to `null` so the entity stays text-only. Seeds create entities first; images are always a pass-2 attach.
- **Every image-bearing vertical** now accepts `imagePrompt` alongside `imageUrl`: storefront, bookings, blog (`coverImagePrompt`), cms (`{"prompt": …}` as an IMAGE value), events, portfolio (covers + gallery items), restaurants. Each vertical's attach mechanics — and their earned trap comments (blog's `displayed+custom` + re-publish, events' required height/width, restaurants' revision+priceInfo echo, portfolio's revision echo) — are untouched.
- **SEED.mds** document the contract: `imageUrl` stays curl-verified; `imagePrompt` is brand-contextual (subject, aesthetic, palette, lighting, always "no text, no watermarks") and costs **1 Wix AI credit per image**, account-billed.

**Live-verified twice on a real site**: bookings ("Hot Stone Ritual") and storefront ("Triceratops Floor Cushion") seeded with `imagePrompt` — generation → import → attach → both generated images serve from wixstatic on the live pages; both seeds exit 0. `node --check` green on all touched seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)