### PR TITLE
sync(editor-react-component): fix(skill): Clarify component preview instructions 

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -20,17 +20,13 @@ file responsibilities:
 | `<component-name>.tsx` | Edit | Implement the component UI and behavior. |
 | `<component-name>.module.css` | Edit | Define scoped component styles. |
 | `component.tsx` | Keep generated | Wire the component and `defaultProps` with `withDefaults`. |
-| `component.preview.tsx` | Usually keep generated | Customize only for editor-specific behavior, such as suppressing autoplay. |
+| `component.preview.tsx` | Edit narrowly | Keep generated wrappers; sync the preview adapter, one crucial data field, and root class. |
 | `<component-name>.generated.ts` | NEVER edit | Generated manifest consumed by the editor. |
 | `<component-name>.extension.ts` | Edit narrowly | Apply supported partial manifest overrides. |
 
 Supplementary files such as `constants.ts`, hooks, or internal sub-components
 are allowed when the implementation needs them. Keep the scaffolded files and
 their responsibilities intact.
-
-## Identity of SDK Calls
-
-A component runs on the live site as the **site visitor or member**, never as the app — see [Identity and Elevation Requirement](../SKILL.md#identity-and-elevation-requirement) before routing any SDK call out to a backend endpoint.
 
 ## Workflow
 
@@ -68,7 +64,9 @@ A component runs on the live site as the **site visitor or member**, never as th
 6. **Configure the editor extension when required.** For a new component or a
    requested sizing, installation, or manifest change, apply
    [`editor-react-component/EDITOR-EXTENSION-CONFIGURATION.md`](editor-react-component/EDITOR-EXTENSION-CONFIGURATION.md)
-   to `<component-name>.extension.ts`. Otherwise preserve the existing file.
+   to `<component-name>.extension.ts`. Otherwise leave the file unchanged.
+   Finally, synchronize `requiredDataFields` and `rootClassName` in
+   `component.preview.tsx`.
 
 7. **Generate and validate.** Run:
 
@@ -107,9 +105,10 @@ component or edit `*.generated.ts` as a reference-driven fix.
 
 | Scope | Required references |
 | --- | --- |
-| Creating a component | [`REACT-GUIDELINES.md`](editor-react-component/REACT-GUIDELINES.md), [`COMPONENT-CONTRACT.md`](editor-react-component/COMPONENT-CONTRACT.md), [`PARTS.md`](editor-react-component/PARTS.md), [`PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md), [`CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md), [`DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md), [`ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md), and [`EDITOR-EXTENSION-CONFIGURATION.md`](editor-react-component/EDITOR-EXTENSION-CONFIGURATION.md) |
+| Creating a component | [`REACT-GUIDELINES.md`](editor-react-component/REACT-GUIDELINES.md), [`COMPONENT-CONTRACT.md`](editor-react-component/COMPONENT-CONTRACT.md), [`PARTS.md`](editor-react-component/PARTS.md), [`PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md), [`CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md), [`DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md), [`ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md), [`COMPONENT-PREVIEW.md`](editor-react-component/COMPONENT-PREVIEW.md), and [`EDITOR-EXTENSION-CONFIGURATION.md`](editor-react-component/EDITOR-EXTENSION-CONFIGURATION.md) |
 | Editing React or JSX | [`REACT-GUIDELINES.md`](editor-react-component/REACT-GUIDELINES.md) and [`ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md) |
 | Changing the public contract, semantic root, or named parts | [`COMPONENT-CONTRACT.md`](editor-react-component/COMPONENT-CONTRACT.md), [`PARTS.md`](editor-react-component/PARTS.md), and [`PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) |
+| Changing public data props or the elected root global class | [`COMPONENT-PREVIEW.md`](editor-react-component/COMPONENT-PREVIEW.md) |
 | Creating or changing an item array where only one body is visible | [`COMPONENT-CONTRACT.md`](editor-react-component/COMPONENT-CONTRACT.md), [`PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md), [`ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md), and [`DESIGN-STATES.md`](editor-react-component/DESIGN-STATES.md) |
 | Creating or changing CSS | [`CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md) |
 | Changing the root direction contract, direction-sensitive behavior, or a `ReactNode` slot | [`DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) |
@@ -151,3 +150,7 @@ component or edit `*.generated.ts` as a reference-driven fix.
   bodies accessibly.
 - If primary content autoplays or loops, provide an accessible play/pause
   control, honor reduced motion, and suppress autoplay in editor design mode.
+- In `component.preview.tsx`, keep `withDefaults` and `withFallbackPlaceholder`,
+  wrap the preview adapter when present, normally put
+  only the one data prop crucial to meaningful rendering in
+  `requiredDataFields`, and match `rootClassName` to the root global class.

--- a/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
+++ b/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
@@ -213,8 +213,7 @@ defaults or fallback-placeholder wiring.
 
 Add `useIsEditMode` to the existing `@wix/react-component-utils` import. In the
 generated preview component, replace only the passthrough return with the gated
-props below. Keep the generated `withFallbackPlaceholder`, required-data fields,
-root class, and `withDefaults` export unchanged.
+props below.
 
 ```tsx
 const MyAnimationPreview: FC<ComponentProps<typeof Component>> = (props) => {
@@ -230,6 +229,10 @@ const MyAnimationPreview: FC<ComponentProps<typeof Component>> = (props) => {
 };
 ```
 
+Keep the generated wrappers, but wrap `MyAnimationPreview`, normally set
+`requiredDataFields` to `['animationUrl']`, and match `rootClassName` to the root
+global class.
+
 In editor design mode (`isEditMode` is `true`) → `autoPlay` is forced to `false` and `pauseButtonVisibility` is forced to `'showAlways'` so the site owner can always see and interact with the button.
 In preview mode (`isEditMode` is `false`) → both use the user's configured values.
 
@@ -243,4 +246,5 @@ In preview mode (`isEditMode` is `false`) → both use the user's configured val
 - [ ] Hover has a paired editor design state; `:focus-visible` remains a
       standalone keyboard indicator.
 - [ ] Hover-only visibility changes behavior, not the button's editable styling surface.
-- [ ] The preview preserves generated wrappers and forces autoplay off in design mode.
+- [ ] The preview exports the adapter with synchronized fallback metadata and
+      disables autoplay in design mode.

--- a/skills/wix-app/references/editor-react-component/COMPONENT-PREVIEW.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-PREVIEW.md
@@ -1,17 +1,22 @@
 # Editor Preview Entry
 
-Use this reference when `component.preview.tsx` must behave differently in
-Harmony Editor design mode than on the live site.
+Use this when creating a component or changing its data, root, or editor-only
+behavior.
 
-## Preserve the Generated Contract
+## Preserve the Structure, Synchronize the Contract
 
 The Wix CLI scaffold generates `component.preview.tsx` and wires its URL into
 the extension's editor resource. It includes `withDefaults`,
 `withFallbackPlaceholder`, required-data fields, and the root class name.
 
-Do not repeat or replace that boilerplate. Keep the generated wrappers and
-metadata, and change only the preview component when editor behavior must differ
-from live behavior.
+Keep the wrapper structure and synchronize its values:
+
+- Wrap the preview adapter when one exists; otherwise wrap `Component`.
+- In `requiredDataFields`, normally use only the one prop crucial to meaningful
+  rendering, such as `animationUrl`. Use more only when each is essential.
+- Set `rootClassName` to the elected root's exact global class, not `styles.root`.
+
+Never remove `withFallbackPlaceholder`.
 
 ## Detect Editor Design Mode
 
@@ -35,10 +40,13 @@ timers, or network activity while a site owner is designing.
 For autoplaying components, force autoplay off in editor design mode and keep
 the live/preview prop values unchanged.
 
+Export the adapter through `withFallbackPlaceholder` and synchronize its data
+field and root class.
+
 ## Checklist
 
-- [ ] Generated defaults and fallback-placeholder behavior remain intact.
-- [ ] Required data fields and root class metadata are unchanged.
+- [ ] Generated wrappers target the preview adapter when one exists.
+- [ ] Normally one crucial data field and the exact root global class are set.
 - [ ] The extension still loads the preview URL as its editor resource.
 - [ ] `useIsEditMode()` is called inside a component.
 - [ ] Live/preview behavior still receives the site owner's original props.


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/92: fix(skill): Clarify component preview instructions 

### What was synced
- Editor React Component entry and references managed by the private source repo
- Editor React Component a11y scanner scripts
- local paths mapped to the public wix/skills layout

Auto-generated by GitHub Actions.