### PR TITLE
feat(wix-base44-connector): spec and page list the request examples

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -64,9 +64,9 @@ const wx = (() => { const m = { exports: {} };
 - `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
 - `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist
-- `wx.page(docsUrl)` — read a doc page
+- `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
-- `wx.spec(docsUrl | code)` — a method's exact schema; pass a hit's docsUrl (direct load), or raw code to query the index yourself
+- `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself
 - `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
 - `wx.installApp(appDefId, siteId, token)` — install a Wix app on the site (Apps Installer). If discovery finds an API whose app isn't installed on the site, install it first — that's a one-call prerequisite, **not** a reason to fall back to a hand-built alternative. `appDefId` from `search` or the Apps-Created-by-Wix table; `siteId` from `context` (the site report)
 
@@ -153,8 +153,9 @@ map and window in the SAME exec; coordinates are for your code, not for a second
 
 ```js
 const pg = await wx.page(docsUrl);   // whole text when small; else { path, bytes, lines, outline }
-// your half, windowed to your term and its Examples (a complete working request — URL, headers,
-// body — usually all you need), one round:
+// pg.examples lists the page's worked requests as { title, line } — a complete request (URL,
+// headers, body) is usually all you need: read_file(pg.path, offset: <its line>)
+// anything else, windowed to your term in the same round:
 return wx.bash(`sed -n '/^## REST API/,/^## JavaScript SDK/p' ${pg.path} | grep -B5 -A40 -i 'examples\\|<term>' | head -c 3800`);
 // a giant fenced example → its field vocabulary instead of paging it:
 // wx.bash(`sed -n '<a>,<b>p' ${pg.path} | grep -oE '"[a-zA-Z]+":' | sort -u | head -60`)
@@ -170,7 +171,9 @@ body, responses, filterable-fields map, examples) in one call, a direct lookup. 
 **descriptions**, not just the names — they carry the rules (which field is canonical, when one is empty):
 
 ```js
-await wx.spec(hit.docsUrl);
+const sp = await wx.spec(hit.docsUrl);
+// sp.examples — the method's worked requests as { title, line }, all saved at sp.examplesPath.
+// The one that matches the task is rarely the first: read_file(sp.examplesPath, offset: <its line>)
 ```
 
 Want to shape the result yourself? Pass raw code against the index (`lightIndex` + `getResourceSchemaByUrl`):

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -139,18 +139,32 @@ async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
 
 // Fetch + save + map in one round: whole text inline when small, else
 // { path, bytes, lines, outline } — the outline's line numbers feed grep and read_file windows.
+// Examples come back as their own title+line list, so the outline's cap can never drop them.
 async function page(url) {
   const { path: p, lines } = await resolveRef(url);
   const text = lines.join("\n");
   if (text.length <= BUDGET) return text;
   const o = outlineOf(lines);
   const bytes = Buffer.byteLength(text);
-  return { path: p, bytes, lines: lines.length, ...o,
+  const ex = pageExamples(lines);
+  return { path: p, bytes, lines: lines.length, ...(ex.length && { examples: ex }), ...o,
            next: [
              `wx.bash("grep -in 'term' ${p} | head -40")`,
              bytes <= 45000 ? `read_file ${p}   // whole (fits the 45K cap), or a window via offset/limit`
                             : `read_file ${p} with offset/limit   // window a section by the outline's lines`,
            ] };
+}
+
+// The page's Examples section, as titles + line numbers — listed on their own so the
+// outline's cap can never drop them.
+function pageExamples(lines) {
+  const heads = [];
+  lines.forEach((t, i) => { const m = /^(#{1,6}) (.+)$/.exec(t); if (m) heads.push({ line: i + 1, level: m[1].length, text: m[2].trim() }); });
+  const at = heads.findIndex(h => /^(examples?|method code examples)$/i.test(h.text));
+  if (at < 0) return [];
+  const sec = heads[at], rest = heads.slice(at + 1);
+  const end = (rest.find(h => h.level < sec.level) || { line: lines.length + 1 }).line;
+  return rest.filter(h => h.line < end).map(h => ({ title: h.text, line: h.line }));
 }
 
 // ── shell ─────────────────────────────────────────────────────────────────────
@@ -172,9 +186,39 @@ function bash(cmd) {
   }
 }
 
+// ── request examples ──────────────────────────────────────────────────────────
+
+// The docs' own working requests: the code-mode index carries them at
+// methods[].legacyExamples[].content, a doc page under its Examples heading. Both are saved
+// whole and come back as titles + line numbers — read the one you need with read_file.
+const examplesOf = (result) => {
+  const methods = result?.methods?.length ? result.methods : (result?.legacyExamples ? [result] : []);
+  const out = [];
+  for (const m of methods) for (const e of m.legacyExamples || []) {
+    const c = e.content || e;
+    if (c.request) out.push({ title: c.title || "", request: typeof c.request === "string" ? c.request : JSON.stringify(c.request, null, 1) });
+  }
+  return out;
+};
+
+// One file, one heading per example — the returned line is where its body starts.
+const saveExamples = (exs, name) => {
+  const parts = [];
+  let line = 1, index = [];
+  for (const e of exs) {
+    const block = "## " + e.title + "\n\n" + e.request + "\n";
+    index.push({ title: e.title, line: line + 2 });
+    parts.push(block);
+    line += block.split("\n").length;
+  }
+  return { ...save("examples-" + name + ".md", parts.join("\n")), index };
+};
+
 // ── the spec index ────────────────────────────────────────────────────────────
 
-// Inspect a method's schema — request body, responses, enums, filterable-fields map. Pass a docsUrl
+// Inspect a method's schema — request body, responses, enums, filterable-fields map — plus the
+// titles of the docs' own request examples, saved together at examplesPath: read the one that
+// matches your task with read_file(examplesPath, offset: <its line>). Pass a docsUrl
 // (from search/browse — a direct load, no scan) and spec returns that method's schema. Or pass raw
 // `async function(){…}` to query the index yourself: lightIndex (RESOURCES with .methods —
 // operationId, summary, httpMethod, publicUrl [callable], docsUrl) and getResourceSchemaByUrl(docsUrl)
@@ -193,8 +237,11 @@ async function spec(arg) {
   if (text.length <= BUDGET) return result;
   let h = 5381;
   for (const ch of code) h = ((h * 33) ^ ch.charCodeAt(0)) >>> 0;   // same query → same file
+  const exs = examplesOf(result);
+  const ex = exs.length ? saveExamples(exs, h.toString(36)) : null;
   return { ...save("spec-" + h.toString(36) + ".json", text),
            shape: Array.isArray(result) ? `Array(${result.length})` : Object.keys(result || {}).slice(0, 15),
+           ...(ex && { examplesPath: ex.path, examples: ex.index }),
            head: text.slice(0, 600) };
 }
 


### PR DESCRIPTION
From `HANDOFF-example-surfacing.md`. When a build asks "how do I write this call," the retrieval tools *hold* the endpoint's worked request example and never mention it.

A staging run (per-choice prices and images on a product) spent **6m05s, 31 calls, 5 failed API calls, ~15 doc reads** reconstructing a body Wix publishes verbatim as *"Update product's main and choice images"*.

### Before

- **`spec(docsUrl)`** returned `{path, bytes: 664513, lines: 18465, shape, head}` — `legacyExamples` was inside that 664 KB file with nothing pointing at it. The run's step #24 is labelled "Reading update product example": a grep over the schema that could not find it.
- **`page(docsUrl)`** relied on the outline, which caps at 30 headings — the example titles are only there by luck.

### After

`spec` writes the method's examples to their own file and returns where they are:

```js
const sp = await wx.spec(hit.docsUrl);
// examplesPath: ".agents/skills/wix-base44-connector/tmp/examples-kogmez.md"
// examples: [ { title: "Update product",                                line: 3   },
//             { title: "Update a single field on a product (brand)",    line: 83  },
//             { title: "Update product's main and choice images",       line: 98  },
//             { title: "Update product name",                           line: 186 } ]
read_file(sp.examplesPath, offset: 98)   // the one that matches the task
```

`page` returns the same list against the page it already saved, as its own key so the outline's cap cannot drop it.

The caller picks which example to read, because only the caller knows the task — the one that solves it is rarely the first (here it is #3 of 4).

### Verified live

Two unrelated endpoints, stores `update-product` and bookings `create-booking`. Returns are **1,229** and **1,689 chars**, and every `line` lands on the first line of that example's body. Edge cases hold: a page with no Examples section and a raw-code `spec()` query return exactly as before. `search` is untouched.

### Not included

The handoff's two reported doc bugs on `update-product` do not reproduce, and I would not report them upstream as written:

- *"field docs say `linkedMedia` is deprecated"* — that deprecation is on the **response** side (the `PRODUCT_CHOICES_MEDIA_REFERENCES` projection returns `media_references` "instead of the deprecated `linked_media` field"). It governs reads; for writes the page instructs `linkedMedia`, which is what the example uses.
- *"'must use preexisting product media' contradicts the example's raw external url"* — the example passes that same URL into `media.itemsInfo.items` **in the same request**, so the media pre-exists by the time the choice links it. That is the gallery-first ordering the run spent reads rediscovering.

So the wasted "upload first, then link" detour came from never seeing the example, not from a doc defect.

Also out of scope: flagging `/v1/` hits on V3 sites (the run's two `428 CATALOG_V3_CALLING_CATALOG_V1_API`), which is a `search` concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)