### PR TITLE
docs(wix-base44-connector): rules for writing the call, split by lane

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -194,11 +194,15 @@ lists, else filter in code.
 **REST, not the JS SDK** — everywhere: the admin ops you run while building, backend functions,
 frontend pages. Doc pages carry twin REST and SDK halves; read the REST one.
 
+**Send what the page documents, nothing more** — required fields, nesting, and enum values exactly
+as spelled; a header only when the operation's REST section lists it. Never `wix-site-id`: every
+token here is already bound to a site, and in the browser the header fails CORS preflight outright.
+
 **Shapes are discovery too**: read a method's request/response schema from `spec()` — its field
 descriptions state which field is canonical and when one reads back empty. Don't infer shape from a
 single live probe: it reflects only the params you sent, so probe with the same request your code makes.
 
-### Admin calls — exec ad hoc, backend functions deployed
+### Admin ops while building — you, in exec_tool
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
@@ -209,8 +213,28 @@ return wx.clip({ error: null, count: data.contacts?.length, first: data.contacts
 // `first` is one complete record — read the real field shapes off it; don't code from remembered key names
 ```
 
-The same call deploys as `base44/functions/…` (work the app does as the owner) — shipped code
-carries its own four-line fetch; the helpers are a build tool, not a runtime dependency.
+### Backend functions — the app, as the owner
+
+The same API call, deployed. **No helpers run here** — `wx.*` is a build tool loaded into exec,
+absent from `base44/functions/…`; write plain `fetch`. Nor `clip`, which caps what an exec returns
+to you: a function returns its data to the app.
+
+```js
+// inside base44/functions/… — plain fetch, no wx
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const res = await fetch("https://www.wixapis.com/contacts/v5/contacts/query", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ query: { cursorPaging: { limit: 10 } } }),
+});
+if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);   // the API's own error, not a generic one
+return (await res.json()).contacts;
+```
+
+- That `Authorization: Bearer …` is the whole auth for this lane, unless the operation's page says
+  otherwise.
+- One file per business area, not per call — each file is its own deploy, and deploys cost time.
+- Call every function you deploy and fix what breaks. Deploying is not testing.
 
 ### A visitor client — src/lib/wixClient.js
 


### PR DESCRIPTION
A Wix API gets called three ways here, and the doc's diagram already names all three: the browser on a visitor token, `base44/functions/…` on the admin token, `exec_tool` on either. Two changes, both about putting guidance where its lane actually is.

### The exec probe and the deployed function were one section

`### Admin calls — exec ad hoc, backend functions deployed` showed a single example built entirely from things that exist only in exec — `wx.post`, `wx.clip`, let-it-throw — and then noted in one sentence that shipped code "carries its own four-line fetch". An agent reading it has a working example of the exec form and prose for the deployed one.

Now two sections. `### Admin ops while building — you, in exec_tool` keeps the existing block. `### Backend functions — the app, as the owner` gets the code its lane runs — plain `fetch`, the API's own error text on non-2xx, data returned to the app — under a line saying why the helpers are absent: `wx.*` is loaded into an exec, and `clip` caps what comes back to a transcript, which a function does not have.

The block shows the call, not a file wrapper — nothing in this repo establishes Base44's function signature, so it isn't invented here.

### The rules go to the lanes they hold in

**Cross-lane** — with `REST, not the JS SDK` and `Shapes are discovery too` at the top of **Write the code**:

> **Send what the page documents, nothing more** — required fields, nesting, and enum values exactly as spelled; a header only when the operation's REST section lists it. Never `wix-site-id`: every token here is already bound to a site, and in the browser the header fails CORS preflight outright.

`wix-site-id` is carried over from other Wix surfaces, is redundant on all three lanes, and on the browser lane is not in the CORS allowlist — the preflight fails and the call never leaves.

**Deployed-function only:** the token it holds, one file per business area (each file is its own deploy), and call every function you deploy — deploying is not testing. That last one mirrors what the visitor section already demands of its own lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)