### PR TITLE
fix(seo): use menu-item docsEntry for SEO tags skill

### DIFF
--- a/yaml/wix-manage/seo/documentation.yaml
+++ b/yaml/wix-manage/seo/documentation.yaml
@@ -8,5 +8,5 @@ apiDoc:
       tags: [seo]
     - file: ../../../skills/wix-manage/references/seo/manage-seo-tags.md
       title: Manage a Wix Site's SEO Tags
-      docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo
       tags: [seo]


### PR DESCRIPTION
## Summary
- The SEO tags skill from [#1075](https://github.com/wix/skills/pull/1075) failed to auto-publish to the docs portal because `item-seo-tags-v1` is a docs **resource**, not a **menu item**
- Changed `docsEntry` from `.../seo/item-seo-tags-v1` to `.../seo` (the nearest valid menu item in the hierarchy)

## Context
Reported in [this Slack thread](https://wix.slack.com/archives/C0B1Q34LX0R/p1787749700345079?thread_ts=1787235124.124579&cid=C0B1Q34LX0R) — the publish pipeline rejects resource-level URLs as docsEntry.

## Test plan
- [ ] Verify the publish pipeline succeeds after merge (skill appears on docs portal)