### PR TITLE
feat: wix-headless-fast — imagePath (local-file seed images) + docs links at every API call site

### DIFF
--- a/skills/wix-headless-fast/references/blog/app/wix/blog/posts.ts
+++ b/skills/wix-headless-fast/references/blog/app/wix/blog/posts.ts
@@ -1,6 +1,8 @@
 // Post reads (Wix Blog V3) — the only file that touches raw post entities. Everything it
 // returns is a plain DTO from ./types. Copy as-is; extend by adding functions, not by editing
 // these. Blog posts are NOT CMS collections — always @wix/blog, never @wix/data.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/get-post-by-slug.md
 import { posts as postsModule } from "@wix/blog";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/blog/app/wix/blog/taxonomy.ts
+++ b/skills/wix-headless-fast/references/blog/app/wix/blog/taxonomy.ts
@@ -1,5 +1,7 @@
 // Category + tag reads (Wix Blog V3) — the only file that touches raw taxonomy entities.
 // Everything it returns is a plain DTO from ./types. Copy as-is; extend by adding functions.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/query-categories.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/query-tags.md
 import { categories as categoriesModule, tags as tagsModule } from "@wix/blog";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/blog/seed/SEED.md
+++ b/skills/wix-headless-fast/references/blog/seed/SEED.md
@@ -51,9 +51,9 @@ feed without covers looks broken.
   ids internally. Optional: skip them entirely when the brief doesn't group posts.
 - Cover — the default is a `coverImagePrompt` (AI-generated, ~1 Wix AI credit per image,
   account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting — always
-  ending "no text, no watermarks". Use `coverImageUrl` ONLY for an asset the user actually
-  supplied (their own photo/URL; verify it with `curl -sI` → 200; imported into Wix Media —
-  Blog binds covers by file id, not URL) — never a stock-photo or guessed URL. Covers resolve
+  ending "no text, no watermarks". For an asset the user actually supplied use
+  `coverImagePath` (a file on this machine — uploaded to Wix Media) or `coverImageUrl` (their
+  own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Covers resolve
   in parallel and never block the seed; a failed cover leaves that post text-only (the script
   re-publishes each post it covers).
 - Posts are created **published** — an unpublished post never reaches visitors. The bulk

--- a/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
+++ b/skills/wix-headless-fast/references/blog/seed/seed-blog.mjs
@@ -106,6 +106,7 @@ function buildPost(p, i, memberId) {
 
 // ---- operations ----------------------------------------------------------------------------
 
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installBlogApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -119,6 +120,7 @@ export async function installBlogApp(ctx) {
 
 // Every post create needs a REAL author memberId — a fabricated id fails with
 // "memberIds ... do not exist". A provisioned site has the owner as members[0].
+// docs: https://dev.wix.com/docs/api-reference/crm/members-contacts/members/members/list-members.md
 export async function getAuthorMemberId(ctx) {
   const r = await req(ctx, "/members/v1/members?fieldsets=PUBLIC&paging.limit=1", { method: "GET" });
   const id = r.members?.[0]?.id;
@@ -131,6 +133,8 @@ export async function getAuthorMemberId(ctx) {
  * Endpoint auto-selected per the recipe: single-post endpoint for exactly one (nested
  * `{ draftPost }` envelope), bulk for >= 2 — `bulk` sits BETWEEN v3 and draft-posts, and each
  * bulk item is FLAT (wrapping it in `draftPost` 400s). Returns [{ id, index, success }].
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-create-draft-posts.md
  */
 export async function createPosts(ctx, posts, { memberId, publish = true } = {}) {
   if (!memberId) throw new Error("createPosts requires opts.memberId (see getAuthorMemberId)");
@@ -148,6 +152,8 @@ export async function createPosts(ctx, posts, { memberId, publish = true } = {})
 }
 
 // Existing label -> id, straight from the query (the source of truth for what persisted).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/query-categories.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/query-tags.md
 async function labelIdMap(ctx, kind) {
   const path = kind === "categories" ? "/blog/v3/categories/query" : "/v3/tags/query";
   const r = await req(ctx, path, { body: { query: { paging: { limit: 100 } } } });
@@ -178,11 +184,13 @@ async function ensureLabels(ctx, kind, createPath, mkBody, names) {
 }
 
 /** Create categories idempotently by label (no bulk endpoint). Feed ids into post.categoryIds. */
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/create-category.md
 export async function createCategories(ctx, names) {
   return ensureLabels(ctx, "categories", "/blog/v3/categories", (name) => ({ category: { label: name } }), names);
 }
 
 /** Create tags idempotently by label. Feed ids into post.tagIds. */
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/create-tag.md
 export async function createTags(ctx, names) {
   return ensureLabels(ctx, "tags", "/blog/v3/tags", (name) => ({ label: name }), names);
 }
@@ -197,6 +205,8 @@ export { importImage } from "../../shared/seed/images.mjs";
 // media.displayed:true + media.custom:true + wixMedia.image.id (the id ALONE is a silent
 // no-op), then RE-PUBLISH — the PATCH sets hasUnpublishedChanges, so the live post stays
 // cover-less until republished. Image failures never block the run.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/update-draft-post.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/publish-draft-post.md
 export async function attachPostCovers(ctx, covers) {
   let attached = 0;
   for (const { postId, fileId } of covers) {
@@ -246,7 +256,7 @@ export async function setupBlog(ctx, { posts = [], categories = [], tags = [] } 
   // never depends on images.
   const files = await resolveItemImages(ctx, created.map((c, i) => (
     c?.id && c?.success
-      ? { url: posts[i]?.coverImageUrl, prompt: posts[i]?.coverImagePrompt, displayName: `post-${i}.png` }
+      ? { path: posts[i]?.coverImagePath, url: posts[i]?.coverImageUrl, prompt: posts[i]?.coverImagePrompt, displayName: `post-${i}.png` }
       : null
   )));
   const covers = created

--- a/skills/wix-headless-fast/references/bookings/app/wix/bookings/booking.ts
+++ b/skills/wix-headless-fast/references/bookings/app/wix/bookings/booking.ts
@@ -1,6 +1,14 @@
 // Availability, the booking form, and the createBooking → Cart V2 → checkout-or-place
 // sequence. The payload shapes here are exact and easy to get subtly wrong — copy as-is;
 // extend by calling these exports, never by editing them. Failures are loud.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/create-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/calculate-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/place-order.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+// docs: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/get-form-summary.md
 import {
   availabilityTimeSlots,
   eventTimeSlots,

--- a/skills/wix-headless-fast/references/bookings/app/wix/bookings/services.ts
+++ b/skills/wix-headless-fast/references/bookings/app/wix/bookings/services.ts
@@ -1,6 +1,8 @@
 // Service reads (Wix Bookings Services V2) — the only file that touches raw service
 // entities. Everything it returns is a plain DTO from ./types. Copy as-is; extend by adding
 // functions, not by editing these.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories.md
 import { services as servicesModule, categoriesV2 } from "@wix/bookings";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/bookings/seed/SEED.md
+++ b/skills/wix-headless-fast/references/bookings/seed/SEED.md
@@ -15,9 +15,9 @@ shows the shape; the owner adds the rest in the dashboard) and make them exercis
 mix APPOINTMENT and CLASS when it fits the business, include ≥1 free/pay-in-person service,
 and give every service an image — the default is an `imagePrompt` (AI-generated, ~1 Wix AI
 credit per image, account-billed): brand-contextual — subject, aesthetic/mood, palette,
-lighting — always ending "no text, no watermarks". Use `imageUrl` ONLY for an asset the user
-actually supplied (their own photo/URL; verify it with `curl -sI` → 200) — never a
-stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed
+lighting — always ending "no text, no watermarks". For an asset the user actually supplied use `imagePath` (a file on this
+machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
+`curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed
 image leaves that service text-only.
 
 ```json

--- a/skills/wix-headless-fast/references/bookings/seed/seed-bookings.mjs
+++ b/skills/wix-headless-fast/references/bookings/seed/seed-bookings.mjs
@@ -87,6 +87,7 @@ function buildService(s) {
 
 // ---- operations ----------------------------------------------------------------------------------
 
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installBookingsApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -99,6 +100,7 @@ export async function installBookingsApp(ctx) {
 }
 
 // ⚠️ staffMemberIds takes resourceId, NOT the staff id.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/query-staff-members.md
 export async function queryStaff(ctx) {
   const r = await req(ctx, "/bookings/v1/staff-members/query", {
     body: { query: {}, fields: ["RESOURCE_DETAILS"] },
@@ -123,6 +125,8 @@ export async function queryStaffWithRetry(ctx, { tries = 15, delayMs = 2000 } = 
 }
 
 // Every service needs a category.id or it's invisible on the live site. Idempotent by name.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category.md
 export async function createCategories(ctx, names) {
   const existing = await req(ctx, "/bookings/v2/categories/query", { body: { query: {} } });
   const byName = new Map((existing.categories ?? []).map((c) => [c.name, { id: c.id, name: c.name }]));
@@ -140,6 +144,7 @@ export async function createCategories(ctx, names) {
 }
 
 // Bulk-create services (APPOINTMENT + CLASS mixed). Run AFTER staff + categories.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services.md
 export async function createServices(ctx, services) {
   const body = { services: services.map(buildService), returnEntity: true };
   const r = await req(ctx, "/bookings/v2/bulk/services/create", { body });
@@ -159,6 +164,7 @@ export async function createServices(ctx, services) {
 
 // CLASS only: schedule sessions (bulk Calendar Events V3). start/end are LOCAL wall-clock
 // "YYYY-MM-DDThh:mm:ss" (no Z), today-or-future.
+// docs: https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event.md
 export async function scheduleClassSessions(ctx, sessions) {
   const body = {
     events: sessions.map((s) => ({
@@ -186,6 +192,7 @@ export async function scheduleClassSessions(ctx, sessions) {
 export { importImage } from "../../shared/seed/images.mjs";
 
 // Writes under media.mainMedia + media.coverMedia (writing media.image 200s but silently drops).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service.md
 export async function attachServiceImage(ctx, it) {
   return req(ctx, `/bookings/v2/services/${it.serviceId}`, {
     method: "PATCH",
@@ -247,6 +254,7 @@ export async function setupBookings(ctx, { services = [], staffResourceId } = {}
   // attach. Failures leave the service text-only; the seed's exit never depends on images.
   const files = await resolveItemImages(ctx, created.map((c, i) => ({
     url: services[i]?.imageUrl,
+    path: services[i]?.imagePath,
     prompt: services[i]?.imagePrompt,
     displayName: `${c?.slug || "service"}.png`,
   })));

--- a/skills/wix-headless-fast/references/cms/app/wix/cms/items.ts
+++ b/skills/wix-headless-fast/references/cms/app/wix/cms/items.ts
@@ -2,6 +2,8 @@
 // CMS is schema-generic: every function takes the collection id from the seed plan
 // (seed/SEED.md) and returns plain CmsItem DTOs from ./types. Copy as-is; extend by adding
 // functions, not by editing these.
+// docs: https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md
+// docs: https://dev.wix.com/docs/sdk/business-solutions/data/items/update.md
 import { items as itemsModule } from "@wix/data";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/cms/seed/SEED.md
+++ b/skills/wix-headless-fast/references/cms/seed/SEED.md
@@ -59,9 +59,9 @@ every content item an image on an IMAGE field (a content site without images loo
   `RICH_TEXT` (an HTML string, stored verbatim), `REFERENCE`, `MULTI_REFERENCE`.
 - `IMAGE` values — the default is `{ "prompt": "..." }` (AI-generated, ~1 Wix AI credit per
   image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
-  always ending "no text, no watermarks". Use an https URL string ONLY for an asset the user
-  actually supplied (their own photo/URL; verify it with `curl -sI` → 200; imported into Wix
-  Media, the permanent `file.url` is stored) — never a stock-photo or guessed URL. Images
+  always ending "no text, no watermarks". For an asset the user actually supplied use
+  `{ "path": "..." }` (a file on this machine — uploaded to Wix Media) or an https URL string
+  (their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images
   resolve in parallel and never block the seed; a failed image leaves that field unset (the
   item stays text-only).
 - `DATE`/`DATETIME` values are ISO strings — the script wraps them as `{ "$date": iso }`.

--- a/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
+++ b/skills/wix-headless-fast/references/cms/seed/seed-cms.mjs
@@ -15,8 +15,8 @@
 //       "items": [{ "<fieldKey>": value, ... }] }] }
 // Reference fields: order collections so targets come FIRST. A REFERENCE value is the
 // target item's index in ITS collection's items array; MULTI_REFERENCE is an array of
-// indices. An IMAGE value is a verified https url STRING or { "prompt": "..." }
-// (AI-generated).
+// indices. An IMAGE value is a verified https url STRING, { "prompt": "..." }
+// (AI-generated), or { "path": "..." } (a local file the user supplied, uploaded).
 //
 // Seeding is ADDITIVE — never deletes or overwrites existing content. Unexpected shapes →
 // read the live API reference; authoritative source recipe:
@@ -80,6 +80,7 @@ async function reqRetryOnce(ctx, path, opts) {
 // ---- operations ----------------------------------------------------------------------------------
 
 // Idempotent; strictly only needed when a data call errors WDE0110 (app not installed).
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installDataApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -117,6 +118,7 @@ function buildField(f, collectionId) {
 const displayNameOf = (id) => String(id).replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
 // The permissions block is MANDATORY. 409 WDE0104 (already exists) is fine — additive.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-collections/create-data-collection.md
 export async function createCollection(ctx, { id, displayName, fields = [], permissions }) {
   try {
     await reqRetryOnce(ctx, "/wix-data/v2/collections", { body: { collection: {
@@ -139,6 +141,7 @@ export async function createCollection(ctx, { id, displayName, fields = [], perm
 export { importImage } from "../../shared/seed/images.mjs";
 
 // Ids come from results[].dataItem.id (there is no results[].item key).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-items.md
 export async function bulkInsertItems(ctx, dataCollectionId, dataItems) {
   const r = await reqRetryOnce(ctx, "/wix-data/v2/bulk/items/insert", { body: {
     dataCollectionId,
@@ -156,6 +159,7 @@ export async function bulkInsertItems(ctx, dataCollectionId, dataItems) {
 
 // Body key is dataItemReferences with referringItemFieldName/referringItemId/referencedItemId
 // — the natural-looking `references` shape is rejected with 400 WDE0080.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-item-references.md
 export async function insertReferences(ctx, dataCollectionId, dataItemReferences) {
   if (!dataItemReferences.length) return 0;
   const r = await req(ctx, "/wix-data/v2/bulk/items/insert-references", {
@@ -165,6 +169,7 @@ export async function insertReferences(ctx, dataCollectionId, dataItemReferences
 }
 
 // A 200 on insert does NOT prove persistence — query back and count.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-data-items.md
 export async function verifyItems(ctx, dataCollectionId) {
   const r = await reqRetryOnce(ctx, "/wix-data/v2/items/query", { body: { dataCollectionId } });
   return (r.dataItems ?? []).length;
@@ -232,6 +237,7 @@ async function resolveAllImages(ctx, collections) {
         keys.push(imageKey(col.id, i, key));
         specs.push({
           url: typeof value === "string" ? value : undefined,
+          path: typeof value === "object" ? value.path : undefined,
           prompt: typeof value === "object" ? value.prompt : undefined,
           displayName: `${col.id}-${i}-${key}.png`,
         });

--- a/skills/wix-headless-fast/references/events/app/wix/events/events.ts
+++ b/skills/wix-headless-fast/references/events/app/wix/events/events.ts
@@ -1,6 +1,8 @@
 // Event reads (Wix Events V3, the `wixEventsV2` module) — the only file that touches raw
 // event entities. Everything it returns is a plain DTO from ./types. Copy as-is; extend by
 // adding functions, not by editing these.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/query-events.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/get-event-by-slug.md
 import { wixEventsV2 } from "@wix/events";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/events/app/wix/events/registration.ts
+++ b/skills/wix-headless-fast/references/events/app/wix/events/registration.ts
@@ -2,6 +2,10 @@
 // are exact and easy to get subtly wrong — copy as-is; extend by calling these exports,
 // never by editing them. Failures are loud. Everything runs as the anonymous VISITOR —
 // no server route, no elevation, anywhere.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/orders/query-available-tickets.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/ticket-reservations/create-ticket-reservation.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/rsvp-v2/create-rsvp.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
 import { orders, rsvpV2, ticketReservations } from "@wix/events";
 import { redirects as redirectsModule } from "@wix/redirects";
 import { wixModule } from "../sdk";

--- a/skills/wix-headless-fast/references/events/seed/SEED.md
+++ b/skills/wix-headless-fast/references/events/seed/SEED.md
@@ -16,9 +16,9 @@ the shape; the owner adds the rest in the dashboard) and make them exercise the 
 `TICKETING` and `RSVP` (≥1 of each), give a ticketed event 2 tiers, and give every event an
 image (an events page without images looks broken) — the default is an `imagePrompt`
 (AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
-aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use `imageUrl`
-ONLY for an asset the user actually supplied (their own photo/URL; verify it with `curl -sI`
-→ 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the
+aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually
+supplied use `imagePath` (a file on this machine — uploaded to Wix Media) or `imageUrl`
+(their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the
 seed; a failed image leaves that event text-only.
 
 ```json

--- a/skills/wix-headless-fast/references/events/seed/seed-events.mjs
+++ b/skills/wix-headless-fast/references/events/seed/seed-events.mjs
@@ -76,6 +76,7 @@ function buildRegistration(ev) {
 // ---- operations ----------------------------------------------------------------------------------
 
 // Idempotent: re-installing an already-installed app returns 200.
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installEventsApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -89,6 +90,7 @@ export async function installEventsApp(ctx) {
 
 // The ticket-definitions API REQUIRES currency and uses whatever you pass verbatim (it does
 // NOT fall back to the site currency) — resolve it once, or a non-USD site gets mis-priced.
+// docs: https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties.md
 export async function getSiteCurrency(ctx) {
   try {
     const r = await req(ctx, "/site-properties/v4/properties", { method: "GET" });
@@ -102,6 +104,7 @@ export async function getSiteCurrency(ctx) {
  * STEP 1 — create ONE event as a draft (no bulk endpoint; loop for multiple). Dates MUST be
  * in the future — a past event isn't registerable and won't show in the live listing.
  * Returns { id, slug } — id feeds the tier/publish steps; slug is the URL identifier.
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/create-event.md
  */
 export async function createEvent(ctx, ev) {
   const body = {
@@ -129,6 +132,7 @@ export async function createEvent(ctx, ev) {
  * publishing a ticketed event with no tiers ships an event with nothing to buy, and there is
  * no un-publish. price is a decimal STRING ("65.00", never a number); name ≤ 30 chars; omit
  * initialLimit for unlimited. Tiers are independent — fired as one parallel batch.
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/ticket-definitions-v3/create-ticket-definition.md
  */
 export async function createTicketTiers(ctx, eventId, tiers) {
   return Promise.all(tiers.map(async (t) => {
@@ -149,11 +153,13 @@ export async function createTicketTiers(ctx, eventId, tiers) {
 }
 
 // STEP 3 — publish (one-way; for TICKETING only after its tiers exist).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/publish-draft-event.md
 export async function publishEvent(ctx, eventId) {
   return req(ctx, `/events/v3/events/${eventId}/publish`, { body: {} });
 }
 
 // STEP 4 (optional) — group events by a format/track. Categories are the v1 API (NOT v3).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/categories/create-category.md
 export async function createEventCategories(ctx, names) {
   const out = [];
   for (const name of names) {
@@ -165,6 +171,7 @@ export async function createEventCategories(ctx, names) {
 
 // Assign events to a category. Path is /{categoryId}/events (NOT /assign); body key is
 // `eventId` — an ARRAY despite the singular name.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/categories/assign-events.md
 export async function assignEventsToCategory(ctx, categoryId, eventIds) {
   return req(ctx, `/events/v1/categories/${categoryId}/events`, { body: { eventId: eventIds } });
 }
@@ -177,6 +184,7 @@ export { importImage } from "../../shared/seed/images.mjs";
 
 // mainImage is an Image OBJECT; height/width are REQUIRED or it won't render. Events V3 uses
 // NO revision — partial PATCH keyed by event.id. Works before OR after publish.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/update-event.md
 export async function setEventMainImage(ctx, it) {
   return req(ctx, `/events/v3/events/${it.eventId}`, {
     method: "PATCH",
@@ -220,6 +228,7 @@ export async function setupEvents(ctx, { events = [] } = {}) {
   // attach. Failures leave the event text-only; the seed's exit never depends on images.
   const files = await resolveItemImages(ctx, created.map((e) => ({
     url: e.imageUrl,
+    path: e.imagePath,
     prompt: e.imagePrompt,
     displayName: `${e.slug || "event"}.png`,
   })));

--- a/skills/wix-headless-fast/references/members/app/wix/members/auth.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/auth.ts
@@ -15,6 +15,8 @@
 // ⚠️ Manual preconditions: the connected site must be PUBLISHED, and `<origin>/callback`
 // must be in the OAuth app's allowedRedirectUris — a manual post-release step; `wix release`
 // registers only the origin. See INSTRUCTIONS → "Wiring — React SPA".
+// docs: https://dev.wix.com/docs/go-headless/wix-managed-headless/authentication/handle-member-login-using-wix-s-astro-integration.md
+// docs: https://dev.wix.com/docs/sdk/core-modules/sdk/oauth-strategy.md
 import type { OauthData } from "@wix/sdk";
 import { WIX_CLIENT_ID } from "../config";
 import { wixAuth } from "../sdk";

--- a/skills/wix-headless-fast/references/members/app/wix/members/members.ts
+++ b/skills/wix-headless-fast/references/members/app/wix/members/members.ts
@@ -3,6 +3,7 @@
 // install, but getCurrentMember returns profile DATA only once the Wix Members Area app is
 // installed (the seed installs it). Copy as-is; extend by adding functions, not by editing
 // these.
+// docs: https://dev.wix.com/docs/api-reference/crm/members-contacts/members/members/get-my-member.md
 import { members } from "@wix/members";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/members/seed/seed-members.mjs
+++ b/skills/wix-headless-fast/references/members/seed/seed-members.mjs
@@ -55,6 +55,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
  * Install the Wix Members Area app (idempotent in effect: re-running against a site that
  * already has it errors — recorded in the result, not thrown, since "already installed" and
  * a real failure aren't distinguishable from the response).
+ * docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
  */
 export async function installMembersAreaApp(ctx) {
   try {

--- a/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/portfolio.ts
+++ b/skills/wix-headless-fast/references/portfolio/app/wix/portfolio/portfolio.ts
@@ -1,6 +1,10 @@
 // Portfolio reads (Wix Portfolio v1) — the only file that touches raw portfolio entities.
 // Read-only vertical: no cart, no checkout, no @wix/ecom. Everything it returns is a plain
 // DTO from ./types. Copy as-is; extend by adding functions, not by editing these.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/list-collections.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/list-projects.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/project-items/list-project-items.md
+// docs: https://dev.wix.com/docs/sdk/core-modules/sdk/media.md
 import {
   collections as collectionsModule,
   projects as projectsModule,

--- a/skills/wix-headless-fast/references/portfolio/seed/SEED.md
+++ b/skills/wix-headless-fast/references/portfolio/seed/SEED.md
@@ -52,10 +52,10 @@ rows (Role, Year, Client…).
 - `details` — optional `[{ label, text }]` rows; render on the project page. Omit for none.
 - Every image field's default is a prompt (`coverImagePrompt` / `items[].imagePrompt` —
   AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
-  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use a url
-  (`coverImageUrl` / `items[].imageUrl`) ONLY for an asset the user actually supplied (their
-  own photo/URL; verify it with `curl -sI` → 200; imported into Wix Media — Portfolio binds
-  by file id, a raw url renders nothing) — never a stock-photo or guessed URL. All images —
+  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually supplied
+  use a path (`coverImagePath` / `items[].imagePath` — a file on this machine, uploaded to
+  Wix Media) or a url (`coverImageUrl` / `items[].imageUrl` — their own hosted URL; verify it
+  with `curl -sI` → 200) — never a stock-photo or guessed URL. All images —
   covers and gallery items alike — resolve in one parallel wave and never block the seed; a
   failed image skips just that item/cover. The **cover** is the
   listing thumbnail; **items** are the detail-page gallery — separate entities, both wanted.

--- a/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
+++ b/skills/wix-headless-fast/references/portfolio/seed/seed-portfolio.mjs
@@ -57,6 +57,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
 // ---- operations ----------------------------------------------------------------------------------
 
 // Idempotent — re-installing returns 200.
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installPortfolioApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -69,10 +70,12 @@ export async function installPortfolioApp(ctx) {
 }
 
 // Read-only listing helpers (partial re-seeds, verification).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/list-collections.md
 export async function listCollections(ctx) {
   const r = await req(ctx, "/portfolio/v1/collections", { method: "GET" });
   return (r.collections ?? []).map((c) => ({ id: c.id, title: c.title, slug: c.slug }));
 }
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/list-projects.md
 export async function listProjects(ctx) {
   const r = await req(ctx, "/portfolio/v1/projects", { method: "GET" });
   return (r.projects ?? []).map((p) => ({ id: p.id, title: p.title, slug: p.slug }));
@@ -81,6 +84,7 @@ export async function listProjects(ctx) {
 // STEP 1 — collections. The display name is `title`, not `name`; `slug` auto-generates from
 // the title; `hidden` defaults to false = shown (omit it — send true only to hide). No
 // bulk-create: one call per collection.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/create-collection.md
 export async function createCollections(ctx, collections) {
   const out = [];
   for (const c of collections) {
@@ -95,6 +99,7 @@ export async function createCollections(ctx, collections) {
 // STEP 2 — projects, AFTER collections: collectionIds must hold real ids from createCollections
 // (they are NOT validated — a wrong/missing id silently orphans the project). `details` is an
 // optional [{ label, text }] array. No bulk-create: one call per project.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/create-project.md
 export async function createProjects(ctx, projects) {
   const out = [];
   for (const p of projects) {
@@ -119,6 +124,7 @@ export { importImage } from "../../shared/seed/images.mjs";
 
 // Cover = the listing-card thumbnail. PATCH per entity, echoing the current revision (missing/
 // stale revision fails); height + width are required alongside the imported file id.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/update-project.md
 export async function attachProjectCovers(ctx, items) {
   for (const it of items) {
     await req(ctx, `/portfolio/v1/projects/${it.id}`, {
@@ -127,6 +133,7 @@ export async function attachProjectCovers(ctx, items) {
     });
   }
 }
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/update-collection.md
 export async function attachCollectionCovers(ctx, items) {
   for (const it of items) {
     await req(ctx, `/portfolio/v1/collections/${it.id}`, {
@@ -138,6 +145,7 @@ export async function attachCollectionCovers(ctx, items) {
 
 // The detail-page gallery is a SEPARATE `item` entity — one POST per image; sortOrder (1,2,3…)
 // sets render order. Lowercase `items` — `/Items` 404s. There is NO public list endpoint.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/project-items/create-project-item.md
 export async function createProjectItems(ctx, items) {
   const out = [];
   for (const it of items) {
@@ -178,13 +186,13 @@ export async function setupPortfolio(ctx, { collections = [], projects = [] } = 
   projects.forEach((p, pi) => {
     for (const it of p.items ?? []) {
       galleryRefs.push({ pi, it, spec: specs.length });
-      specs.push({ url: it.imageUrl, prompt: it.imagePrompt, displayName: `${it.title || "item"}.png` });
+      specs.push({ path: it.imagePath, url: it.imageUrl, prompt: it.imagePrompt, displayName: `${it.title || "item"}.png` });
     }
   });
   const projCoverAt = specs.length;
-  projects.forEach((p) => specs.push({ url: p.coverImageUrl, prompt: p.coverImagePrompt, displayName: `${p.title || "project"}-cover.png` }));
+  projects.forEach((p) => specs.push({ path: p.coverImagePath, url: p.coverImageUrl, prompt: p.coverImagePrompt, displayName: `${p.title || "project"}-cover.png` }));
   const colCoverAt = specs.length;
-  collections.forEach((c) => specs.push({ url: c.coverImageUrl, prompt: c.coverImagePrompt, displayName: `${c.title || "collection"}-cover.png` }));
+  collections.forEach((c) => specs.push({ path: c.coverImagePath, url: c.coverImageUrl, prompt: c.coverImagePrompt, displayName: `${c.title || "collection"}-cover.png` }));
   const files = await resolveItemImages(ctx, specs);
   const dims = { height: 1024, width: 1024 };
 

--- a/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/plans.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/plans.ts
@@ -3,6 +3,7 @@
 // not by editing these.
 //
 // The read module is plansV3 — NOT `plans` (that's the V2 namespace; it has no queryPlans).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/query-plans.md
 import { plansV3 } from "@wix/pricing-plans";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";

--- a/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/purchase.ts
+++ b/skills/wix-headless-fast/references/pricing-plans/app/wix/pricing-plans/purchase.ts
@@ -3,6 +3,7 @@
 // the order form, and payment itself — so this works from an anonymous visitor session.
 // Never create the order yourself (orders.createOnlineOrder needs a logged-in member and
 // still leaves payment unhandled); never hand-build a checkout URL. Copy as-is.
+// docs: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
 import { redirects as redirectsModule } from "@wix/redirects";
 import { wixModule } from "../sdk";
 

--- a/skills/wix-headless-fast/references/pricing-plans/seed/seed-pricing-plans.mjs
+++ b/skills/wix-headless-fast/references/pricing-plans/seed/seed-pricing-plans.mjs
@@ -125,6 +125,7 @@ function buildPlan(plan) {
 
 // ---- operations ----------------------------------------------------------------------------------
 
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installPricingPlansApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -138,6 +139,7 @@ export async function installPricingPlansApp(ctx) {
 
 // Create the plan(s) — Plans V3 has NO bulk-create: one POST per plan. Keep plan.id: the
 // frontend orders by it AND it is the coverage externalId.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan.md
 export async function createPlans(ctx, plans) {
   const out = [];
   for (const plan of plans) {
@@ -157,6 +159,7 @@ export async function createPlans(ctx, plans) {
 
 // 2a: READ the auto-created program definition (the Plans app creates it; you never create
 // it). Provisioning is ~immediate but async — retry ONCE after a short backoff, don't loop.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/program-definitions/introduction.md
 export async function getProgramDefinition(ctx, planId) {
   const path = `/benefit-programs/v1/program-definitions/by-namespace-and-external-id?externalId=${planId}&namespace=${encodeURIComponent(PP_NAMESPACE)}`;
   try {
@@ -174,6 +177,7 @@ export async function getProgramDefinition(ctx, planId) {
 // price "0" = unlimited (default; no creditConfiguration). Limited pack: pass creditAmount →
 // price "1" + details.creditConfiguration (a SIBLING of benefits[], NOT inside a benefit —
 // nesting it 400s with "Price should be 0 when credit pool is not set up").
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/pool-definitions/create-pool-definition.md
 export async function createPoolDefinition(ctx, programDefinitionId, { creditAmount } = {}) {
   const limited = creditAmount != null;
   const details = {
@@ -205,6 +209,7 @@ export async function createPoolDefinition(ctx, programDefinitionId, { creditAmo
 // 2c: bulk-create the benefit items — ONE item per covered service (externalId = bookings
 // service id). Up to 100 per call; category is an empty string; namespace/providerAppId
 // repeat 2b's values.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/items/bulk-create-items.md
 export async function createBenefitItems(ctx, itemSetId, serviceIds) {
   return req(ctx, "/benefit-programs/v1/bulk/items/create", {
     body: {

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/menu.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/menu.ts
@@ -5,6 +5,13 @@
 // The hierarchy is Menu → Sections → Items wired by ID ARRAYS: display structure and order
 // live in menu.sectionIds / section.itemIds, NOT in the list* response order — fetchMenus
 // stitches in id-array order and drops dangling ids. Entity ids are `_id` (never `id`).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/list-menus.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/list-sections.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/list-items.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-variants/list-variants.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifier-groups/list-modifier-groups.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifiers/list-modifiers.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-labels/list-labels.md
 import {
   menus as menusModule,
   sections as sectionsModule,

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/ordering.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/ordering.ts
@@ -8,6 +8,13 @@
 //     documented for client add-to-cart (display modifiers; send quantity only).
 // Failures are loud: throws on a missing ordering operation, unavailable lines, and an empty
 // cart at checkout — surface the message, don't swallow it.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/list-operations.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/fulfillment-methods/list-fulfillment-methods.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/list-items.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/get-current-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/add-line-items-to-current-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/update-line-items.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
 import { operations as operationsModule, fulfillmentMethods as fulfillmentModule, items as itemsModule } from "@wix/restaurants";
 import { currentCartV2 } from "@wix/ecom";
 import { redirects as redirectsModule } from "@wix/redirects";

--- a/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/reservations.ts
+++ b/skills/wix-headless-fast/references/restaurants/app/wix/restaurants/reservations.ts
@@ -6,6 +6,10 @@
 // getTimeSlots takes POSITIONAL args and a Date (not an ISO string); reserveReservation takes
 // THREE positional args (id, reservee, revision) and the only exit from HELD is reserve.
 // Failures are loud — surface the message, don't swallow it.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/list-reservation-locations.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/time-slots/get-time-slots.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservations/create-held-reservation.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservations/reserve-reservation.md
 import { reservationLocations, timeSlots, reservations as reservationsModule } from "@wix/table-reservations";
 import { wixModule } from "../sdk";
 import type {

--- a/skills/wix-headless-fast/references/restaurants/seed/SEED.md
+++ b/skills/wix-headless-fast/references/restaurants/seed/SEED.md
@@ -14,9 +14,9 @@ node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
 of 2–3 items each** (the seed shows the shape; the owner adds the rest in the dashboard),
 every item with an image (a menu without photos looks broken) — the default is an
 `imagePrompt` (AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual —
-subject, aesthetic/mood, palette, lighting — always ending "no text, no watermarks". Use
-`imageUrl` ONLY for an asset the user actually supplied (their own photo/URL; verify it with
-`curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never
+subject, aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually
+supplied use `imagePath` (a file on this machine — uploaded to Wix Media) or `imageUrl`
+(their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never
 block the seed, a failed image leaves that item text-only — and both add-ons on for a
 restaurant that takes orders and reservations:
 

--- a/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
+++ b/skills/wix-headless-fast/references/restaurants/seed/seed-restaurants.mjs
@@ -60,6 +60,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ---- app installs --------------------------------------------------------------------------------
 
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 async function installApp(ctx, appDefId) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -75,6 +76,7 @@ export async function installOrdersApp(ctx) { return installApp(ctx, ORDERS_APP_
 export async function installTableReservationsApp(ctx) { return installApp(ctx, TABLE_RESERVATIONS_APP_ID); }
 
 /** True when the Menus API answers — i.e. the app is already on the site. */
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/list-menus.md
 export async function menusAppPresent(ctx) {
   try {
     await req(ctx, "/restaurants/menus/v1/menus", { method: "GET" });
@@ -94,6 +96,11 @@ export async function menusAppPresent(ctx) {
  * run installed the app onto a site that didn't have it (menusAppPresent was false) — then
  * everything present is provably the install's own sample. Polls briefly (the sample
  * provisions async), then deletes children before parents. No-op when nothing appears.
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/list-items.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/list-sections.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/bulk-delete-items.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/bulk-delete-sections.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/delete-menu.md
  */
 export async function removeSampleMenu(ctx, { tries = 8, delayMs = 2000 } = {}) {
   let menus = [];
@@ -127,6 +134,9 @@ export async function removeSampleMenu(ctx, { tries = 8, delayMs = 2000 } = {}) 
  * visible:true is baked in at every level — required to render on the live site.
  * Returns { menuId, name, sectionIds, itemIds, items: [{ id, revision, price }] } — the
  * per-item revision/price feed the image pass (Update Item is a full replace).
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/bulk-create-items.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/bulk-create-sections.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/create-menu.md
  */
 export async function createMenu(ctx, menu) {
   // STEP 1 — bulk-create every item across all sections in ONE request.
@@ -196,6 +206,7 @@ export { importImage } from "../../shared/seed/images.mjs";
 // image does NOT apply. `image` is an OBJECT { id, url, height, width } (never a bare string);
 // the binding field is the Wix Media file `id`.
 // items: [{ id, revision, price, image: { id, url, height, width } }]
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/bulk-update-item.md
 export async function attachItemImages(ctx, items) {
   return req(ctx, "/restaurants/menus/v1/bulk/items/update", {
     body: {
@@ -218,6 +229,9 @@ export async function attachItemImages(ctx, items) {
 // "testing only" and checkout breaks — a placeholder must be flagged to the owner.
 // location: { name, timeZone, email?, phone?, address: { country, subdivision, city,
 //             postalCode, streetAddress: { number, name }, formattedAddress } }
+// docs: https://dev.wix.com/docs/api-reference/business-management/locations/list-locations.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/locations/create-location.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/locations/update-location.md
 export async function setBusinessLocation(ctx, location) {
   const list = await req(ctx, "/locations/v1/locations", { method: "GET" });
   const def = (list.locations ?? []).find((l) => l.default);
@@ -239,6 +253,7 @@ export async function setBusinessLocation(ctx, location) {
 // Delivery attached, every menu ordering-enabled) — these helpers VERIFY it; they never POST
 // an operation. Each micro-service is on its OWN host prefix — do not normalize.
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/list-operations.md
 export async function listOperations(ctx) {
   const r = await req(ctx, "/restaurants-operations/v1/operations", { method: "GET" });
   return r.operations ?? [];
@@ -255,6 +270,7 @@ export async function listOperationsWithRetry(ctx, { tries = 15, delayMs = 2000 
 }
 
 // Normally already ENABLED — only PATCH when DISABLED/PAUSED_UNTIL. revision mandatory + current.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/update-operation.md
 export async function enableOperation(ctx, operationId, revision) {
   return req(ctx, `/restaurants-operations/v1/operations/${operationId}`, {
     method: "PATCH",
@@ -262,12 +278,14 @@ export async function enableOperation(ctx, operationId, revision) {
   });
 }
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/menu-ordering-settings/query-menu-ordering-settings.md
 export async function queryMenuOrderingSettings(ctx) {
   const r = await req(ctx, "/menu-ordering-settings/v1/menu-ordering-settings/query", { body: { query: {} } });
   return r.menuOrderingSettings ?? [];
 }
 
 // Only when an entry shows onlineOrderingEnabled:false / operationId:"none".
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/menu-ordering-settings/update-menu-ordering-settings.md
 export async function updateMenuOrderingSettings(ctx, settingsId, patch) {
   return req(ctx, `/menu-ordering-settings/v1/menu-ordering-settings/${settingsId}`, {
     method: "PATCH",
@@ -281,6 +299,7 @@ export async function updateMenuOrderingSettings(ctx, settingsId, patch) {
 // be created via this API — discover, configure, enable. Post-Jan-2026 field names:
 // partySize (not partiesSize), approval (not manualApproval).
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/list-reservation-locations.md
 export async function listReservationLocations(ctx) {
   const r = await req(ctx, "/table-reservations/reservation-locations/v1/reservation-locations", { method: "GET" });
   return r.reservationLocations ?? [];
@@ -297,6 +316,7 @@ export async function listReservationLocationsWithRetry(ctx, { tries = 15, delay
 
 // Partial PATCH; revision mandatory; works on a non-premium site. The `location` object
 // (address/name) is IMMUTABLE here — only touch `configuration`.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/update-reservation-location.md
 export async function updateReservationLocation(ctx, reservationLocationId, revision, configuration) {
   return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
     method: "PATCH",
@@ -306,6 +326,7 @@ export async function updateReservationLocation(ctx, reservationLocationId, revi
 
 // PREMIUM-ONLY: on a non-premium site this THROWS `428 PREMIUM_ONLY` — expected and
 // non-fatal; the caller records it and continues (never retry-spiral, never fail the seed).
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/update-reservation-location.md
 export async function enableOnlineReservations(ctx, reservationLocationId, revision) {
   return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
     method: "PATCH",
@@ -352,6 +373,7 @@ export async function setupRestaurants(ctx, plan) {
   });
   const files = await resolveItemImages(ctx, imageItems.map((it) => ({
     url: it.imageUrl,
+    path: it.imagePath,
     prompt: it.imagePrompt,
     displayName: `${it.name || "item"}.png`,
   })));

--- a/skills/wix-headless-fast/references/shared/app/wix/media.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/media.ts
@@ -4,6 +4,7 @@
 // `wix:image://v1/<hash>/<file>#originWidth=…` identifier that a browser cannot load
 // (ERR_UNKNOWN_URL_SCHEME). The wix:image:// form must go through the SDK media module;
 // never hand-build a static.wixstatic.com URL (wrong format → 403).
+// docs: https://dev.wix.com/docs/sdk/core-modules/sdk/media.md
 import { media } from "@wix/sdk";
 
 type MediaLike =

--- a/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
@@ -12,6 +12,8 @@
 // The visitor token IS the identity of the current cart / member session, so in manual mode
 // tokens persist to localStorage — never re-minted per load (a fresh anonymous mint is a NEW
 // visitor and silently empties the cart).
+// docs: https://dev.wix.com/docs/sdk/core-modules/sdk/oauth-strategy.md
+// docs: https://dev.wix.com/docs/go-headless/wix-managed-headless/authentication/about-the-astro-integration.md
 import { createClient, OAuthStrategy, EMPTY_TOKENS } from "@wix/sdk";
 import type { IOAuthStrategy, TokenStorage, Tokens } from "@wix/sdk";
 import { WIX_CLIENT_ID } from "./config";

--- a/skills/wix-headless-fast/references/shared/seed/images.mjs
+++ b/skills/wix-headless-fast/references/shared/seed/images.mjs
@@ -12,6 +12,8 @@
 // Generation costs 1 Wix AI credit per image, billed to the account behind the site.
 // Authoritative reference: wix-headless/references/IMAGE_GENERATION.md.
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { basename, extname } from "node:path";
 
 const API = "https://www.wixapis.com";
 // Order = cheap-and-permissive first (runware ~0.009 credits/img, ~5s, loosest content
@@ -42,6 +44,7 @@ async function req(ctx, path, body, timeoutMs = 45_000) {
  * Generate one image; returns its short-lived URL (import it immediately). Tries each model
  * once — a per-model failure (bad params, 5xx, credit exhaustion, timeout) falls through to
  * the next; throws only after all models failed.
+ * docs: no public reference for /runwareschemaless/v1/request — see wix-headless/references/IMAGE_GENERATION.md
  */
 export async function generateImage(ctx, prompt, { width = 1024, height = 1024 } = {}) {
   let lastErr;
@@ -70,7 +73,40 @@ export async function generateImage(ctx, prompt, { width = 1024, height = 1024 }
   throw lastErr;
 }
 
+const MIME = { ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp", ".gif": "image/gif", ".avif": "image/avif" };
+
+/**
+ * Upload a LOCAL file (a path on this machine — the user's own asset) into Wix Media;
+ * returns { id, url } (permanent). Two steps per the Upload API: generate-upload-url, then
+ * PUT the bytes to it — the PUT response carries the file descriptor.
+ * docs: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/generate-file-upload-url.md
+ */
+export async function uploadImage(ctx, path, displayName) {
+  const ext = extname(path).toLowerCase();
+  const mimeType = MIME[ext];
+  if (!mimeType) throw new Error(`unsupported image extension: ${path}`);
+  const bytes = readFileSync(path); // throws loud on a wrong path (caught per-item by resolveItemImages)
+  // fileName's extension MUST match the real file type — a mismatch (slug.png for a .jpg) is
+  // rejected; keep the caller's display name, swap in the file's own extension.
+  const fileName = (displayName ?? basename(path)).replace(/\.[a-z0-9]+$/i, "") + ext;
+  const { uploadUrl } = await req(ctx, "/site-media/v1/files/generate-upload-url", {
+    mimeType,
+    fileName,
+  });
+  const res = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": mimeType },
+    body: bytes,
+    signal: AbortSignal.timeout(120_000),
+  });
+  const json = await res.json().catch(() => ({}));
+  const f = json.file || json;
+  if (!res.ok || !f?.id) throw new Error(`upload failed (${res.status}): ${JSON.stringify(json).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
 /** Import an external/generated URL into Wix Media; returns { id, url } (permanent). */
+// docs: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
 export async function importImage(ctx, url, displayName = "image.png") {
   const r = await req(ctx, "/site-media/v1/files/import", { url, mimeType: "image/png", displayName });
   const f = r.file || r;
@@ -80,16 +116,23 @@ export async function importImage(ctx, url, displayName = "image.png") {
 
 /**
  * THE seed entry point. Resolves a batch of image specs to Wix Media files in ONE parallel
- * wave. Each spec: { url } (verified external URL — imported as-is) OR { prompt } (generated,
- * 1 credit) — plus optional displayName, width, height. Returns an array aligned with the
- * input: { id, url } per success, null per failure or empty spec. Never throws.
+ * wave. Each spec: { path } (LOCAL file — the user's own asset, uploaded) OR { url }
+ * (verified external URL — imported) OR { prompt } (generated, ~1 credit) — plus optional
+ * displayName, width, height. Returns an array aligned with the input: { id, url } per
+ * success, null per failure or empty spec. Never throws.
  */
 export async function resolveItemImages(ctx, specs, { perImageBudgetMs = 120_000 } = {}) {
-  const deadline = new Promise((r) => setTimeout(() => r(null), perImageBudgetMs));
+  // unref: the budget timer must never keep the seed process alive after the work is done —
+  // a lingering timer delays the seed's exit (and the run's .seed-exit marker) by the budget.
+  const deadline = new Promise((r) => {
+    const t = setTimeout(() => r(null), perImageBudgetMs);
+    t.unref?.();
+  });
   const results = await Promise.allSettled(
     (specs ?? []).map(async (s) => {
-      if (!s || (!s.url && !s.prompt)) return null;
+      if (!s || (!s.path && !s.url && !s.prompt)) return null;
       const resolve = (async () => {
+        if (s.path) return uploadImage(ctx, s.path, s.displayName);
         const source = s.url ?? (await generateImage(ctx, s.prompt, { width: s.width, height: s.height }));
         return importImage(ctx, source, s.displayName ?? "image.png");
       })();

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
@@ -5,6 +5,11 @@
 //
 // Failures are loud: these throw on out-of-stock lines, an empty cart at checkout, and a
 // missing required selection — surface the message to the buyer, don't swallow it.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/get-current-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/add-line-items-to-current-cart.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/update-line-items.md
+// docs: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products.md
 import { currentCartV2 } from "@wix/ecom";
 import { redirects as redirectsModule } from "@wix/redirects";
 import { productsV3 } from "@wix/stores";

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/catalog.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/catalog.ts
@@ -1,6 +1,9 @@
 // Catalog reads (Wix Stores Catalog V3) — the only file that touches raw catalog entities.
 // Everything it returns is a plain DTO from ./types: images resolved, prices formatted,
 // variants normalized. Copy as-is; extend by adding functions, not by editing these.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product-by-slug.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/query-categories.md
 import { productsV3 } from "@wix/stores";
 import { categories as categoriesModule } from "@wix/categories";
 import { wixModule } from "../sdk";

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -39,9 +39,9 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
 - **Give every product an image** (a store without product images looks broken: gray boxes on
   tiles, PDP, and cart) — the default is an `imagePrompt` (AI-generated, ~1 Wix AI credit
   per image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
-  always ending "no text, no watermarks". Use `imageUrl` ONLY for an asset the user actually
-  supplied (their own photo/URL; verify it with `curl -sI` → 200) — never a stock-photo or
-  guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
+  always ending "no text, no watermarks". For an asset the user actually supplied use `imagePath` (a file on
+  this machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
+  `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
   that product text-only. Seed text-only only when the user explicitly asks.
 - `categories` — category name → product NAMES. Omit when the brief names none.
 

--- a/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
+++ b/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
@@ -79,6 +79,7 @@ function isProvisioning(status, json) {
   return status === 428 && /provision/i.test(json?.message || "");
 }
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products.md
 async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
     const res = await fetch(`${API}/stores/v3/products/query`, {
@@ -182,6 +183,7 @@ function expandVariants(options = [], { price, compareAtPrice, quantity }) {
 
 // ---- operations ---------------------------------------------------------------------------------
 
+// docs: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
 export async function installStoresApp(ctx) {
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
@@ -212,6 +214,7 @@ export async function queryProductsByNames(ctx, names) {
   return out;
 }
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory.md
 export async function bulkCreateProducts(ctx, products) {
   const body = {
     returnEntity: true,
@@ -240,6 +243,8 @@ export async function bulkCreateProducts(ctx, products) {
 
 // The bulk create stocks a variant via its choices; an OPTION-LESS product's single default
 // variant is NOT stocked by it and lands OUT_OF_STOCK — stock those explicitly.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products.md
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/inventory-items-v3/bulk-create-inventory-items.md
 async function stockOptionlessProducts(ctx, created) {
   const need = created.filter((p) => !p.hasOptions && p.id);
   if (!need.length) return;
@@ -258,6 +263,7 @@ async function stockOptionlessProducts(ctx, created) {
 }
 
 // Categories share the @wix/stores tree revision — concurrent creates 409, so: sequential.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category.md
 export async function createCategories(ctx, names) {
   const out = [];
   for (const name of names) {
@@ -269,6 +275,7 @@ export async function createCategories(ctx, names) {
   return out;
 }
 
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/bulk-add-items-to-category.md
 export async function addProductsToCategories(ctx, mapping) {
   for (const [categoryId, productIds] of Object.entries(mapping)) {
     await req(ctx, `/categories/v1/bulk/categories/${categoryId}/add-items`, {
@@ -284,6 +291,7 @@ export async function addProductsToCategories(ctx, mapping) {
 // current revision is read right before the update, so attach any number of times, any pass.
 // Wix re-hosts each url server-side; the media can take a little while to appear on read-back
 // (propagation) — normal, not a failure.
+// docs: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-update-products.md
 export async function attachProductImages(ctx, items) {
   if (!items?.length) return;
   const ids = items.map((it) => it.id);
@@ -333,6 +341,7 @@ export async function setupStore(ctx, { products = [], categories = {} } = {}) {
   // bulk-attach. Failures leave the product text-only; the seed's exit never depends on images.
   const files = await resolveItemImages(ctx, withNames.map((p, i) => ({
     url: products[i]?.imageUrl,
+    path: products[i]?.imagePath,
     prompt: products[i]?.imagePrompt,
     displayName: `${p.slug || "product"}.png`,
   })));


### PR DESCRIPTION
Two seed-layer improvements in one PR (per review):

**1. `imagePath` — seed images from the user's own local files.** Third image source alongside `imagePrompt` (default, AI-generated) and `imageUrl` (user's own hosted URL): a path on the machine, uploaded via the Media Manager Upload API (`generate-upload-url` → `PUT` bytes; [docs](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/upload-api.md)), attached through each vertical's existing pass-2 mechanics. One source per item (`path` → `url` → `prompt` precedence if ever combined). Same guarantees: parallel wave, per-item failure → text-only, nothing can fail a seed. Two live-found fixes: fileName-extension mismatch on upload (slug`.png` vs a `.jpg` file → rejected; extension now follows the real file), and the 120s budget timer keeping the seed process alive past completion — **every image-bearing seed had been delaying its `.seed-exit` barrier marker by up to 2 minutes**; now `unref`'d (live seed exits in ~12s). Live-verified end-to-end.

**2. Docs links at every Wix API call site.** Seed endpoints annotated at the owning function, app data layers in the file header (one line per SDK module): 136 `docs:` comment lines across 29 files, **every one of the 89 unique dev.wix.com `.md` URLs curl-verified 200**. Flagged: no public doc for the runware proxy (points at wix-headless's IMAGE_GENERATION.md), apps-installer linked to about-apps-created-by-wix.md, benefit-programs by-namespace linked to its introduction page. Side-finding: several URLs in the classic skill's recipes are stale 404s (blog posts moved under `posts-stats/`, calendar bulk-create renamed) — live paths used here; the classic skill deserves the same sweep.

Comments only in part 2 — zero behavior changes; `node --check` green on all seeds, strict tsc green on all annotated data layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)