### PR TITLE
fix: variantImage() built its URL from uploadId (403 on every read) + correct the choice-media PATCH example

### DIFF
--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -301,7 +301,12 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 
 ### Choice & variant fields (what you can set)
 
-Send these inside the `options` / `variantsInfo.variants` arrays — whole array each time (see *Update Options and Variants*), with the current `revision`.
+Send these inside the `options` / `variantsInfo.variants` arrays — **both arrays complete, in the
+same PATCH**, with the current `revision`, and **identity-preserving** (see *Update Options and
+Variants*): keep the option's `id` and every `choiceId`, or the ids are re-minted and the existing
+variants no longer resolve (`400 "Variant choice not found in product options"`). Each variant needs
+its `id`, its `choices` (by `optionChoiceIds` — or `optionChoiceNames`, see *Gotchas*) **and** a
+`price` — omitting price is `400 "price must not be empty"`.
 
 **Option choice** (`options[].choicesSettings.choices[]`):
 - `name`, `choiceType`, `colorCode` — the choice's identity and swatch colour.
@@ -309,7 +314,7 @@ Send these inside the `options` / `variantsInfo.variants` arrays — whole array
 - `displayImage` — the image shown on the swatch itself (distinct from `media`).
 - Read-only, don't send: `inStock`, `visible`, `key`.
 
-**Variant** (`variantsInfo.variants[]`, by its `id` from Get Product):
+**Variant** (`variantsInfo.variants[]`, by its `id` from Get Product; always send `choices` + `price` with it):
 - `price` = `{ "actualPrice": { "amount" }, "compareAtPrice": { "amount" } }` — set `compareAtPrice` above `actualPrice` for a strikethrough sale; omit it for full price.
 - `sku`, `barcode` — per combination.
 - `visible` — hide a single variant.
@@ -317,15 +322,23 @@ Send these inside the `options` / `variantsInfo.variants` arrays — whole array
 - Read-only, don't send: `media` (derived from the choices' media), `inventoryStatus` (stock — use the Inventory API, see *Set Stock for New Variants*), `subscriptionPricesInfo`.
 
 ```bash
-# a choice image + a variant's SKU and sale price, one PATCH
+# A choice image + a variant's sale price, one PATCH. Both arrays are complete and keep their ids —
+# this exact shape is the one that succeeds; the two shortcuts (choices by name only, or a variant
+# without its choices/price) each 400.
 curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   -H "Content-Type: application/json" -H "Authorization: <AUTH>" \
   -d '{ "product": { "id": "{productId}", "revision": "{currentRevision}",
-        "options": [ { "name": "Color", "choicesSettings": { "choices": [
-          { "name": "Red", "media": { "items": [ { "mediaId": "abc~mv2.jpg" } ] } } ] } } ],
+        "options": [ { "id": "{optionId}", "name": "Color", "optionRenderType": "COLOR_CHOICES",
+          "choicesSettings": { "choices": [
+            { "choiceId": "{choiceId1}", "name": "Red", "choiceType": "ONE_COLOR", "colorCode": "#C0392B",
+              "media": { "items": [ { "mediaId": "abc~mv2.jpg" } ] } },
+            { "choiceId": "{choiceId2}", "name": "Blue", "choiceType": "ONE_COLOR", "colorCode": "#2C3E50" } ] } } ],
         "variantsInfo": { "variants": [
-          { "id": "{existingVariantId}", "sku": "TEE-RED-L",
-            "price": { "actualPrice": { "amount": "20" }, "compareAtPrice": { "amount": "30" } } } ] } } }'
+          { "id": "{variantId1}", "sku": "TEE-RED-L",
+            "price": { "actualPrice": { "amount": "20" }, "compareAtPrice": { "amount": "30" } },
+            "choices": [ { "optionChoiceIds": { "optionId": "{optionId}", "choiceId": "{choiceId1}" } } ] },
+          { "id": "{variantId2}", "price": { "actualPrice": { "amount": "20" } },
+            "choices": [ { "optionChoiceIds": { "optionId": "{optionId}", "choiceId": "{choiceId2}" } } ] } ] } } }'
 ```
 
 ### Update Variant Price Only

--- a/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
+++ b/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
@@ -35,10 +35,14 @@ export function choiceImage(choice) {
 // The image for a resolved VARIANT (a full choice combination). Wix computes variant.media from the
 // picked choices' media, so this is the exact image for the current selection — prefer it over a
 // single choice's image once all options are chosen.
+// ⚠️ Read `media.image.url` (the URL the API already returns), or build from `media.id` — the
+// `~mv2` file id. NOT `media.uploadId`: that's a dashed GUID (the id the file was uploaded with),
+// and https://static.wixstatic.com/media/<uploadId> is a 403. Variants without media (a fresh
+// template's demo products) return null, and the caller falls back to the choice's own image.
 export function variantImage(variant) {
   const m = variant?.media;
   if (!m) return null;
-  return m.uploadId ? wixMediaUrl(m.uploadId) : storeImage(m.thumbnail?.url);
+  return storeImage(m.image?.url) || wixMediaUrl(m.id) || storeImage(m.thumbnail?.url);
 }
 
 // The main catalog image for a product (grid tiles, cart fallbacks).


### PR DESCRIPTION
Follow-up to #1162, from reviewing it against live Catalog V3 data. Both findings were reproduced in a browser against a real site with the skill's own `storeImage.js` executed verbatim (local bench app, anonymous visitor token from the site's public client id — the same auth a vibe storefront ships).

## 1. `variantImage()` returned a URL the CDN refuses

What a variant's media actually looks like on the shipped read path:

```json
{ "id": "e6a89e_9ec2…~mv2.png",
  "image": { "url": "https://static.wixstatic.com/media/e6a89e_9ec2…~mv2.png" },
  "uploadId": "beed46cd-bd4d-402b-890a-a6a0dfb4abb9" }
```

`uploadId` is the dashed GUID the file was uploaded with. Measured: `static.wixstatic.com/media/<uploadId>` → **403**; `media.id` / `media.image.url` → **200**. `uploadId` is present on **9/9 variants across 3 products**, so the `m.uploadId ? …` branch always won — and the `m.thumbnail?.url` fallback is dead too, since `thumbnail` is only returned with the `THUMBNAIL` field mask that `getProductBySlug` doesn't request.

**Impact:** `useProductDetail` pre-selects the first in-stock choice per option, so a variant resolves on first paint → `focusMediaUrl` was the 403 URL → `ProductGallery` compared a dashed GUID against `~mv2` file ids → never matched → **the gallery silently ignored the selection**, and the early return also skipped the `choiceImage()` fallback that does work. No broken `<img>` renders, which is why this passes a casual look.

Fix is one line — read the URL the API already returns.

## 2. The "Choice & variant fields" PATCH example couldn't work as written

Live testing hit both rejections in order:
- `400 "Variant choice not found in product options"` — sending `options` with choices by name only re-mints the option/choice ids, orphaning existing variants;
- then `400 "price must not be empty"` — a variant sent without its `price`.

The example is now the payload that **actually succeeded**: both arrays complete and identity-preserving (option `id` + every `choiceId` kept), variants carrying `id`, `choices` and `price`. Prose above it states both failure modes.

## Verified correct, left alone

`choiceImage()`. After linking choice media through the corrected PATCH, `choice.media.items[].mediaId` reads back as the `~mv2` **file id**, so `wixMediaUrl()` resolves it — and `linkedMedia` returns empty exactly as the docs say when `PRODUCT_CHOICES_MEDIA_REFERENCES` is requested. The new field masks, `wixMediaId()` id-matching, and variant-aware `compareAtPrice` all check out too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)