### PR TITLE
feat(wix-base44-connector): search lists each hit's worked requests

### DIFF
--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -118,17 +118,30 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
 
 // Semantic search — ranks, never says "no match". The reduced hits come back inline
 // AND the full raw content is saved for grep/window follow-ups. { type } picks the portal:
-// REST (default) · WIX_HEADLESS.
-async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
+// REST (default) · WIX_HEADLESS. Each hit lists the worked requests the docs publish for it
+// as { title, line } into the saved file — read one with read_file(path, offset: <its line>).
+async function search(term, { type = "REST", max = 5, lines = 0 } = {}) {
   const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
+    // lines_in_each_result 0 skips the server's per-section budget, which otherwise cuts every
+    // code example after the first 30 lines and the rest after 5 — the saved file would carry
+    // stubs instead of the working requests the hits point at
     { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });
-  const hits = content.split(/\n---\n+(?=#### )/).map(b => ({
+  const nl = [];   // newline offsets — a match's char offset becomes its line in the saved file
+  for (let i = content.indexOf("\n"); i >= 0; i = content.indexOf("\n", i + 1)) nl.push(i);
+  const lineAt = (off) => { let lo = 0, hi = nl.length; while (lo < hi) { const m = (lo + hi) >> 1; nl[m] < off ? lo = m + 1 : hi = m; } return lo + 1; };
+  let cursor = 0;
+  const hits = content.split(/\n---\n+(?=#### )/).map(b => {
+    const start = content.indexOf(b, cursor); cursor = start + b.length;
+    const examples = [...b.matchAll(/--- Code Example: (.+?) ---/g)]
+      .map(m => ({ title: m[1].trim(), line: lineAt(start + m.index) }));
+    return {
     method:   (b.match(/^# Method: (.+)$/m) || [])[1],
     endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // "VERB url" — read the verb + url; call wx.<verb>(url, body, token)
     docsUrl:  (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
     gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
       .trim().replace(/\s+/g, " ").slice(0, 220),
-  })).filter(h => h.docsUrl);
+    ...(examples.length && { examples }),
+  }; }).filter(h => h.docsUrl);
   const saved = save("search-" + term.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40) + ".md", content);
   if (!hits.length) return clip({ ...saved, head: content.slice(0, 1200),
     note: `no method blocks parsed — raw head above; wx.bash("grep -in 'term' ${saved.path}") for the rest` });


### PR DESCRIPTION
Third and last piece from `HANDOFF-example-surfacing.md`, after #1180 did `spec` and `page`. This is the one that matters, because search is where discovery actually starts.

### What was wrong

The docs publish a working request for most methods. `search` returned neither the bodies nor the fact that they exist:

- **The server truncates.** `formatMethodContent` applies a per-section line budget — 30 lines for the first code example, **5 for every one after**. The example that solved the reported run was #3 of 4, so it arrived as 167 chars of curl headers followed by `... 84 more lines ...`.
- **The parser dropped the titles.** Each block is delimited `--- Code Example: <title> ---`, and those delimiters survive the truncation. `search` extracted only `gist` from `## Method Description:` and threw the rest away.

### The change

```diff
-async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
+async function search(term, { type = "REST", max = 5, lines = 0 } = {}) {
```

`lines_in_each_result: 0` skips the per-section budget, so the content `search` **already saves to disk** carries the requests whole. Each hit then lists them as `{ title, line }` into that file:

```json
{ "method": "Update Product",
  "endpoint": "PATCH https://www.wixapis.com/stores/v3/products/{product.id}",
  "docsUrl": "https://dev.wix.com/docs/…/products-v3/update-product",
  "gist": "Updates a product. Each time the product is updated, `revision` increments by 1…",
  "examples": [
    { "title": "Update product",                             "line": 10  },
    { "title": "Update a single field on a product (brand)", "line": 149 },
    { "title": "Update product's main and choice images",    "line": 193 },
    { "title": "Update product name",                        "line": 284 } ] }
```

`read_file(path, offset: 193)` returns that request whole. Discovery for the reported run becomes **one search plus one read** — no `spec`, no second network call.

Same endpoint (`/docs/search/markdown`), same single request, same hit shape otherwise.

### Verified live

The example named at line 193 reads back complete — `linkedMedia` and `actualPrice` present, no collapse markers. The existing hit parser is unaffected by the new value: 5 valid hits at both `0` and `6`.

### Cost and one risk

- Inline return **1,546 → 1,871 chars**. Saved file **8,829 → 96,101 chars** per search.
- **`lines_in_each_result: 0` is out of contract.** The proto declares this field with a minimum of 1; zero works because the web-function route does not validate it. If that gets closed, search silently returns collapsed bodies again while still advertising titles, and the `line` numbers land on stubs. Worth confirming with whoever owns `docs-search-server` before leaning on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)