### PR TITLE
fix(wix): variant-aware storefront + verb transports for discovery

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on the connected Wix site from a Base44 app — site management/admin, front-end code, and backend functions: discover and call any Wix API, gather the site's context, route each call to the right identity, and follow curated recipes for multi-step admin flows."
+description: "Build on and manage the connected Wix site from a Base44 app: discover and call any Wix API, gather site context, route each call to the right identity, and follow curated recipes for multi-step admin flows."
 ---
 
 # Building on Wix from Base44
@@ -53,14 +53,14 @@ const wx = (() => { const m = { exports: {} };
 
 `wx` exports nine helpers:
 
-- `wx.post(url, body, token?)` — the one JSON transport: Bearer from `token`, non-2xx **throws** the API's own error
+- `wx.post/get/patch/put/del(url, [body], token?)` — JSON transports, one per verb (`get`/`del` take no body): Bearer from `token`, non-2xx **throws** the API's own error
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint + docsUrl + gist
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist
 - `wx.page(docsUrl)` — read a doc page
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
-- `wx.spec(code)` — run `code` against the spec index for a method's exact schema
+- `wx.spec(docsUrl | code)` — a method's exact schema; pass a hit's docsUrl (direct load), or raw code to query the index yourself
 - `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
 
 Every helper answers inline when the result fits (≤ 4,000 chars — exec results clip at ~5,000).
@@ -84,7 +84,9 @@ An empty report = bad token, never an empty site.
 ## Learn Wix — find the APIs, learn their contracts
 
 ```js
-// know the product? browse is deterministic — menuUrl alone orients (children + counts);
+// name the method? search finds it in one call:
+await wx.search("stores v3 update product");   // → [{ method, endpoint: "VERB url", docsUrl, gist }]; call wx.<verb>(url, body, token); spec(docsUrl) for the full schema
+// exploring an unfamiliar product? browse is deterministic — menuUrl alone orients (children + counts);
 // filter before listing methods. browse works for both portals this skill uses — REST
 // (api-reference) and WIX_HEADLESS (go-headless) — just pass that portal's menu URL.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
@@ -123,7 +125,14 @@ lines weren't enough.
 
 ### The spec index — a located method's exact schema
 
-Read the schema of a method you already have a `docsUrl` for (from search/browse):
+Pass a method's `docsUrl` (a search/browse hit carries it) — spec loads that method's schema (request
+body, responses, filterable-fields map, examples) in one call, a direct lookup:
+
+```js
+await wx.spec(hit.docsUrl);
+```
+
+Want to shape the result yourself? Pass raw code against the index (`lightIndex` + `getResourceSchemaByUrl`):
 
 ```js
 await wx.spec(`

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -31,10 +31,12 @@ const clip = (out) => {
   return s.length <= BUDGET ? JSON.parse(s) : { truncated: true, total: s.length, head: s.slice(0, BUDGET) };
 };
 
-// One transport for every JSON call — Content-Type, optional Bearer, ok-guard.
-// Admin calls are this with the connector token: post(publicUrl, body, accessToken).
-async function post(url, body, token) {
-  const r = await fetch(url, { method: "POST", body: JSON.stringify(body),
+// One transport for every JSON call — Content-Type, optional Bearer, ok-guard. One per verb, so a
+// PATCH/GET/PUT/DELETE endpoint is a helper call, never a hand-rolled fetch. Admin calls are these
+// with the connector token: patch(publicUrl, body, accessToken).
+async function req(method, url, body, token) {
+  const r = await fetch(url, { method,
+    ...(body !== undefined && { body: JSON.stringify(body) }),
     headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
   if (!r.ok) {
     const head = (await r.text()).slice(0, 300);
@@ -44,6 +46,11 @@ async function post(url, body, token) {
   }
   return r.json();
 }
+const post  = (url, body, token) => req("POST", url, body, token);
+const get   = (url, token)       => req("GET", url, undefined, token);
+const patch = (url, body, token) => req("PATCH", url, body, token);
+const put   = (url, body, token) => req("PUT", url, body, token);
+const del   = (url, token)       => req("DELETE", url, undefined, token);
 
 function save(name, text) {
   const dir = SCRATCH;
@@ -117,7 +124,7 @@ async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
     { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });
   const hits = content.split(/\n---\n+(?=#### )/).map(b => ({
     method:   (b.match(/^# Method: (.+)$/m) || [])[1],
-    endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // callable
+    endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // "VERB url" — read the verb + url; call wx.<verb>(url, body, token)
     docsUrl:  (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
     gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
       .trim().replace(/\s+/g, " ").slice(0, 220),
@@ -167,15 +174,18 @@ function bash(cmd) {
 
 // ── the spec index ────────────────────────────────────────────────────────────
 
-// Inspect a located method's schema — request body, responses, enums, and the
-// filterable-fields map. In scope: lightIndex (RESOURCES with .methods — operationId,
-// summary, httpMethod, path [PARTIAL — never call it], publicUrl [callable], docsUrl)
-// and getResourceSchemaByUrl(docsUrl) → s.methods (each with requestBody, responses,
-// legacyExamples, queryMethodData.queryFieldsCapabilitiesMap; $circular via
-// s.components.schemas). Arrive with a docsUrl from search/browse — not a discovery
-// tool. A big result is saved as JSON; grep it for the keys you saw in its head.
-async function spec(code) {
-  if (!/^\s*async function/.test(code)) code = `async function(){ ${code} }`;
+// Inspect a method's schema — request body, responses, enums, filterable-fields map. Pass a docsUrl
+// (from search/browse — a direct load, no scan) and spec returns that method's schema. Or pass raw
+// `async function(){…}` to query the index yourself: lightIndex (RESOURCES with .methods —
+// operationId, summary, httpMethod, publicUrl [callable], docsUrl) and getResourceSchemaByUrl(docsUrl)
+// → s.methods (each with requestBody, responses, legacyExamples,
+// queryMethodData.queryFieldsCapabilitiesMap; $circular via s.components.schemas). A big result is
+// saved as JSON; grep it for the keys you saw in its head.
+async function spec(arg) {
+  const s = String(arg).trim();
+  const code = /^async function/.test(s) ? s
+    : /^https:\/\/dev\.wix\.com\/docs\//.test(s) ? "async function(){ return await getResourceSchemaByUrl(" + JSON.stringify(s) + "); }"
+    : "async function(){ " + s + " }";
   const { result } = await post("https://mcp.wix.com/api/code-mode/search", { code });
   if (result == null || (Array.isArray(result) && !result.length))
     return { result, note: "empty — the query missed the shape; match your docsUrl against s.methods[].docsUrl" };
@@ -236,4 +246,4 @@ async function mgmtRecipes(q) {
   return clip(m.map(row));
 }
 
-module.exports = { post, clip, context, browse, search, page, bash, spec, mgmtRecipes };
+module.exports = { req, post, get, patch, put, del, clip, context, browse, search, page, bash, spec, mgmtRecipes };

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -429,7 +429,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Technical:** Manages pre-order settings for product variants using V3 Inventory API. Covers enabling/disabling pre-orders, setting messages, configuring limits, and handling trackQuantity requirements.
 
 ### [Update Product with Options](references/stores/update-product-with-options.md)
-**Technical:** Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, and revision-based updates to prevent conflicts.
+**Technical:** Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, and the writable choice/variant fields — media & displayImage, SKU/barcode, price incl. compareAtPrice (sale), visibility — plus revision-based updates and which fields are read-only (choice inStock/visible, variant media/inventory).
 
 ### [Stores Dashboard Navigation](references/stores/stores-dashboard-navigation.md)
 **Technical:** Direct links to Wix Stores and eCommerce dashboard pages on manage.wix.com (products list, edit product, categories, inventory, orders list, order details, abandoned checkouts, gift cards, shipping, tax), pairing each main Stores/eCommerce entity with its read API for "view it in your dashboard" links.

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -275,6 +275,8 @@ curl -X POST "https://www.wixapis.com/stores/v3/bulk/inventory-items/create" \
 
 ### Update Media Only
 
+Sets the product-level gallery (`media.itemsInfo.items`). For an image shown per option choice (a swatch's photo), see **Per-choice media** below.
+
 ```bash
 curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   -H "Content-Type: application/json" \
@@ -295,6 +297,35 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
       }
     }
   }'
+```
+
+### Choice & variant fields (what you can set)
+
+Send these inside the `options` / `variantsInfo.variants` arrays — whole array each time (see *Update Options and Variants*), with the current `revision`.
+
+**Option choice** (`options[].choicesSettings.choices[]`):
+- `name`, `choiceType`, `colorCode` — the choice's identity and swatch colour.
+- `media` = `{ "items": [ { "mediaId" } | { "url" } ] }` — the product photos shown when this choice is picked. `url` is write-only; on read you get `mediaId` (request the `PRODUCT_CHOICES_MEDIA_REFERENCES` mask). Use `media`, **not** `linkedMedia` (a separate display-filter, returned empty when you read `media`). The image must already be in the product's `media.itemsInfo.items` (import + add to the gallery first).
+- `displayImage` — the image shown on the swatch itself (distinct from `media`).
+- Read-only, don't send: `inStock`, `visible`, `key`.
+
+**Variant** (`variantsInfo.variants[]`, by its `id` from Get Product):
+- `price` = `{ "actualPrice": { "amount" }, "compareAtPrice": { "amount" } }` — set `compareAtPrice` above `actualPrice` for a strikethrough sale; omit it for full price.
+- `sku`, `barcode` — per combination.
+- `visible` — hide a single variant.
+- `revenueDetails` — cost / profit tracking.
+- Read-only, don't send: `media` (derived from the choices' media), `inventoryStatus` (stock — use the Inventory API, see *Set Stock for New Variants*), `subscriptionPricesInfo`.
+
+```bash
+# a choice image + a variant's SKU and sale price, one PATCH
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" -H "Authorization: <AUTH>" \
+  -d '{ "product": { "id": "{productId}", "revision": "{currentRevision}",
+        "options": [ { "name": "Color", "choicesSettings": { "choices": [
+          { "name": "Red", "media": { "items": [ { "mediaId": "abc~mv2.jpg" } ] } } ] } } ],
+        "variantsInfo": { "variants": [
+          { "id": "{existingVariantId}", "sku": "TEE-RED-L",
+            "price": { "actualPrice": { "amount": "20" }, "compareAtPrice": { "amount": "30" } } } ] } } }'
 ```
 
 ### Update Variant Price Only

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -28,7 +28,7 @@ so you don't need to open them:**
 | `components/ProductCard.jsx` | reference implementation of a grid tile built on `useProductCard` — read it for inspiration, build your own component rather than using it directly |
 | `components/ProductGrid.jsx` | reference grid layout (2-col mobile → auto-fill desktop) with skeleton + empty state — read it for the skeleton/empty-state patterns, build your own layout rather than using it directly |
 | `components/ProductGallery.jsx` | PDP main image + thumbnails |
-| `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` — normalise Wix image urls |
+| `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` / `choiceImage()` — normalise Wix image urls; `choiceImage(choice)` resolves an option choice's photo (V3 read shape: `media.items[].mediaId`, not `linkedMedia`) |
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
 | `hooks/useVariantOptions.js` | headless data layer for options/modifiers — returns `optionGroups` + `modifierGroups` (normalised, render-agnostic); **always use this to build your own variant UI on the PDP** |

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductGallery.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductGallery.jsx
@@ -3,6 +3,7 @@
 // single image renders just the main frame, so this is safe for a one-photo catalog.
 // Styled with base44 design tokens (shadcn Tailwind classes).
 import { useEffect, useState } from "react";
+import { wixMediaId } from "@/lib/storeImage";
 
 export default function ProductGallery({ images, name, focusUrl }) {
   const [index, setIndex] = useState(0);
@@ -11,10 +12,13 @@ export default function ProductGallery({ images, name, focusUrl }) {
   // a quantity bump, an option click — would land here and throw away the image the buyer picked.
   useEffect(() => { setIndex(0); }, [images]);
 
-  // Picking a colour swatch shows that colour: focusUrl is the choice's linked photo. Runs after the
-  // reset effect, so a first paint with a colour pre-selected opens on the right image.
+  // Picking an option shows that selection's image: focusUrl is the variant/choice photo. Match by
+  // Wix media id, so the same image counts even when the gallery url carries sizing params the built
+  // focusUrl doesn't. Runs after the reset effect, so a first paint with an option pre-selected opens
+  // on the right image.
   useEffect(() => {
-    const i = images?.findIndex((img) => img.url === focusUrl) ?? -1;
+    const target = wixMediaId(focusUrl);
+    const i = target ? (images?.findIndex((img) => wixMediaId(img.url) === target) ?? -1) : -1;
     if (i >= 0) setIndex(i);
   }, [focusUrl, images]);
 

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -5,7 +5,7 @@
 // renders what this returns.
 import { useState, useEffect, useMemo } from "react";
 import { getProductBySlug } from "@/rest/wix-store-catalog";
-import { storeImage } from "@/lib/storeImage";
+import { choiceImage, variantImage } from "@/lib/storeImage";
 import { useCart } from "@/context/CartContext";
 
 export function useProductDetail(slug) {
@@ -61,19 +61,26 @@ export function useProductDetail(slug) {
       m.modifierRenderType === "FREE_TEXT" ? !!modifierValues[m.freeTextSettings?.key] : !!modifierValues[m.key]);
   }, [options, variant, inStock, modifiers, modifierValues]);
 
+  // Everything the buyer sees follows the resolved `variant` (also returned below, so an agent can
+  // surface more from it — sku, barcode, subscriptionPricesInfo — without new plumbing). Price and
+  // its struck-through "was" price come off the variant, falling back to the product's range before
+  // every option is picked.
   const price = variant?.price?.actualPrice?.formattedAmount || product?.actualPriceRange?.minValue?.formattedAmount || "";
+  const compareAtPrice = variant?.price?.compareAtPrice?.formattedAmount || product?.compareAtPriceRange?.minValue?.formattedAmount || "";
 
-  // A colour choice carries `linkedMedia` — the shots of the product in that colour. Picking "Dark
-  // Green" should move the gallery to the green photo, so resolve the selection to a URL here; only
-  // colour-style choices have linked media, so the first hit across the options is the right one.
+  // The gallery follows the selection: a resolved variant carries the exact combination's image
+  // (variant.media), so prefer it; before every option is picked, fall back to the selected choice's
+  // own image (choice.media.items[].mediaId). See lib/storeImage: variantImage() / choiceImage().
   const focusMediaUrl = useMemo(() => {
+    const fromVariant = variantImage(variant);
+    if (fromVariant) return fromVariant;
     for (const o of options) {
       const choice = (o.choicesSettings?.choices || []).find((c) => c.choiceId === selectedOptions[o.id]);
-      const url = storeImage(choice?.linkedMedia?.[0]);
+      const url = choiceImage(choice);
       if (url) return url;
     }
     return null;
-  }, [options, selectedOptions]);
+  }, [variant, options, selectedOptions]);
 
   const selectOption = (optionId, choiceId) => setSelectedOptions((s) => ({ ...s, [optionId]: choiceId }));
   const setModifier = (key, value) => setModifierValues((s) => ({ ...s, [key]: value }));
@@ -104,6 +111,6 @@ export function useProductDetail(slug) {
     product, notFound, error, retry: () => setReloadKey((k) => k + 1),
     options, modifiers,
     selectedOptions, selectOption, modifierValues, setModifier,
-    quantity, setQuantity, variant, inStock, canAdd, adding, price, submit, focusMediaUrl,
+    quantity, setQuantity, variant, inStock, canAdd, adding, price, compareAtPrice, submit, focusMediaUrl,
   };
 }

--- a/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
+++ b/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
@@ -10,6 +10,37 @@ export function storeImage(value) {
   return url;
 }
 
+// A Wix media id (e.g. "abc123~mv2.jpg") is NOT a URL — build the static CDN url for it.
+export function wixMediaUrl(mediaId) {
+  if (!mediaId || typeof mediaId !== "string") return null;
+  if (mediaId.startsWith("http") || mediaId.startsWith("//")) return storeImage(mediaId);
+  return `https://static.wixstatic.com/media/${mediaId}`;
+}
+
+// The media id inside a Wix image url (…/media/<id>/v1/… or a bare …/media/<id>). Compare two urls of
+// the SAME image that differ only in sizing/format params by their id, not full-string equality.
+export function wixMediaId(url) {
+  const m = typeof url === "string" && url.match(/\/media\/([^/?]+)/);
+  return m ? m[1] : url;
+}
+
+// The image assigned to a product OPTION CHOICE (e.g. a colour swatch). Wix V3 exposes it at
+// choice.media.items[].mediaId — build the CDN url from the id. Needs the
+// PRODUCT_CHOICES_MEDIA_REFERENCES field on the fetch.
+export function choiceImage(choice) {
+  const mediaId = choice?.media?.items?.[0]?.mediaId;
+  return mediaId ? wixMediaUrl(mediaId) : null;
+}
+
+// The image for a resolved VARIANT (a full choice combination). Wix computes variant.media from the
+// picked choices' media, so this is the exact image for the current selection — prefer it over a
+// single choice's image once all options are chosen.
+export function variantImage(variant) {
+  const m = variant?.media;
+  if (!m) return null;
+  return m.uploadId ? wixMediaUrl(m.uploadId) : storeImage(m.thumbnail?.url);
+}
+
 // The main catalog image for a product (grid tiles, cart fallbacks).
 export function productImage(product) {
   return storeImage(product?.media?.main?.image?.url);

--- a/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
@@ -34,7 +34,7 @@ export default function ProductDetail() {
   }
   if (!d.product) return <ProductDetailSkeleton />;
 
-  const compareAt = d.product?.compareAtPriceRange?.minValue?.formattedAmount;
+  const compareAt = d.compareAtPrice;   // follows the selected variant (falls back to the product range)
 
   return (
     <main className="max-w-[1200px] mx-auto p-4">

--- a/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
+++ b/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
@@ -30,12 +30,13 @@ import { wixApiRequest } from "./wix-client.js";
  *   options {array} — product options e.g. Size, Color:
  *     [{ id, name, optionRenderType "TEXT_CHOICES"|"COLOR_CHOICES"|"SWATCH_CHOICES",
  *        choicesSettings.choices [{ choiceId, key, name, inStock, visible, choiceType, colorCode,
- *                                   linkedMedia }] }],
+ *                                   media }] }],
  *     A COLOR/SWATCH option's choices carry choiceType "ONE_COLOR" and colorCode "#395E55" — render
- *     those as real colour swatches, not text pills. linkedMedia [{ image.url }] holds that colour's
- *     photos, so selecting a swatch can move the gallery to the matching shot. visible false is a
- *     retired choice the merchant no longer sells: filter it out. (TEXT_CHOICES choices are
- *     choiceType "CHOICE_TEXT" with no colorCode.)
+ *     those as real colour swatches, not text pills. A choice's photo is at media.items[].mediaId (a
+ *     bare Wix media id — build https://static.wixstatic.com/media/<id>); use choiceImage() from
+ *     lib/storeImage to resolve it. Needs the PRODUCT_CHOICES_MEDIA_REFERENCES field (requested by
+ *     getProductBySlug below). visible false is a retired choice the merchant no longer sells: filter
+ *     it out. (TEXT_CHOICES choices are choiceType "CHOICE_TEXT" with no colorCode.)
  *   modifiers {array} — non-variant customizations (engraving, gift wrap):
  *     [{ id, name, mandatory, modifierRenderType "TEXT_CHOICES"|"FREE_TEXT",
  *        key, choicesSettings.choices, freeTextSettings.key }],
@@ -85,7 +86,18 @@ export async function queryProducts({ limit = 100, cursor } = {}) {
 export async function getProductBySlug(slug) {
   const res = await wixApiRequest(`/stores/v3/products/slug/${encodeURIComponent(slug)}`, {
     method: "GET",
-    query: { fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"] },
+    // PRODUCT_CHOICES_MEDIA_REFERENCES → choice.media.items[].mediaId (the per-colour photos, needed
+    // for the swatch→gallery swap); VARIANT_OPTION_CHOICE_NAMES → variant choice names. Without these
+    // the choice media / variant data come back null.
+    query: {
+      fields: [
+        "CURRENCY",
+        "PLAIN_DESCRIPTION",
+        "MEDIA_ITEMS_INFO",
+        "PRODUCT_CHOICES_MEDIA_REFERENCES",
+        "VARIANT_OPTION_CHOICE_NAMES",
+      ],
+    },
   });
   return res?.product ?? null;
 }

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -64,9 +64,10 @@ Two things this module does **not** seed, so don't try:
 
 - **Ribbons** ("New", "Best Seller"). The tile renders `product.ribbon` when it's there, but ribbons
   are set in the Wix dashboard — tell the merchant that's where to add them.
-- **Per-choice linked media** (`linkedMedia`), which is what makes picking a colour swap the gallery
-  photo. Seeded swatches select and price correctly; the gallery just doesn't follow the colour until
-  the merchant links photos to choices in the dashboard.
+- **Per-choice media** — the photo that makes picking a choice swap the gallery image. Seeded swatches
+  select and price correctly; the gallery follows a choice once photos are linked to it (Wix dashboard,
+  or the wix-manage "Update Product with Options" recipe → Choice & variant fields). The shipped PDP then
+  follows automatically — `choiceImage()` reads it back at `media.items[].mediaId`.
 
 ## Escape hatch — individual functions
 Reach for the functions below only when the one-call `setupStore` doesn't fit (partial re-seed, custom


### PR DESCRIPTION
## Context

A Base44 store on Wix Catalog V3 couldn't show a different image per option choice. Digging in, the root issue was that the storefront wasn't grounded in the V3 **variant** model. This PR fixes that generally (verified against the schema via the code-mode spec API), rather than patching the one symptom.

## The V3 model (what the storefront now follows)

A shopper picks one **choice** per **option** → that resolves to a **variant** (a full combination). Per-**variant** fields: `price` (actual + `compareAtPrice`), `media` (the resolved image for the combo), `inventoryStatus` (stock), `sku`, `barcode`, `subscriptionPricesInfo`. Per-**choice** fields: `colorCode`, `media` (that swatch's image), name/visibility.

## What changed

**wix-vibe-headless — the seeded storefront**
- **Image follows the selection**: `variantImage()` uses the variant's resolved `media` (Wix computes it from the picked choices); `choiceImage()` (reads `choice.media.items[].mediaId`) is the partial-selection fallback. `getProductBySlug` requests the choice/variant field masks.
- **Sale price is variant-aware**: the hook returns `compareAtPrice` off the resolved variant (falls back to the product range); the PDP renders that instead of the product-level "from" price.
- The raw **`variant`** is returned with a note on its per-combination fields (`sku`, `barcode`, `subscriptionPricesInfo`), so an agent can surface more **without new plumbing** — the extension point.
- **Per-product image + seeding flow unchanged.** Fixed the misleading media comments (INSTRUCTIONS.md tells agents to trust them).

**wix-manage — recipes**
- Concise **Per-choice media** section in `update-product-with-options`: write `choice.media` (`mediaId` or `url`), read `mediaId`, field masks; `linkedMedia` is a separate display-filter Wix says to avoid.

**wix-base44-connector — discovery**
- Added `get`/`patch`/`put`/`del` transports (was POST-only), so a non-POST endpoint is a helper call, not a hand-rolled fetch.
- Discovery leads with `wx.search`; a hit is `{ method, endpoint: "VERB url", docsUrl, gist }`.
- Broadened the description to "build **and manage**".

## Validation note
Field names + read/write semantics are verified against the Catalog V3 schema. Whether `variant.media` is populated on the slug read (vs needing an extra mask) wasn't checked on a live site — but `choiceImage()` is a safe fallback, so there's no regression either way. A live round-trip is the last confirmation if wanted.
