### PR TITLE
docs(wix-base44-connector): recipes are not in the search corpus

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -10,6 +10,12 @@ find the APIs and learn their contracts from the docs, write the code. **Discove
 request and response fields all come from the calls below, never from memory or pattern. 404 or
 empty ⇒ discover, not permute. Examples teach mechanics and go stale — verify before relying.
 
+**A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) before any
+search, and follow the recipe it names. Search runs over the API reference alone — the recipes are
+a separate corpus, so no search returns one, and the facts a recipe states outright (what an API
+does not support, which fields a bulk call actually writes, the order two calls have to go in) get
+re-derived from schemas instead, several errors at a time.
+
 ## What are you building?
 
 The app's audience picks the token, and the token picks the architecture: the **visitor token is


### PR DESCRIPTION
From a real builder run (store variant-price + per-variant-image update). The skill was read first and its helpers were used exactly as written — but `wx.mgmtRecipes` was never called. The agent narrated *"now let me find the recipe for updating product variants"* and then ran `wx.search`.

That is the whole bug: **it went looking for the recipe with search.** `wx.search` queries the API reference; the recipes are a separate corpus that endpoint does not index, so the search that felt like looking for a recipe could only ever return methods. ~30 tool calls and 5 errors followed, re-deriving from schemas what `stores/update-product-with-options.md` states outright — per-variant media isn't supported (assign to the choice), the bulk filter writes only price/visible, the gallery-first media-id ordering.

Ordering prose was already in place and lost: `### Management recipes — first stop for an admin task` is the first subsection of Learn Wix, ahead of search. Restating the preference more firmly is the thing that just failed, so this note leads with the mechanism, in the intro block where the rules of engagement are:

> **A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) before any search, and follow the recipe it names. Search runs over the API reference alone — the recipes are a separate corpus, so no search returns one, and the facts a recipe states outright (what an API does not support, which fields a bulk call actually writes, the order two calls have to go in) get re-derived from schemas instead, several errors at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)