### PR TITLE
docs(wix-base44-connector): REST, not the JS SDK

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -191,6 +191,9 @@ lists, else filter in code.
 
 ## Write the code
 
+**REST, not the JS SDK** — everywhere: the admin ops you run while building, backend functions,
+frontend pages. Doc pages carry twin REST and SDK halves; read the REST one.
+
 **Shapes are discovery too**: read a method's request/response schema from `spec()` — its field
 descriptions state which field is canonical and when one reads back empty. Don't infer shape from a
 single live probe: it reflects only the params you sent, so probe with the same request your code makes.


### PR DESCRIPTION
The skill is REST end to end and never says so. An agent reading a doc page's twin REST/SDK halves, or reaching for `@wix/sdk` out of habit, has nothing to point at.

One line at the top of **Write the code**, naming each lane as it exists in the sections below it — `wx.<verb>` is the builder's admin transport, and shipped code splits into a backend function holding the connection token and frontend pages holding a visitor token:

> **REST, not the JS SDK** — every lane is plain HTTP against `wixapis.com`: `wx.<verb>` for the admin ops you run while building, `fetch` with the connection token in backend functions, `fetch` with a visitor token in frontend pages. Doc pages carry twin REST and SDK halves; read the REST one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)