### PR TITLE
fix: stores seed — idempotent-by-name creation (safe reruns after partial-apply)

### DIFF
--- a/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
+++ b/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
@@ -45,11 +45,10 @@ export function makeCtx({ cwd = process.cwd() } = {}) {
 
 async function req(ctx, path, { method = "POST", body } = {}) {
   // Retry while the catalog is still provisioning: right after a fresh Stores install the V3
-  // WRITE path becomes usable later than the read path, so the first bulk-create can 428 —
-  // or answer a bare 429 {} (same cold-path race wearing the rate-limit status; and a real
-  // rate limit wants the same backoff). Wait both out (~80s budget); other errors throw
-  // immediately. ⚠️ An errored bulk create may still have applied server-side — creation is
-  // made idempotent by name in setupStore for exactly that reason.
+  // WRITE path becomes usable later than the read path, so the first bulk-create can 428 even
+  // after the read probe clears. Wait it out (~80s budget); other errors throw immediately.
+  // ⚠️ An errored bulk create (seen live with a bare 429 {}) may still have APPLIED
+  // server-side — creation is idempotent by name in setupStore for exactly that reason.
   for (let attempt = 0; ; attempt++) {
     const res = await fetch(API + path, {
       method,
@@ -62,7 +61,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
     });
     const json = await res.json().catch(() => ({}));
     if (res.ok) return json;
-    if ((isProvisioning(res.status, json) || res.status === 429) && attempt < 40) {
+    if (isProvisioning(res.status, json) && attempt < 40) {
       await sleep(2000);
       continue;
     }

--- a/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
+++ b/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
@@ -45,8 +45,11 @@ export function makeCtx({ cwd = process.cwd() } = {}) {
 
 async function req(ctx, path, { method = "POST", body } = {}) {
   // Retry while the catalog is still provisioning: right after a fresh Stores install the V3
-  // WRITE path becomes usable later than the read path, so the first bulk-create can 428 even
-  // after the read probe clears. Wait it out (~80s budget); other errors throw immediately.
+  // WRITE path becomes usable later than the read path, so the first bulk-create can 428 —
+  // or answer a bare 429 {} (same cold-path race wearing the rate-limit status; and a real
+  // rate limit wants the same backoff). Wait both out (~80s budget); other errors throw
+  // immediately. ⚠️ An errored bulk create may still have applied server-side — creation is
+  // made idempotent by name in setupStore for exactly that reason.
   for (let attempt = 0; ; attempt++) {
     const res = await fetch(API + path, {
       method,
@@ -59,7 +62,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
     });
     const json = await res.json().catch(() => ({}));
     if (res.ok) return json;
-    if (isProvisioning(res.status, json) && attempt < 40) {
+    if ((isProvisioning(res.status, json) || res.status === 429) && attempt < 40) {
       await sleep(2000);
       continue;
     }
@@ -192,6 +195,24 @@ export async function installStoresApp(ctx) {
   await waitForCatalogV3(ctx);
 }
 
+// Existing products by exact name (for idempotent reruns). `name` is NOT filterable on the
+// V3 query — fetch a page and match client-side (seed catalogs are small). Empty map on any
+// failure — falling back to create-everything is the additive behavior we had before.
+export async function queryProductsByNames(ctx, names) {
+  const out = new Map();
+  if (!names.length) return out;
+  try {
+    const wanted = new Set(names);
+    const r = await req(ctx, "/stores/v3/products/query", { body: { query: { cursorPaging: { limit: 100 } } } });
+    for (const p of r.products ?? []) {
+      if (wanted.has(p.name) && !out.has(p.name)) out.set(p.name, { id: p.id, slug: p.slug, revision: p.revision });
+    }
+  } catch (e) {
+    console.error(`product name pre-check failed (creating everything): ${String(e.message).slice(0, 120)}`);
+  }
+  return out;
+}
+
 export async function bulkCreateProducts(ctx, products) {
   const body = {
     returnEntity: true,
@@ -285,8 +306,17 @@ export async function attachProductImages(ctx, items) {
 export async function setupStore(ctx, { products = [], categories = {} } = {}) {
   await installStoresApp(ctx);
 
-  const created = await bulkCreateProducts(ctx, products);
-  const withNames = created.map((p, i) => ({ ...p, name: products[i]?.name }));
+  // Idempotent by name: an errored bulk create (429/5xx) may still have applied server-side,
+  // and SKILL.md tells the agent to re-run a failed seed — creating only the names that don't
+  // exist yet makes that rerun safe instead of a duplicator.
+  const existing = await queryProductsByNames(ctx, products.map((p) => p.name));
+  const toCreate = products.filter((p) => !existing.has(p.name));
+  const created = toCreate.length ? await bulkCreateProducts(ctx, toCreate) : [];
+  const createdByName = new Map(created.map((p, i) => [toCreate[i]?.name, p]));
+  const withNames = products.map((p) => {
+    const hit = createdByName.get(p.name) ?? existing.get(p.name);
+    return { ...(hit ?? {}), name: p.name };
+  });
   const idByName = new Map(withNames.map((p) => [p.name, p.id]));
 
   const names = Object.keys(categories);


### PR DESCRIPTION
Run41 hit a bare `429 {}` on a fresh site's first bulk product create — and the errored call **had applied server-side**, so the manual rerun SKILL.md prescribes duplicated the catalog (3 imageless ghosts alongside the repaired products).

The fix: **idempotent-by-name creation** — `setupStore` pre-checks existing products (V3 query; `name` isn't filterable, so fetch-a-page + client-side match) and creates only what's missing. A rerun now returns the same ids and repairs images instead of duplicating. The 429 itself still fails loud (no retry added); the transport comment records the partial-apply observation.

Live-verified on the run41 site: rerun created 0 products, returned the same ids, re-attached 3 images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)