### PR TITLE
fix(wix-manage stores): per-choice image write — id/ordering trap + create-flow pointer

### DIFF
--- a/skills/wix-manage/references/stores/create-product-catalog-v3.md
+++ b/skills/wix-manage/references/stores/create-product-catalog-v3.md
@@ -127,9 +127,18 @@ This inventory-aware physical product is the reusable shape. Remove `inventoryIt
 }
 ```
 
-For a color option, use `SWATCH_CHOICES`; each choice uses `choiceType: ONE_COLOR` and `colorCode`, and the variant reference uses `renderType: SWATCH_CHOICES`.
+For a color option, use `SWATCH_CHOICES`; each choice uses `choiceType: ONE_COLOR` and `colorCode`, and the variant reference uses `renderType: SWATCH_CHOICES`. For a different **image** per colour (not just the swatch), each choice also carries its own `media`:
 
-A per-choice **image** (a colour that swaps the gallery, not just the swatch) is `choice.media` — assign it as a follow-up PATCH once the images are in the gallery. Full choice-vs-variant field split (choice: `media`/`colorCode`; variant: `price`/`sku`/`barcode`/stock) and the media ordering gotcha: **[Update Product with Options](update-product-with-options.md) → Choice & variant fields**.
+```json
+"choicesSettings": {"choices": [
+  {"choiceType": "ONE_COLOR", "name": "Black", "colorCode": "#000000",
+   "media": {"items": [{"url": "https://static.wixstatic.com/media/<black>.jpg"}]}},
+  {"choiceType": "ONE_COLOR", "name": "White", "colorCode": "#FFFFFF",
+   "media": {"items": [{"url": "https://static.wixstatic.com/media/<white>.jpg"}]}}
+]}
+```
+
+The image must be in the product gallery first, and the id/ordering has a trap — assign per-choice media via **[Update Product with Options](update-product-with-options.md) → Choice & variant fields** (also the full choice-vs-variant field split: choice `media`/`colorCode`; variant `price`/`sku`/`barcode`/stock).
 
 A digital product uses the smaller shape below. Add the supplied variant-level digital file only when one was provided.
 

--- a/skills/wix-manage/references/stores/create-product-catalog-v3.md
+++ b/skills/wix-manage/references/stores/create-product-catalog-v3.md
@@ -129,6 +129,8 @@ This inventory-aware physical product is the reusable shape. Remove `inventoryIt
 
 For a color option, use `SWATCH_CHOICES`; each choice uses `choiceType: ONE_COLOR` and `colorCode`, and the variant reference uses `renderType: SWATCH_CHOICES`.
 
+A per-choice **image** (a colour that swaps the gallery, not just the swatch) is `choice.media` — assign it as a follow-up PATCH once the images are in the gallery. Full choice-vs-variant field split (choice: `media`/`colorCode`; variant: `price`/`sku`/`barcode`/stock) and the media ordering gotcha: **[Update Product with Options](update-product-with-options.md) → Choice & variant fields**.
+
 A digital product uses the smaller shape below. Add the supplied variant-level digital file only when one was provided.
 
 ```json

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -311,7 +311,14 @@ its `id`, its `choices` (by `optionChoiceIds` — or `optionChoiceNames`, see *G
 **Option choice** (`options[].choicesSettings.choices[]`):
 - `name`, `choiceType`, `colorCode` — the choice's identity and swatch colour.
 - `media` = `{ "items": [ { "mediaId" } | { "url" } ] }` — the product photos shown when this choice is picked. `url` is write-only; on read you get `mediaId` (request the `PRODUCT_CHOICES_MEDIA_REFERENCES` mask). Use `media`, **not** `linkedMedia` (a separate display-filter, returned empty when you read `media`).
-  - **Gallery-first; the id is not the upload id.** Add the file's `url` to the product gallery (`media.itemsInfo.items`), then link the `mediaId` you read back off the gallery (`MEDIA_ITEMS_INFO` mask). The upload / `import` / `get-file-by-id` id 400s as a choice `mediaId`; `{ "url" }` works too, but only once it's in the gallery.
+  - **Gallery-first; the id you link is the gallery item's, not the upload's.** Add the `url` to the gallery, then read the product back and link the id you see there:
+
+    ```
+    GET /stores/v3/products/{id}?fields=MEDIA_ITEMS_INFO
+    #  → media.itemsInfo.items[].id = "abc~mv2.jpg"   ← link THIS as choice media.items[].mediaId
+    # the id from POST /site-media/v1/files/import or /files/get-file-by-id 400s as a choice mediaId
+    ```
+    `{ "url" }` works in place of `{ "mediaId" }` too, but only once the image is already in the gallery.
 - `displayImage` — the image shown on the swatch itself (distinct from `media`).
 - Read-only, don't send: `inStock`, `visible`, `key`.
 

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -310,7 +310,8 @@ its `id`, its `choices` (by `optionChoiceIds` — or `optionChoiceNames`, see *G
 
 **Option choice** (`options[].choicesSettings.choices[]`):
 - `name`, `choiceType`, `colorCode` — the choice's identity and swatch colour.
-- `media` = `{ "items": [ { "mediaId" } | { "url" } ] }` — the product photos shown when this choice is picked. `url` is write-only; on read you get `mediaId` (request the `PRODUCT_CHOICES_MEDIA_REFERENCES` mask). Use `media`, **not** `linkedMedia` (a separate display-filter, returned empty when you read `media`). The image must already be in the product's `media.itemsInfo.items` (import + add to the gallery first).
+- `media` = `{ "items": [ { "mediaId" } | { "url" } ] }` — the product photos shown when this choice is picked. `url` is write-only; on read you get `mediaId` (request the `PRODUCT_CHOICES_MEDIA_REFERENCES` mask). Use `media`, **not** `linkedMedia` (a separate display-filter, returned empty when you read `media`).
+  - **Gallery-first; the id is not the upload id.** Add the file's `url` to the product gallery (`media.itemsInfo.items`), then link the `mediaId` you read back off the gallery (`MEDIA_ITEMS_INFO` mask). The upload / `import` / `get-file-by-id` id 400s as a choice `mediaId`; `{ "url" }` works too, but only once it's in the gallery.
 - `displayImage` — the image shown on the swatch itself (distinct from `media`).
 - Read-only, don't send: `inStock`, `visible`, `key`.
 


### PR DESCRIPTION
## Why

Two live moomin-ceramics store builds hit the same wall on "add a colour option, each colour its own image." The **read** side is fixed (#1166), so the friction moved to the **admin write** path — and it's a doc gap, not model flakiness:

- **T4 (create):** user asked for "black/white with different images." The agent used `create-product-catalog-v3`, whose `SWATCH_CHOICES` note only mentions `colorCode` — so it created the swatches **without** the per-choice images. That made the "images don't switch" follow-up inevitable.
- **T6 (assign media):** ~10 tool calls thrashing on *which id* to link — it uploaded the files, tried to link the upload/`get-file-by-id` ids to the choices, got 400s, and only eventually discovered it had to add the url to the product gallery and link the **gallery** `mediaId` read back off the product.

## What

- `create-product-catalog-v3.md`: one line at the `SWATCH_CHOICES` note pointing at `choice.media` and the full choice-vs-variant field split in the update recipe (no duplication).
- `update-product-with-options.md`: the per-choice `media` bullet now states the ordering/id trap — gallery-first, and the id you link is the gallery item's `mediaId`, not the upload/import id.

Both are admin-write concerns, so they live in the `wix-manage` recipes. No storefront/read changes.