### PR TITLE
feat(wix-base44-connector): a REST search ranks the recipes too

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -10,11 +10,11 @@ find the APIs and learn their contracts from the docs, write the code. **Discove
 request and response fields all come from the calls below, never from memory or pattern. 404 or
 empty ⇒ discover, not permute. Examples teach mechanics and go stale — verify before relying.
 
-**A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) before any
-search, and follow the recipe it names. Search runs over the API reference alone — the recipes are
-a separate corpus, so no search returns one, and the facts a recipe states outright (what an API
-does not support, which fields a bulk call actually writes, the order two calls have to go in) get
-re-derived from schemas instead, several errors at a time.
+**A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) and follow
+the one that fits. A recipe states outright what an API does not support, which fields a bulk call
+actually writes, and the order two calls have to go in — from the schemas alone those get re-derived
+several errors at a time. A REST search ranks the matching recipes too (`recipes` in its return), so
+they also surface from a search that began at the methods.
 
 ## What are you building?
 
@@ -63,7 +63,7 @@ const wx = (() => { const m = { exports: {} };
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A REST search also ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself
@@ -102,8 +102,8 @@ await wx.mgmtRecipes("stores");   // a category's list — or any task word: wx.
 // straight off disk — else `url`: wx.page(url), whole when small, saved + outline when big
 ```
 
-A recipe carries prerequisites, order, and gotchas that no method page has. No matching recipe —
-search and browse below.
+A recipe carries prerequisites, order, and gotchas that no method page has. A REST search ranks
+these same recipes as its own `recipes` list, so they surface either way.
 
 ### Find a method — search and browse
 

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -102,6 +102,40 @@ async function context(token, section) {
   return clip({ total: markdown.length, section: m ? m[0] : "not found — call context(token) for the outline" });
 }
 
+// The wix-manage skill, when it is installed in the sandbox, is these same recipes on disk —
+// a read_file instead of a fetch. Indexed by frontmatter name AND filename slug, because the
+// docs title drifts from the local one ("…Connect a domain" vs "…Connect").
+const RECIPE_ROOT = ".agents/skills/wix-manage/references";
+const rkey = (s) => String(s || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+let LOCAL_RECIPES;
+function localRecipes() {
+  if (LOCAL_RECIPES) return LOCAL_RECIPES;
+  LOCAL_RECIPES = new Map();
+  if (!fs.existsSync(RECIPE_ROOT)) return LOCAL_RECIPES;
+  const walk = (rel) => {
+    for (const e of fs.readdirSync(RECIPE_ROOT + rel, { withFileTypes: true })) {
+      if (e.isDirectory()) { walk(rel + "/" + e.name); continue; }
+      if (!e.name.endsWith(".md")) continue;
+      const file = RECIPE_ROOT + rel + "/" + e.name;
+      const name = (fs.readFileSync(file, "utf8").slice(0, 600).match(/^name:\s*"?(.+?)"?\s*$/m) || [])[1];
+      if (name) LOCAL_RECIPES.set(rkey(name), file);
+      LOCAL_RECIPES.set(rkey(e.name.replace(/\.md$/, "")), file);
+    }
+  };
+  walk("");
+  return LOCAL_RECIPES;
+}
+// title, else the docsUrl slug, else either one as a prefix of the other
+function recipeFile(title, docsUrl) {
+  const idx = localRecipes();
+  if (!idx.size) return undefined;
+  const slug = (docsUrl || "").replace(/\/+$/, "").split("/").pop();
+  for (const k of [rkey(title), rkey(slug)]) if (k && idx.has(k)) return idx.get(k);
+  const t = rkey(title);
+  if (t.length >= 12) for (const [k, v] of idx) if (k.startsWith(t) || t.startsWith(k)) return v;
+  return undefined;
+}
+
 // ── find what to read ─────────────────────────────────────────────────────────
 
 // Browse the docs tree — deterministic. menuUrl alone orients (children + counts);
@@ -116,36 +150,91 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
   return { ...s, next: `wx.bash("grep -in 'term' ${s.path} | head -40")   // one line per node — or re-browse with a filter` };
 }
 
-// Semantic search — ranks, never says "no match". The reduced hits come back inline
-// AND the full raw content is saved for grep/window follow-ups. { type } picks the portal:
-// REST (default) · WIX_HEADLESS. Each hit lists the worked requests the docs publish for it
-// as { title, line } into the saved file — read one with read_file(path, offset: <its line>).
-async function search(term, { type = "REST", max = 5, lines = 0 } = {}) {
-  const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
-    // lines_in_each_result 0 skips the server's per-section budget, which otherwise cuts every
-    // code example after the first 30 lines and the rest after 5 — the saved file would carry
-    // stubs instead of the working requests the hits point at
-    { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });
+// Semantic search — ranks, never says "no match". The reduced hits come back inline AND the full
+// raw content is saved for grep/window follow-ups. { type } picks the corpus, one per request:
+// REST (default) · SKILLS · WIX_HEADLESS · SDK · VELO · CLI · WDS · BUILD_APPS · OVERVIEW ·
+// BUSINESS_SOLUTIONS. A REST search also runs SKILLS — the management recipes rank as their own
+// hits, ahead of the methods, and land in the saved file whole. Each method hit lists the worked
+// requests the docs publish for it; every line number reads with read_file(path, offset: <line>).
+async function search(term, { type = "REST", max = 5, lines = 0, recipes = type === "REST" } = {}) {
+  const ask = (document_type, maximum_results) =>
+    post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
+      // lines_in_each_result 0 skips the server's per-section budget, which otherwise cuts every
+      // code example after the first 30 lines and the rest after 5, and every recipe at 20 —
+      // the saved file would carry stubs instead of the requests and flows the hits point at
+      { search_term: term, document_type, maximum_results, lines_in_each_result: lines });
+  const [main, skills] = await Promise.all([ask(type, max),
+    recipes ? ask("SKILLS", 3).catch(() => null) : null]);   // a recipe corpus miss must not fail the search
+  const recipeText = skills?.content ? skills.content.trimEnd() + "\n" : "";
+  const content = recipeText + main.content;
   const nl = [];   // newline offsets — a match's char offset becomes its line in the saved file
   for (let i = content.indexOf("\n"); i >= 0; i = content.indexOf("\n", i + 1)) nl.push(i);
   const lineAt = (off) => { let lo = 0, hi = nl.length; while (lo < hi) { const m = (lo + hi) >> 1; nl[m] < off ? lo = m + 1 : hi = m; } return lo + 1; };
-  let cursor = 0;
-  const hits = content.split(/\n---\n+(?=#### )/).map(b => {
+  // recipes are articles — no "# Method:" header, no code-example delimiters, and no fixed body
+  // shape. Two things every one of them has: headings, and the endpoints it calls. Those are the
+  // outline — enough to tell whether this is the recipe for the task without reading 400 lines.
+  const recipeHits = !recipeText ? [] : recipeText.split(/\n---\n+(?=#### )/).map(b => {
+    const at = content.indexOf(b), rows = b.split("\n");
+    const steps = [], calls = [];
+    let verb = null;
+    for (const t of rows) {
+      if (/^#{1,4} /.test(t) && !/^#### \[|^## (Resource|Article|Article Link|Article Content):/.test(t))
+        steps.push(t.replace(/^#+ /, "").trim().slice(0, 52));
+      const c = t.match(/curl\s+-X\s+(GET|POST|PATCH|PUT|DELETE)/i);
+      const u = t.match(/https:\/\/www\.wixapis\.com\/[^\s"'`)\\]+/);
+      if (c && !u) { verb = c[1].toUpperCase(); continue; }   // curl -X VERB, url on the next line
+      if (!u) continue;
+      const v = (c && c[1].toUpperCase()) || (t.match(/\b(GET|POST|PATCH|PUT|DELETE)\b/) || [])[1] || verb || "";
+      verb = null;
+      const call = (v + " " + u[0].replace(/\{[^}]*\}|<[^>]*>/g, "{id}")).trim();
+      if (!calls.includes(call)) calls.push(call);
+    }
+    const title = (b.match(/^## Resource: (.+)$/m) || [])[1];
+    const docsUrl = (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1];
+    return { recipe: title, docsUrl,
+             ...(recipeFile(title, docsUrl) && { file: recipeFile(title, docsUrl) }),
+             line: at < 0 ? 1 : lineAt(at), lines: rows.length,
+             ...(steps.length && { steps: steps.slice(0, 6) }),
+             ...(calls.length && { calls: calls.slice(0, 4) }) };
+  }).filter(h => h.docsUrl && h.recipe);
+  let cursor = recipeText.length;
+  const hits = main.content.split(/\n---\n+(?=#### )/).map(b => {
     const start = content.indexOf(b, cursor); cursor = start + b.length;
     const examples = [...b.matchAll(/--- Code Example: (.+?) ---/g)]
       .map(m => ({ title: m[1].trim(), line: lineAt(start + m.index) }));
+    const docsUrl = (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1];
+    const method = (b.match(/^# Method: (.+)$/m) || [])[1];
+    // the REST corpus mixes guides in with the methods — an article has no method header, so
+    // name it from its own title rather than returning a row of nulls
+    if (!method) return { article: (b.match(/^## (?:Resource|Article): (.+)$/m) || [])[1], docsUrl,
+                          line: start < 0 ? 1 : lineAt(start) };
     return {
-    method:   (b.match(/^# Method: (.+)$/m) || [])[1],
+    method,
     endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // "VERB url" — read the verb + url; call wx.<verb>(url, body, token)
-    docsUrl:  (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
+    docsUrl,
     gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
       .trim().replace(/\s+/g, " ").slice(0, 220),
     ...(examples.length && { examples }),
   }; }).filter(h => h.docsUrl);
   const saved = save("search-" + term.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40) + ".md", content);
-  if (!hits.length) return clip({ ...saved, head: content.slice(0, 1200),
+  if (!hits.length && !recipeHits.length) return clip({ ...saved, head: content.slice(0, 1200),
     note: `no method blocks parsed — raw head above; wx.bash("grep -in 'term' ${saved.path}") for the rest` });
-  return clip({ ...saved, hits });
+  // one URL, one row: a long article is indexed in chunks that rank separately, and a stray skills
+  // page sits in the REST corpus, so the same page can rank two or three times
+  const seen = new Set();
+  const recipeRows = recipeHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
+  const uniq = hits.filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
+  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), hits: uniq };
+  // over budget, shed enrichment rather than structure — clip would drop the whole shape, and
+  // every title, URL and line number stays useful with the outlines gone
+  for (const shed of [() => recipeRows.forEach(r => delete r.calls),
+                      () => recipeRows.forEach(r => delete r.steps),
+                      () => uniq.forEach(h => { if (h.examples) h.examples = h.examples.slice(0, 3); }),
+                      () => uniq.forEach(h => delete h.examples)]) {
+    if (JSON.stringify(out).length <= BUDGET) break;
+    shed();
+  }
+  return clip(out);
 }
 
 // ── read a page (docs pages and recipes alike) ────────────────────────────────


### PR DESCRIPTION
The management recipes are indexed as their own corpus and reachable from the search endpoint we already call — `document_type: "SKILLS"`, one type per request. A REST search now fires SKILLS alongside it.

### Why

Two days ago the fix for "the agent never calls `wx.mgmtRecipes`" was a note in the skill saying an admin task starts at the recipes, justified by a mechanism: *"Search runs over the API reference alone — the recipes are a separate corpus, so no search returns one."*

**That mechanism was wrong.** I wrote it off a stale `igor-tools` checkout whose `DocumentType` union predates `SKILLS` and `OVERVIEW`; `origin/master` has both, and the live API's own error message enumerates them. Searching `SKILLS` for the query from the reported run returns `stores/skills/update-product-with-options-catalog-v3` as the #1 hit at relevance 0.716 — the recipe that would have solved it.

So instead of telling the agent to remember a second call, the recipe now arrives from the call it already makes.

### What it returns

```json
{ "path": ".agents/…/tmp/search-update-product-variant-price-and-choice-.md",
  "bytes": 114559, "lines": 2607,
  "recipes": [
    { "recipe": "Update Product with Options (Catalog V3)",
      "docsUrl": "https://dev.wix.com/docs/…/stores/skills/update-product-with-options-catalog-v3", "line": 1 },
    { "recipe": "Create Product (Catalog V3)", "docsUrl": "…/create-product-catalog-v3", "line": 412 },
    { "recipe": "Add to Cart",                 "docsUrl": "…/purchase-flow/skills/add-to-cart", "line": 704 } ],
  "hits": [ … Update Product, Update Product Variants, Create Product … ] }
```

Recipes are **articles**, not methods — no `# Method:` header, no `--- Code Example: --- ` delimiters — so they get their own parse, titled from `## Resource:`. With `lines_in_each_result: 0` they land in the saved file whole, so following one is a `read_file`, not another fetch.

### Cost and safety

- The two requests run **concurrently**: 1,645 ms total, 114 KB saved, 3,044-char inline return.
- A SKILLS failure is caught and never fails the search.
- A non-REST `type` skips it, as does `{ recipes: false }`.
- Method hits are unchanged: still 5 examples on the top hit, the choice-images body still complete and uncollapsed.

### Docs

The false sentence is gone. The intro note now says a search returns the matching recipes ranked ahead of the methods and `wx.mgmtRecipes` browses the index by category — and the Learn Wix subsection no longer implies the call is the only way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)