### PR TITLE
fix(wix-vibe-headless): choice image beats variant image + linkedMedia guard

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -68,18 +68,18 @@ export function useProductDetail(slug) {
   const price = variant?.price?.actualPrice?.formattedAmount || product?.actualPriceRange?.minValue?.formattedAmount || "";
   const compareAtPrice = variant?.price?.compareAtPrice?.formattedAmount || product?.compareAtPriceRange?.minValue?.formattedAmount || "";
 
-  // The gallery follows the selection: a resolved variant carries the exact combination's image
-  // (variant.media), so prefer it; before every option is picked, fall back to the selected choice's
-  // own image (choice.media.items[].mediaId). See lib/storeImage: variantImage() / choiceImage().
+  // The gallery follows the selection. Prefer the selected choice's own image (the per-swatch photo,
+  // choice.media.items[].mediaId) — Wix's per-variant media is often NOT differentiated (it defaults to
+  // the product's main image), so preferring the variant would override the correct choice image for
+  // every colour. Fall back to the resolved variant's image only when no chosen option carries one.
+  // See lib/storeImage: choiceImage() / variantImage().
   const focusMediaUrl = useMemo(() => {
-    const fromVariant = variantImage(variant);
-    if (fromVariant) return fromVariant;
     for (const o of options) {
       const choice = (o.choicesSettings?.choices || []).find((c) => c.choiceId === selectedOptions[o.id]);
       const url = choiceImage(choice);
       if (url) return url;
     }
-    return null;
+    return variantImage(variant);
   }, [variant, options, selectedOptions]);
 
   const selectOption = (optionId, choiceId) => setSelectedOptions((s) => ({ ...s, [optionId]: choiceId }));

--- a/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
+++ b/skills/wix-vibe-headless/references/storefront/app/lib/storeImage.js
@@ -24,9 +24,11 @@ export function wixMediaId(url) {
   return m ? m[1] : url;
 }
 
-// The image assigned to a product OPTION CHOICE (e.g. a colour swatch). Wix V3 exposes it at
-// choice.media.items[].mediaId — build the CDN url from the id. Needs the
-// PRODUCT_CHOICES_MEDIA_REFERENCES field on the fetch.
+// The image assigned to a product OPTION CHOICE (e.g. a colour swatch). The storefront fetches with the
+// PRODUCT_CHOICES_MEDIA_REFERENCES field, so Wix returns the choice image at choice.media.items[].mediaId
+// and returns choice.linkedMedia EMPTY. Read media.items — do NOT switch this to choice.linkedMedia even
+// if a direct admin/API probe shows linkedMedia populated: a probe made WITHOUT that field mask returns
+// linkedMedia, but the storefront requests the mask, which blanks linkedMedia and returns media.items.
 export function choiceImage(choice) {
   const mediaId = choice?.media?.items?.[0]?.mediaId;
   return mediaId ? wixMediaUrl(mediaId) : null;


### PR DESCRIPTION
## From a real store build

A store where picking a colour didn't switch the product image (and the cart showed the wrong variant image). Two issues, both in the seeded storefront.

## 1. Choice image should beat variant image

`focusMediaUrl` preferred `variantImage(variant)` over `choiceImage(choice)`. But Wix's **per-variant media is often not differentiated** — it defaults to the product's main image when the merchant didn't set distinct variant media — so `variantImage` returned the same image for every colour and **overrode the correct per-choice image**.

Fixed: prefer `choiceImage()` (the per-swatch photo the shopper expects); fall back to `variantImage()` only when no chosen option carries an image.

## 2. Don't "correct" choiceImage to `linkedMedia`

The storefront fetches with the `PRODUCT_CHOICES_MEDIA_REFERENCES` field, so Wix returns the choice image at `choice.media.items[].mediaId` and returns `choice.linkedMedia` **empty** (Wix's schema: *"use this field instead of linked_media"*). An agent debugging the storefront often probes the API **without** that field mask, sees `linkedMedia` populated, and "corrects" the storefront to read `linkedMedia` — which breaks it (the storefront's masked read has `linkedMedia` empty).

Fixed: the `choiceImage` comment now says explicitly to read `media.items` and **not** switch to `linkedMedia` even if a maskless probe shows it populated.

## Scope
Storefront only (`wix-vibe-headless`). The `wix-manage` recipe stays admin-focused and is untouched — the visitor/field-mask read shape is a storefront concern.
