### PR TITLE
docs(wix-base44-connector): response shape is part of discovery (read spec field descriptions)

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on and manage the connected Wix site from a Base44 app: discover and call any Wix API, gather site context, route each call to the right identity, and follow curated recipes for multi-step admin flows."
+description: "Build on and manage the connected Wix site from a Base44 app: discover and call any Wix API (endpoints, request/response shapes, fields), gather site context, route each call to the right identity, and follow curated recipes for multi-step admin flows."
 ---
 
 # Building on Wix from Base44
@@ -126,7 +126,8 @@ lines weren't enough.
 ### The spec index — a located method's exact schema
 
 Pass a method's `docsUrl` (a search/browse hit carries it) — spec loads that method's schema (request
-body, responses, filterable-fields map, examples) in one call, a direct lookup:
+body, responses, filterable-fields map, examples) in one call, a direct lookup. Read the field
+**descriptions**, not just the names — they carry the rules (which field is canonical, when one is empty):
 
 ```js
 await wx.spec(hit.docsUrl);
@@ -172,8 +173,9 @@ cross-step gotchas no method page mentions.
 
 ## Write the code
 
-**Response shapes obey the discover rule in every lane**: code against fields you saw in a live
-response or the schema — remembered names are often from older versions. Probe one real row first.
+**Shapes are discovery too**: read a method's request/response schema from `spec()` — its field
+descriptions state which field is canonical and when one reads back empty. Don't infer shape from a
+single live probe: it reflects only the params you sent, so probe with the same request your code makes.
 
 ### Admin calls — exec ad hoc, backend functions deployed
 


### PR DESCRIPTION
## Why

A real store build flip-flopped for **3 turns** on a per-choice image field. The agent had the endpoint and was probing live data — but its probes used **different field-masks each time**, so the empirical shape contradicted itself:

- probe **without** the mask → `choice.linkedMedia` populated, no `media` field
- probe **with** `PRODUCT_CHOICES_MEDIA_REFERENCES` → `linkedMedia` empty, `choice.media.items[].mediaId` populated

With no anchor, it switched the storefront to `linkedMedia`, broke it, then reverted. It **never read the schema** — where `spec()` states the rule outright: *"use this field instead of `linked_media`… when `PRODUCT_CHOICES_MEDIA_REFERENCES` is requested, `linked_media` is returned empty."*

The lesson: **response shape is part of discovery**, and a single live probe is params-dependent — not authoritative. The skill treated a live probe and the schema as equivalent ("code against fields you saw in a live response or the schema… probe one real row first").

## What changed (docs only, `wix-base44-connector`)

- **"Write the code"** now says: response shape is part of discovery — read it from `spec()`, don't guess it from one probe. A probe reflects only the params/mask you sent, so probe with the **same request** your code makes (or both ways to compare).
- **`spec()` intro**: the field **descriptions** are where the gotchas live (which field is canonical, which fields a request field-mask blanks) — read them, not just the field names.

Verified against a live site: the same product/token returns opposite choice-media shapes purely by field-mask.
