### PR TITLE
fix: pin the @wix/cli example in the root replatform copy

### DIFF
--- a/wix-replatform/resources/rp-target-wix/lib/wix-writers.js
+++ b/wix-replatform/resources/rp-target-wix/lib/wix-writers.js
@@ -324,7 +324,7 @@ function applySafeModeToRequestBody(body, safeModeOptions) {
 // media import, Contacts manage/schema, and Members manage.
 //
 // Auth scheme normalization: Wix API keys (`IST.…`) are sent RAW in the Authorization
-// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli token --site …`)
+// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli@latest token --site …`)
 // must be sent as `Bearer <token>`. Detect and prefix so both credential kinds work.
 function authHeaderValue(token) {
   const t = String(token).trim();


### PR DESCRIPTION
`check-cli-pinned` fails on **every PR in the repo** right now.

#979 pinned this comment in `skills/wix-replatform/`. #1156 then published a second copy of the replatform skill at the repo root (`wix-replatform/`, 242 files), and that copy still carries the pre-#979 text. The check scans from the repo root, so it finds the unpinned one:

```
./wix-replatform/resources/rp-target-wix/lib/wix-writers.js:327
// ... a Wix CLI token from `npx @wix/cli token --site …`
```

One line, identical to #979's fix. `bash .github/scripts/check-cli-pinned.sh` passes locally after it.

**Worth a separate look:** the two copies have diverged beyond this line — the root one has `bulk/products-with-inventory/create` and `bulk/contacts/upsert` handling that `skills/wix-replatform/` lacks. So this class of fix will keep missing one copy until the duplication is resolved.