### PR TITLE
feat(wix-base44-connector): wx.installApp — install a not-yet-installed Wix app instead of giving up

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -51,7 +51,7 @@ const wx = (() => { const m = { exports: {} };
   new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
 ```
 
-`wx` exports nine helpers:
+`wx` exports these helpers:
 
 - `wx.post/get/patch/put/del(url, [body], token?)` — JSON transports, one per verb (`get`/`del` take no body): Bearer from `token`, non-2xx **throws** the API's own error
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
@@ -62,6 +62,7 @@ const wx = (() => { const m = { exports: {} };
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema; pass a hit's docsUrl (direct load), or raw code to query the index yourself
 - `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
+- `wx.installApp(appDefId, siteId, token)` — install a Wix app on the site (Apps Installer). If discovery finds an API whose app isn't installed on the site, install it first — that's a one-call prerequisite, **not** a reason to fall back to a hand-built alternative. `appDefId` from `search` or the Apps-Created-by-Wix table; `siteId` from `context` (the site report)
 
 Every helper answers inline when the result fits (≤ 4,000 chars — exec results clip at ~5,000).
 A bigger result is saved under `.agents/skills/wix-base44-connector/tmp/` and comes back as

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -246,4 +246,12 @@ async function mgmtRecipes(q) {
   return clip(m.map(row));
 }
 
-module.exports = { req, post, get, patch, put, del, clip, context, browse, search, page, bash, spec, mgmtRecipes };
+// Install a Wix app on the site (Apps Installer). Use when discovery finds an API but its app is
+// not installed yet — that is a one-call prerequisite, not a dead end. appDefId from search or the
+// Apps-Created-by-Wix table; siteId from context (the site report).
+async function installApp(appDefId, siteId, token) {
+  return post("https://www.wixapis.com/apps-installer-service/v1/app-instance/install",
+    { tenant: { tenantType: "SITE", id: siteId }, appInstance: { appDefId } }, token);
+}
+
+module.exports = { req, post, get, patch, put, del, clip, context, browse, search, page, bash, spec, mgmtRecipes, installApp };


### PR DESCRIPTION
## Why

A live Base44 build asked for a loyalty program on a Wix-connected store. The agent (correctly, this time) checked Wix first: `wx.search` found the full **Wix Loyalty Program API**. But the Loyalty *app* wasn't installed on the site — so it concluded *"Wix's loyalty API isn't available"* and fell back to a hand-built Base44 entities/functions system. One step short: the app can be **installed programmatically** (Apps Installer API).

## What

- **`wx.installApp(appDefId, siteId, token)`** in `scripts/utils.js` — wraps `POST /apps-installer-service/v1/app-instance/install`.
- A helper-list line making the rule explicit: *if discovery finds an API whose app isn't installed on the site, install it first — a one-call prerequisite, **not** a reason to fall back to a hand-built alternative.* `appDefId` from `search` / the Apps-Created-by-Wix table; `siteId` from `context`.

The matching guidance is mirrored in the Base44 `wix` capability guide (apper PR #22063).