### PR TITLE
feat: wix-headless-fast — design & content floors (distilled from the classic skill)

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -55,7 +55,7 @@ re-litigate them.
 3. **Create runs (empty directory): run the fast path** — one deterministic call:
 
    ```bash
-   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json --vertical <storefront|bookings>
+   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json --vertical <vertical>
    ```
 
    `--vertical` is required and picks which shipped code deploys AND which seed runs — use
@@ -83,7 +83,9 @@ re-litigate them.
    tokens, brand the chrome, and implement the vertical's creative surfaces yourself on the
    shipped hooks (for storefront: your product card + grid, shop surface, PDP surface, and the
    home page) — designed to fit the brief, not copied from the reference components. Read the
-   INSTRUCTIONS now (not earlier — its contracts matter only from this step on); the hook/DTO
+   INSTRUCTIONS and the shared floors — `references/shared/DESIGN.md` +
+   `references/shared/CONTENT.md` — now (not earlier — their contracts matter only from this
+   step on); the hook/DTO
    contracts are inlined there, so don't open the shipped files themselves. **Author your
    surfaces in as few messages as possible** — batch multiple Write calls in one message
    (components are independent files); don't pay a round-trip per file.

--- a/skills/wix-headless-fast/references/blog/seed/SEED.md
+++ b/skills/wix-headless-fast/references/blog/seed/SEED.md
@@ -51,7 +51,7 @@ feed without covers looks broken.
   ids internally. Optional: skip them entirely when the brief doesn't group posts.
 - Cover — the default is a `coverImagePrompt` (AI-generated, ~1 Wix AI credit per image,
   account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting — always
-  ending "no text, no watermarks". For an asset the user actually supplied use
+  ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually supplied use
   `coverImagePath` (a file on this machine — uploaded to Wix Media) or `coverImageUrl` (their
   own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Covers resolve
   in parallel and never block the seed; a failed cover leaves that post text-only (the script

--- a/skills/wix-headless-fast/references/bookings/seed/SEED.md
+++ b/skills/wix-headless-fast/references/bookings/seed/SEED.md
@@ -15,7 +15,7 @@ shows the shape; the owner adds the rest in the dashboard) and make them exercis
 mix APPOINTMENT and CLASS when it fits the business, include ≥1 free/pay-in-person service,
 and give every service an image — the default is an `imagePrompt` (AI-generated, ~1 Wix AI
 credit per image, account-billed): brand-contextual — subject, aesthetic/mood, palette,
-lighting — always ending "no text, no watermarks". For an asset the user actually supplied use `imagePath` (a file on this
+lighting — always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually supplied use `imagePath` (a file on this
 machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
 `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed
 image leaves that service text-only.

--- a/skills/wix-headless-fast/references/cms/seed/SEED.md
+++ b/skills/wix-headless-fast/references/cms/seed/SEED.md
@@ -59,7 +59,7 @@ every content item an image on an IMAGE field (a content site without images loo
   `RICH_TEXT` (an HTML string, stored verbatim), `REFERENCE`, `MULTI_REFERENCE`.
 - `IMAGE` values — the default is `{ "prompt": "..." }` (AI-generated, ~1 Wix AI credit per
   image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
-  always ending "no text, no watermarks". For an asset the user actually supplied use
+  always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually supplied use
   `{ "path": "..." }` (a file on this machine — uploaded to Wix Media) or an https URL string
   (their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images
   resolve in parallel and never block the seed; a failed image leaves that field unset (the

--- a/skills/wix-headless-fast/references/events/seed/SEED.md
+++ b/skills/wix-headless-fast/references/events/seed/SEED.md
@@ -16,7 +16,7 @@ the shape; the owner adds the rest in the dashboard) and make them exercise the 
 `TICKETING` and `RSVP` (≥1 of each), give a ticketed event 2 tiers, and give every event an
 image (an events page without images looks broken) — the default is an `imagePrompt`
 (AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
-aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually
+aesthetic/mood, palette, lighting — always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually
 supplied use `imagePath` (a file on this machine — uploaded to Wix Media) or `imageUrl`
 (their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the
 seed; a failed image leaves that event text-only.

--- a/skills/wix-headless-fast/references/portfolio/seed/SEED.md
+++ b/skills/wix-headless-fast/references/portfolio/seed/SEED.md
@@ -52,7 +52,7 @@ rows (Role, Year, Client…).
 - `details` — optional `[{ label, text }]` rows; render on the project page. Omit for none.
 - Every image field's default is a prompt (`coverImagePrompt` / `items[].imagePrompt` —
   AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual — subject,
-  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually supplied
+  aesthetic/mood, palette, lighting — always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually supplied
   use a path (`coverImagePath` / `items[].imagePath` — a file on this machine, uploaded to
   Wix Media) or a url (`coverImageUrl` / `items[].imageUrl` — their own hosted URL; verify it
   with `curl -sI` → 200) — never a stock-photo or guessed URL. All images —

--- a/skills/wix-headless-fast/references/restaurants/seed/SEED.md
+++ b/skills/wix-headless-fast/references/restaurants/seed/SEED.md
@@ -14,7 +14,7 @@ node <SKILL_ROOT>/references/restaurants/seed/seed-restaurants.mjs plan.json
 of 2–3 items each** (the seed shows the shape; the owner adds the rest in the dashboard),
 every item with an image (a menu without photos looks broken) — the default is an
 `imagePrompt` (AI-generated, ~1 Wix AI credit per image, account-billed): brand-contextual —
-subject, aesthetic/mood, palette, lighting — always ending "no text, no watermarks". For an asset the user actually
+subject, aesthetic/mood, palette, lighting — always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually
 supplied use `imagePath` (a file on this machine — uploaded to Wix Media) or `imageUrl`
 (their own hosted URL; verify it with `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never
 block the seed, a failed image leaves that item text-only — and both add-ons on for a

--- a/skills/wix-headless-fast/references/shared/CONTENT.md
+++ b/skills/wix-headless-fast/references/shared/CONTENT.md
@@ -1,0 +1,22 @@
+# Content floor — the copy you write on every authored surface
+
+**A fallback, not an override.** If the user supplied copy, voice, or tone, use theirs. The
+one exception is the first rule — a comprehension floor, not a style preference.
+
+- **Say what the business is, literally, above the fold.** A first-time visitor must know
+  what the site *is* and can *do* from the hero alone. The business category ("ceramics
+  studio", "trattoria", "yoga studio") appears verbatim in the H1, the kicker above it, or
+  the first clause of the subtitle. A witty H1 is welcome — beside an explicit category,
+  never instead of one.
+- **The subtitle leads with the offer** — the verb the visitor cares about comes early
+  ("Book…", "Order…", "Browse…"), flavor after.
+- **Kickers carry information or don't exist.** "Handmade in Portland · Since 2019" earns its
+  place; "The Collection" above a Collection heading doesn't. A voice-led H1 pairs with an
+  informative kicker (that's where the category goes).
+- **Titles and subtitles end without a period.** Paragraphs keep theirs.
+- **CTA labels are short, concrete, and not all-caps** — the actual action, matching the one
+  primary CTA per page (`DESIGN.md`).
+- **No fluff.** Every line moves a visitor's understanding forward — the H1 and subtitle most
+  of all.
+- **A caption describes what its image actually shows.** A slogan overlaid on a photo is not
+  a caption; if none is warranted, write none.

--- a/skills/wix-headless-fast/references/shared/DESIGN.md
+++ b/skills/wix-headless-fast/references/shared/DESIGN.md
@@ -1,0 +1,26 @@
+# Design floor — every vertical, every surface you author
+
+**A fallback, not an override.** These rules fill the gap when the user gave no design
+direction. The moment the brief specifies a palette, a mood, a reference — their intent wins.
+Two exceptions that hold regardless: the contrast floor (in `styles/global.css`, where you
+choose the tokens), and the anti-genericism intent — derive the look from *this* brand even
+when the user supplied the inputs.
+
+Token judgment (polarity, palette, contrast, type floors) lives in the `@theme` header in
+`styles/global.css` — you'll meet it when you set the tokens. This file governs the surfaces:
+
+- **Full-bleed, not boxed.** Don't wrap pages in a narrow centered shell (`max-w-4xl mx-auto`
+  around everything). Design for the viewport; use peripheral space intentionally.
+- **One primary CTA per page**, worded to the page's actual action — "Add to Cart",
+  "Book a Table", "Reserve Your Spot" — never "Submit" / "Click here" / "Learn more" as the
+  hero action.
+- **Icons render bare on the surface** — no circle/square/pill shell behind nav or card
+  glyphs.
+- **No emojis** in UI copy, headings, or empty states (unless the brief itself asks for
+  them).
+- **Vary the look across projects.** Repeating the same palette/layout on unrelated brands is
+  a failure mode, not a shortcut — two sites with the same vertical and different briefs
+  should look nothing alike.
+
+This constrains the *how*, not the *what* — the brief and the vertical decide what the pages
+are; INSTRUCTIONS decides which surfaces exist.

--- a/skills/wix-headless-fast/references/shared/app/styles/global.css
+++ b/skills/wix-headless-fast/references/shared/app/styles/global.css
@@ -6,7 +6,14 @@
    Wix headless templates). Every shipped component styles itself from these via Tailwind
    utilities (bg-primary, text-muted-foreground, rounded-lg, …) — change a token, everything
    follows. A dark theme is just flipped values (dark background/foreground, adjusted
-   secondary/border). Don't restyle shipped component markup; restyle the tokens. */
+   secondary/border). Don't restyle shipped component markup; restyle the tokens.
+
+   Choosing values: argue polarity from the business — light is not "cheap" (wellness/food
+   usually read better light); never dark-by-default for "premium". Palette: one dominant +
+   accents from ADJACENT hues (~30° arc), 2-4 colors total. Every background/foreground pair
+   you set must hit WCAG 4.5:1 (3:1 for text ≥24px); body copy never below 16px/1.5. Derive
+   from THIS brand — a look repeated across projects is a failure, not a shortcut. The user's
+   explicit direction beats all of this except the contrast floor. */
 @theme {
   --color-background: hsl(0 0% 100%);
   --color-foreground: hsl(230 24% 14%);

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -39,7 +39,7 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
 - **Give every product an image** (a store without product images looks broken: gray boxes on
   tiles, PDP, and cart) — the default is an `imagePrompt` (AI-generated, ~1 Wix AI credit
   per image, account-billed): brand-contextual — subject, aesthetic/mood, palette, lighting —
-  always ending "no text, no watermarks". For an asset the user actually supplied use `imagePath` (a file on
+  always ending "no text, no watermarks". At least one image in the set shows the real subject of the business — the actual product/space/service, not abstract decoration. For an asset the user actually supplied use `imagePath` (a file on
   this machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
   `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
   that product text-only. Seed text-only only when the user explicitly asks.


### PR DESCRIPTION
Ports the judgment half of `wix-headless`'s DESIGN.md/CONTENT.md — everything the fast skill couldn't ship as code — distilled to ~480 words total and placed where the agent's eyes already are at each decision moment:

| rules | home | extra read cost |
|---|---|---|
| polarity argued from the business · analogous palette (~30° arc) · WCAG 4.5:1 contrast floor · 16px/1.5 body floor · vary-per-brand | `@theme` header in shared `global.css` — read every run before token edits | **zero** |
| full-bleed not boxed · one primary CTA worded to the action · bare icons · no emojis in UI copy · vary across projects | new `references/shared/DESIGN.md` | one small read |
| category named literally above the fold · subtitle leads with the offer · informative kickers only · titles without trailing periods · concrete CTA labels · honest captions | new `references/shared/CONTENT.md` | (same read moment) |
| ≥1 image shows the real subject of the business | the existing prompt-guidance sentence in all 7 image-bearing SEED.mds | zero |

Read scheduling stays single-authority: SKILL.md step 4 — the sentence that already times the INSTRUCTIONS read — now names both floors. Both carry the classic fallback-not-override framing (user's direction wins, except contrast). Deliberately **no** verify-step enforcement.

Rider: step 3's fast-path usage line still said `--vertical <storefront|bookings>` from the two-vertical era — now `<vertical>` (the Verticals table is the reference, as the next sentence already says).

🤖 Generated with [Claude Code](https://claude.com/claude-code)