### PR TITLE
feat(wix-vibe-headless): rentals, inside the bookings vertical

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -120,6 +120,7 @@ Each vertical's UI + helpers ship in `references/<vertical>/app/`; copy that dir
 |---|---|---|
 | Online store: products, categories, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` |
 | Appointments: services, time slots, booking, checkout — **and the form attached to a bookable service** | **bookings** | `references/bookings/INSTRUCTIONS.md` |
+| Rentals: a room, vehicle or item hired for a length **the customer picks** (by the hour or by the day) — Wix Rentals runs on the Bookings APIs, so it is the same vertical | **bookings** | `references/bookings/INSTRUCTIONS.md` ("Rentals") |
 | Blog/news: post feed, post pages, categories, tags | **blog** | `references/blog/INSTRUCTIONS.md` |
 | Events: browse, event page, RSVP, ticketing — **an RSVP is here, not `forms`**, even for one occasion with no tickets | **events** | `references/events/INSTRUCTIONS.md` |
 | Portfolio/showcase: collections, projects, media galleries | **portfolio** | `references/portfolio/INSTRUCTIONS.md` |

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -225,6 +225,49 @@ the areas they sit in:
 - eCommerce checkout (paid bookings): https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md
 - Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
 
+## Rentals — the same client, one extra step
+
+**Wix Rentals has no APIs of its own.** A rental is a Bookings *service* with rentals-specific
+field values, so this whole client works on it: the catalog read, the booking form, and the
+`createBooking → cart → checkout` chain are all unchanged. `rest/wix-bookings-rentals.js` and
+`hooks/useRentalDuration.js` carry the only differences.
+
+**What tells a rental apart — the DATA, never the brief.** A service carries either a fixed
+session length or a duration RANGE the customer picks within; the two are mutually exclusive:
+
+```js
+import { isRental, rentalDuration, rentalRateLabel } from "@/rest/wix-bookings-rentals";
+isRental(service)   // true only when schedule.availabilityConstraints.durationRange is present
+```
+
+A 60-minute yoga class and a 60-minute massage are **not** rentals even though a massage is
+`type: "APPOINTMENT"` exactly like a rental is. Never branch on the service's name, its
+category, or what the brief called it.
+
+**The extra step.** An ordinary service is one choice (a slot). A rental is two: pick a START,
+then pick HOW LONG — and the price follows the length.
+
+```jsx
+const detail = useServiceDetail(serviceId);                        // service + start times
+const rental = useRentalDuration(detail.service, detail.selectedSlot, detail.timeZone);
+
+<SlotPicker … />                                                   {/* pick a start, as ever */}
+{rental.isRental && <RentalDurationPicker rental={rental} />}      {/* then pick a length */}
+```
+
+Book with `rental.endDate` as the slot's `localEndDate`; everything else in the booking call is
+identical.
+
+**Hard rules on top of the ones below:**
+
+- **Filter every catalog read by `appId`.** `queryRentals()` does it. On a site with both apps
+  an unfiltered `queryServices` returns haircuts next to meeting rooms.
+- **Never compute the total yourself.** A rental is charged as a rate, hourly at per-minute
+  granularity — 90 minutes of a $10/hour room is $15. `useRentalDuration` prices the chosen
+  length on the server; multiplying the displayed rate disagrees with checkout.
+- **Show the total before the customer commits.** A rate alone is not a price.
+- **One unit type per service.** A room rented by the hour *and* by the day is two services.
+
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped

--- a/skills/wix-vibe-headless/references/bookings/app/components/RentalDurationPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/RentalDurationPicker.jsx
@@ -1,0 +1,67 @@
+// Rental length picker — pure UI. The options, the selection handler and the priced total all
+// come from useRentalDuration; no data wiring lives here.
+//
+// Renders the step an ordinary service doesn't have: the customer has already picked a START
+// (SlotPicker), and now picks HOW LONG. The running total sits beside the choices because a
+// rental's cost depends on the length — showing only a rate per hour leaves the customer
+// discovering the real number at checkout.
+//
+// Show this only when `rental.isRental` — an appointment or class has no length to choose.
+// Styled with base44 design tokens (shadcn Tailwind classes).
+const optionCls = "py-2.5 px-3 cursor-pointer text-sm font-body border rounded-sm transition-colors";
+const idle = "border-border bg-card text-foreground hover:border-foreground/40";
+const active = "border-primary bg-primary text-primary-foreground";
+
+/**
+ * @param {{
+ *   rental: object,        // the whole return of useRentalDuration
+ *   startLabel?: string,   // e.g. "Fri 4 Sep, 10:00" — what the customer already picked
+ * }} props
+ */
+export default function RentalDurationPicker({ rental, startLabel }) {
+  const { isRental, duration, options, selected, select, price, loading, error } = rental;
+  if (!isRental) return null;
+
+  const unitWord = duration?.unit === "DAY" ? "days" : "hours";
+
+  return (
+    <div className="mb-6">
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          How long{startLabel ? ` from ${startLabel}` : ""}
+        </p>
+        {price?.total ? (
+          <p className="text-sm font-semibold text-foreground">{price.total}</p>
+        ) : selected ? (
+          <p className="text-sm text-muted-foreground">Pricing…</p>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading available {unitWord}…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : !options.length ? (
+        // An empty list is a real answer: this start has no bookable length. Say so, and leave
+        // the start picker in place so the customer can choose another one.
+        <p className="text-sm text-muted-foreground">
+          Nothing available from that start — pick another time.
+        </p>
+      ) : (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {options.map((option) => (
+            <button
+              key={option.localEndDate}
+              type="button"
+              aria-pressed={selected?.localEndDate === option.localEndDate}
+              className={`${optionCls} ${selected?.localEndDate === option.localEndDate ? active : idle}`}
+              onClick={() => select(option)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/hooks/useRentalDuration.js
+++ b/skills/wix-vibe-headless/references/bookings/app/hooks/useRentalDuration.js
@@ -1,0 +1,126 @@
+// useRentalDuration — the extra step a rental has and an ordinary service doesn't: once the
+// customer has picked a START, they pick how LONG, and the price follows the length.
+//
+// Compose it with useServiceDetail rather than replacing it. That hook already loads the
+// service, lists start times, holds the contact fields and runs bookAndCheckout — all of which
+// a rental uses unchanged. This adds only the second choice and its price:
+//
+//   const detail = useServiceDetail(serviceId);                       // service + start slots
+//   const rental = useRentalDuration(detail.service, detail.selectedSlot, detail.timeZone);
+//   // render detail.slots → customer picks a start → render rental.options → picks a length
+//   // book with rental.endDate as the slot's localEndDate
+//
+// Returns empty options for a non-rental service, so a page that renders both kinds needs no
+// branch of its own — `isRental(service)` decides whether to show the length step at all.
+import { useCallback, useEffect, useState } from "react";
+import {
+  dailyEndOptions,
+  isRental,
+  listEndOptions,
+  previewRentalPrice,
+  rentalDuration,
+} from "@/rest/wix-bookings-rentals";
+
+/** "1 hr 30 min" / "2 days" — the label for one length option. */
+function lengthLabel(startLocal, endLocal, unit) {
+  if (unit === "DAY") {
+    const days = Math.round((new Date(`${endLocal}Z`) - new Date(`${startLocal}Z`)) / 86400000);
+    return days === 1 ? "1 day" : `${days} days`;
+  }
+  const minutes = Math.round((new Date(`${endLocal}Z`) - new Date(`${startLocal}Z`)) / 60000);
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return [h ? `${h} hr` : "", m ? `${m} min` : ""].filter(Boolean).join(" ") || "0 min";
+}
+
+/**
+ * @param {object|null} service   The service from useServiceDetail — may be null while loading.
+ * @param {object|null} startSlot The slot the customer picked (its localStartDate is the start).
+ * @param {string|null} timeZone  The zone the slot list came back in.
+ * @returns {{
+ *   isRental: boolean,
+ *   duration: { unit: "HOUR"|"DAY", min: number, max: number, step: number }|null,
+ *   options: { localEndDate: string, label: string }[],
+ *   selected: object|null,
+ *   select: (option: object) => void,
+ *   endDate: string|null,   // pass as the booking's localEndDate
+ *   price: { total: string, currency: string|null }|null,
+ *   loading: boolean,
+ *   error: string|null,
+ * }}
+ */
+export function useRentalDuration(service, startSlot, timeZone) {
+  const [options, setOptions] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [price, setPrice] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const rental = isRental(service);
+  const duration = rentalDuration(service);
+  const start = startSlot?.localStartDate ?? null;
+  const serviceId = service?._id || service?.id || null;
+
+  // A new start invalidates the lengths that were valid for the previous one.
+  useEffect(() => {
+    setSelected(null);
+    setPrice(null);
+    if (!rental || !start || !serviceId) {
+      setOptions([]);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    const load = duration.unit === "DAY"
+      ? dailyEndOptions(service, { localStartDate: start, timeZone })
+          .then((list) => list.map((o) => ({ localEndDate: o.localEndDate, label: lengthLabel(start, o.localEndDate, "DAY") })))
+      : listEndOptions(serviceId, { localStartDate: start, timeZone })
+          .then(({ endOptions }) =>
+            endOptions.map((o) => ({ localEndDate: o.localEndDate, label: lengthLabel(start, o.localEndDate, "HOUR") })),
+          );
+    load
+      .then((list) => {
+        if (!alive) return;
+        setOptions(list);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        // Fail loudly — an empty length list and a failed call look identical on screen
+        // otherwise, and the second one is a bug the visitor should not absorb silently.
+        setError(e?.message || "Could not load available lengths.");
+        setOptions([]);
+        setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rental, serviceId, start, timeZone, duration?.unit]);
+
+  // The price comes from the server for the chosen length — never multiply the rate locally.
+  const select = useCallback(
+    (option) => {
+      setSelected(option);
+      setPrice(null);
+      if (!option || !serviceId || !start || !timeZone) return;
+      previewRentalPrice(serviceId, { localStartDate: start, localEndDate: option.localEndDate, timeZone })
+        .then((p) => setPrice({ total: p.total, currency: p.currency }))
+        .catch((e) => setError(e?.message || "Could not price that length."));
+    },
+    [serviceId, start, timeZone],
+  );
+
+  return {
+    isRental: rental,
+    duration,
+    options,
+    selected,
+    select,
+    endDate: selected?.localEndDate ?? null,
+    price,
+    loading,
+    error,
+  };
+}

--- a/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-rentals.js
+++ b/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-rentals.js
@@ -1,0 +1,230 @@
+import { wixApiRequest } from "./wix-client.js";
+import { listAvailableSlots } from "./wix-bookings-services.js";
+
+/**
+ * Wix Rentals — a DELTA on `wix-bookings-services.js`, not a replacement.
+ *
+ * Wix Rentals has no APIs of its own. A rental is a Bookings **service** with rentals-specific
+ * field values, so the catalog read, the booking form, and the whole
+ * `createBooking → cart → checkout` chain in `wix-bookings-checkout.js` are UNCHANGED. Only
+ * three things differ, and they are all here:
+ *
+ *   1. every catalog read filters by the rentals `appId`, or rentals and appointments interleave
+ *   2. the customer picks the LENGTH, so availability is two calls: start times, then the valid
+ *      ends for the chosen start
+ *   3. price is a rate per unit, so the total for a chosen length comes from the server
+ *
+ * What makes a service a rental (from the docs' own mapping — nothing is inferred):
+ *   type      always "APPOINTMENT"
+ *   appId     always RENTALS_APP_ID
+ *   schedule.availabilityConstraints.durationRange   replaces `sessionDurations`
+ *                                                    — MUTUALLY EXCLUSIVE, one or the other
+ *   primaryResourceType   a resource type id, not staff — availability comes from its resources
+ *   payment.rateType      always "FIXED", charged per hour or per day
+ *
+ * ⚠️ Because the two constraint fields are mutually exclusive, `isRental()` below is a reliable
+ * test on the DATA. Never decide "this is a rental" from the brief, the service name, or a
+ * category — a 60-minute yoga class and a meeting room rented for 1–8 hours are told apart by
+ * which constraint the service carries, and nothing else.
+ *
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/rentals/wix-rentals-and-the-bookings-apis.md
+ * docs: https://dev.wix.com/docs/api-reference/business-solutions/rentals/about-wix-rentals-availability.md
+ */
+
+/** The Wix Rentals app. Used twice: to filter the catalog, and as the cart's catalogReference.appId. */
+export const RENTALS_APP_ID = "ff5d6eb1-65e4-4f9a-8b14-64d34c12cc2e";
+
+/** The Wix Bookings app — the other half of a mixed site. */
+export const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97";
+
+/**
+ * Is this service a rental? True when it carries a duration RANGE the customer picks within,
+ * rather than a fixed session length. This is the only correct test.
+ * @param {object} service
+ * @returns {boolean}
+ */
+export function isRental(service) {
+  return Boolean(service?.schedule?.availabilityConstraints?.durationRange);
+}
+
+/**
+ * The rental's unit and bounds, or null for an ordinary service.
+ * Hourly bounds are MINUTES (30–1440), daily bounds are DAYS (1–8).
+ * @param {object} service
+ * @returns {{ unit: "HOUR"|"DAY", min: number, max: number, step: number }|null}
+ */
+export function rentalDuration(service) {
+  const range = service?.schedule?.availabilityConstraints?.durationRange;
+  if (!range) return null;
+  if (range.unitType === "DAY") {
+    return {
+      unit: "DAY",
+      min: range.dayOptions?.minDurationInDays ?? 1,
+      max: range.dayOptions?.maxDurationInDays ?? 1,
+      step: 1,
+    };
+  }
+  return {
+    unit: "HOUR",
+    min: range.hourOptions?.minDurationInMinutes ?? 30,
+    max: range.hourOptions?.maxDurationInMinutes ?? 1440,
+    step: 30,
+  };
+}
+
+/**
+ * Query rentals only. On a site that has both apps an unfiltered `queryServices` returns
+ * haircuts next to meeting rooms, so this is not optional — it is the same query with the
+ * rentals `appId` on the filter.
+ *
+ * Pass `appId: BOOKINGS_APP_ID` to get the ordinary services instead, on a mixed site.
+ * @param {{ limit?: number, offset?: number, appId?: string }} [options]
+ * @returns {Promise<{ services: object[], total: number, nextOffset: number|null }>}
+ */
+export async function queryRentals({ limit = 100, offset = 0, appId = RENTALS_APP_ID } = {}) {
+  const res = await wixApiRequest("/bookings/v2/services/query", {
+    method: "POST",
+    body: { query: { filter: { hidden: false, appId }, paging: { limit, offset } } },
+  });
+  const services = res?.services ?? [];
+  const total = res?.pagingMetadata?.total ?? services.length;
+  const loaded = offset + services.length;
+  return { services, total, nextOffset: loaded < total ? loaded : null };
+}
+
+/**
+ * Start times for a rental — step 1 of 2.
+ *
+ * A rental is an APPOINTMENT-typed service, so this is the same availability call an
+ * appointment uses; what comes back are the times a rental may START. The customer then picks
+ * how long, which is `listEndOptions` below.
+ * @param {string} serviceId
+ * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
+ * @returns {Promise<{ slots: object[], nextCursor: string|null, timeZone: string|null }>}
+ */
+export function listRentalStartSlots(serviceId, options = {}) {
+  return listAvailableSlots(serviceId, options);
+}
+
+/**
+ * The valid END times for a chosen start — step 2 of 2, HOURLY rentals only.
+ *
+ * Each entry is a TimeSlot sharing `localStartDate` with the request and varying only in
+ * `localEndDate`, sorted shortest first. The service's maximum duration always caps the list,
+ * so a `maxLocalEndDate` beyond it is ignored rather than rejected.
+ *
+ * ⚠️ Hourly only. A DAILY rental has no end options — its lengths are whole days, so walk
+ * consecutive days from the chosen start instead (`dailyEndOptions` below).
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slot-end-options.md
+ * @param {string} serviceId
+ * @param {{ localStartDate: string, maxLocalEndDate?: string, timeZone?: string }} options
+ * @returns {Promise<{ endOptions: object[], timeZone: string|null }>}
+ */
+export async function listEndOptions(serviceId, { localStartDate, maxLocalEndDate, timeZone } = {}) {
+  if (!localStartDate) throw new Error("listEndOptions requires localStartDate (local 'YYYY-MM-DDThh:mm:ss').");
+  const res = await wixApiRequest("/_api/service-availability/v2/time-slots/end-options", {
+    method: "POST",
+    body: {
+      serviceId,
+      localStartDate,
+      ...(maxLocalEndDate ? { maxLocalEndDate } : {}),
+      ...(timeZone ? { timeZone } : {}),
+    },
+  });
+  return { endOptions: res?.endOptions ?? [], timeZone: res?.timeZone ?? null };
+}
+
+/**
+ * The lengths a DAILY rental can run for from a chosen start day — the daily counterpart to
+ * `listEndOptions`. A day's slot list is the availability, so this walks forward from the start
+ * and stops at the first day that has none: a 3-day rental needs all 3 days free, and a gap
+ * means the longer options are not bookable however far out the calendar goes.
+ *
+ * Returns one entry per bookable length, `{ days, localEndDate }`, shortest first.
+ * `localEndDate` is midnight of the day AFTER the last rented day — the end boundary is
+ * exclusive, which is the same convention the catalog's availability window uses.
+ * @param {object} service  A rental service (daily).
+ * @param {{ localStartDate: string, timeZone?: string }} options
+ * @returns {Promise<{ days: number, localEndDate: string }[]>}
+ */
+export async function dailyEndOptions(service, { localStartDate, timeZone } = {}) {
+  const duration = rentalDuration(service);
+  if (!duration || duration.unit !== "DAY") {
+    throw new Error("dailyEndOptions expects a DAY-unit rental — use listEndOptions for hourly.");
+  }
+  const serviceId = service._id || service.id;
+  const startDay = localStartDate.slice(0, 10);
+  const dayAfter = (isoDay, n) => {
+    const d = new Date(`${isoDay}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const out = [];
+  for (let days = 1; days <= duration.max; days++) {
+    const dayToCheck = dayAfter(startDay, days - 1);
+    const { slots } = await listAvailableSlots(serviceId, {
+      fromLocalDate: `${dayToCheck}T00:00:00`,
+      toLocalDate: `${dayAfter(dayToCheck, 1)}T00:00:00`,
+      timeZone,
+      limit: 1,
+    });
+    if (!slots.length) break; // a gap — every longer option is unbookable too
+    if (days >= duration.min) out.push({ days, localEndDate: `${dayAfter(startDay, days)}T00:00:00` });
+  }
+  return out;
+}
+
+/**
+ * The price for a chosen length, from the server.
+ *
+ * ⚠️ Never compute this client-side. A rental is charged as a RATE — per hour or per day — and
+ * hourly is calculated at per-minute granularity, so a 90-minute rental of a $10/hour room is
+ * $15. Multiplying a displayed base price by a rounded number of hours quietly disagrees with
+ * what the customer is charged at checkout.
+ *
+ * ⚠️ Omitting the local dates or the time zone does NOT error — it returns a duration-blind
+ * price, which is the same trap in a quieter form.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/pricing/pricing-api/preview-price.md
+ * @param {string} serviceId
+ * @param {{ localStartDate: string, localEndDate: string, timeZone: string, numberOfParticipants?: number }} options
+ * @returns {Promise<{ total: string, currency: string|null, raw: object }>}
+ */
+export async function previewRentalPrice(serviceId, { localStartDate, localEndDate, timeZone, numberOfParticipants = 1 } = {}) {
+  if (!localStartDate || !localEndDate || !timeZone) {
+    throw new Error("previewRentalPrice requires localStartDate, localEndDate and timeZone — without them the price ignores the duration.");
+  }
+  const res = await wixApiRequest("/bookings/v2/pricing/v2/pricing/preview", {
+    method: "POST",
+    body: {
+      bookingLineItems: [{ serviceId, localStartDate, localEndDate, timeZone, numberOfParticipants }],
+    },
+  });
+  const info = res?.priceInfo ?? {};
+  const total = info.totalPrice ?? info.total ?? {};
+  return {
+    total: total.formattedValue ?? (total.value != null ? String(total.value) : ""),
+    currency: total.currency ?? null,
+    raw: info,
+  };
+}
+
+/**
+ * A rental's rate, ready to render — "$10 / hour" or "$120 / day".
+ * `servicePriceLabel` in `lib/serviceFacts.js` renders the same number as a flat price, which
+ * reads as the whole cost of the rental rather than its rate.
+ * @param {object} service
+ * @returns {string}
+ */
+export function rentalRateLabel(service) {
+  const duration = rentalDuration(service);
+  if (!duration) return "";
+  const price = service?.payment?.fixed?.price;
+  const money =
+    price?.formattedValue ||
+    (price?.currency && price?.value != null
+      ? new Intl.NumberFormat(undefined, { style: "currency", currency: price.currency }).format(Number(price.value))
+      : "");
+  if (!money) return "";
+  return `${money} / ${duration.unit === "DAY" ? "day" : "hour"}`;
+}

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -101,6 +101,47 @@ await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: servic
 Both bulk calls report per-item `success`/`error` — retry only the failed items **once** with the
 same body; don't loop and don't re-create the ones that already succeeded.
 
+## Rentals
+
+`seed-rentals.js` is the rentals half — the same transport, a different create order and payload.
+Wix Rentals has no APIs of its own, so a rental is a Bookings service with rentals-specific
+field values.
+
+```js
+const seed = require("…/references/bookings/seed/seed-rentals.js");
+await seed.setupRentals(ctx, {
+  resourceTypeName: "Meeting rooms",
+  resources: ["Room A", "Room B"],              // parallel capacity = MORE RESOURCES
+  rentals: [
+    { name: "Meeting room, hourly", description: "…", price: 25, unit: "HOUR", min: 60, max: 480 },
+    { name: "Meeting room, daily",  description: "…", price: 180, unit: "DAY", min: 1, max: 5 },
+  ],
+});
+// → { resourceType, resources, services, ok, problems }
+```
+
+`price` is a RATE — per hour or per day — not the cost of a rental.
+Hourly `min`/`max` are MINUTES (30–1440); daily are DAYS (1–8).
+
+**`ok` must be true.** `problems` is the read-back check: a service created without `appId` or
+without `durationRange` still returns 200 and is simply a plain Bookings service from then on.
+
+### The four traps this seed handles
+
+- **Install Rentals ONLY.** It provisions the Bookings infrastructure it runs on; installing
+  Wix Bookings as well is redundant.
+- **`appId` is immutable after create.** A service created without it is a plain Bookings
+  service forever — there is no update that converts it.
+- **Order is load-bearing: resource type → resources → services.** A service whose resource
+  type holds no resources has permanently empty availability, and nothing errors.
+- **Rental services do not use categories.** Unlike bookings, do not create or assign one.
+- **`serviceResources` is required** and the docs' Create Service parameter list omits it.
+  Without it the create fails `MISSING_APPOINTMENT_RESOURCES`, whose message sends you to check
+  the resource type's contents — a dead end, since it fails even when the type is populated.
+
+Resources are seeded **24/7** (no working hours) so a multi-day rental stays one booking rather
+than a multi-service group. Pass `workingHours` only when the brief names opening hours.
+
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.js
@@ -1,0 +1,258 @@
+// Rentals seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// A DELTA on seed-bookings.js: Wix Rentals has no APIs of its own, so a rental is a Bookings
+// service carrying rentals-specific field values. Everything about the transport, images and
+// error handling is the same; only the create order and the service payload differ.
+//
+// **NOT yet live-verified — transcribed from the Rentals ↔ Bookings API mapping and
+// wix-headless/references/inline-recipes/setup-rentals.md, which WAS run end to end.**
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   await seed.installRentalsApp(ctx);          // installs Rentals — do NOT also install Bookings
+//
+//   // ORDER IS LOAD-BEARING: resource type → resources → services.
+//   const type = await seed.createResourceType(ctx, "Meeting rooms");
+//   await seed.createResources(ctx, type.id, ["Room A", "Room B"]);   // capacity = MORE RESOURCES
+//   await seed.createRentals(ctx, [
+//     { name: "Meeting room, hourly", description: "…", price: 25,
+//       resourceTypeId: type.id, unit: "HOUR", min: 60, max: 480 },
+//     { name: "Meeting room, daily",  description: "…", price: 180,
+//       resourceTypeId: type.id, unit: "DAY",  min: 1,  max: 5 },
+//   ]);
+//
+// ⚠️ THREE THINGS THAT SILENTLY BREAK A RENTAL, all handled below:
+//   1. `appId` is IMMUTABLE after create. A service created without it is a plain Bookings
+//      service forever — there is no update that turns it into a rental.
+//   2. Resources must exist BEFORE the service. A service whose resource type holds no
+//      resources has permanently empty availability, with no error anywhere.
+//   3. Rental services do NOT use categories. Unlike bookings, do not create or assign one.
+//
+// Images and the app-install helper are reused from seed-bookings.js — require both.
+// Source recipe (authoritative): wix-headless/references/inline-recipes/setup-rentals.md.
+
+const API = "https://www.wixapis.com";
+
+/** The Wix Rentals app. Installing it provisions the Bookings infrastructure it runs on. */
+const RENTALS_APP_ID = "ff5d6eb1-65e4-4f9a-8b14-64d34c12cc2e";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+/**
+ * Install Wix Rentals. Idempotent.
+ * ⚠️ Install Rentals ONLY. It provisions the Bookings infrastructure automatically, so also
+ * installing Wix Bookings is redundant.
+ */
+async function installRentalsApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", {
+      body: {
+        tenant: { tenantType: "SITE", id: ctx.siteId },
+        appInstance: { appDefId: RENTALS_APP_ID, enabled: true },
+      },
+    });
+  } catch {
+    /* already installed is fine */
+  }
+}
+
+/**
+ * A resource TYPE — the kind of thing being rented ("Meeting rooms", "Vans", "Cameras").
+ * A rental service points at one of these; the individual rentable items live inside it.
+ * @returns {Promise<{ id: string, name: string }>}
+ */
+async function createResourceType(ctx, name) {
+  const res = await req(ctx, "/bookings/v2/resource-types", { body: { resourceType: { name } } });
+  const type = res?.resourceType ?? {};
+  return { id: type.id ?? type._id, name: type.name ?? name };
+}
+
+/** Existing resource types, so a re-run reuses one instead of making a duplicate. */
+async function queryResourceTypes(ctx) {
+  const res = await req(ctx, "/bookings/v2/resource-types/query", { body: { query: {} } });
+  return (res?.resourceTypes ?? []).map((t) => ({ id: t.id ?? t._id, name: t.name }));
+}
+
+/** Get a resource type by name, creating it only if it isn't there. Additive. */
+async function ensureResourceType(ctx, name) {
+  const existing = (await queryResourceTypes(ctx)).find((t) => t.name === name);
+  return existing ?? createResourceType(ctx, name);
+}
+
+/**
+ * The individual rentable items inside a type — Room A, Room B, Van 1.
+ *
+ * ⚠️ PARALLEL CAPACITY COMES FROM MORE RESOURCES, not from a capacity number: two rooms that
+ * can be booked at the same time are two resources.
+ *
+ * ⚠️ Seeded 24/7 on purpose — no `workingHoursSchedules`. A resource with working hours makes a
+ * multi-day rental span several bookable windows, which Wix then models as a multi-service
+ * group booking instead of one booking. Pass `workingHours` only when the brief names opening
+ * hours and you accept that.
+ * @returns {Promise<{ id: string, name: string }[]>}
+ */
+async function createResources(ctx, resourceTypeId, names, { workingHours } = {}) {
+  const out = [];
+  for (const name of names) {
+    const res = await req(ctx, "/bookings/v2/resources", {
+      body: {
+        resource: {
+          name,
+          resourceType: { id: resourceTypeId },
+          ...(workingHours ? { workingHoursSchedules: workingHours } : {}),
+        },
+      },
+    });
+    const r = res?.resource ?? {};
+    out.push({ id: r.id ?? r._id, name: r.name ?? name });
+  }
+  return out;
+}
+
+/**
+ * Build one rental service payload.
+ *
+ * Field values that MAKE it a rental (all four are required together):
+ *   type: "APPOINTMENT"          — rentals are always appointment-typed
+ *   appId: RENTALS_APP_ID        — immutable after create
+ *   durationRange                — replaces sessionDurations; the two are mutually exclusive
+ *   serviceResources +           — which resource type supplies availability
+ *   primaryResourceType
+ *
+ * Hourly bounds are MINUTES (30–1440); daily bounds are DAYS (1–8). One service = one unit
+ * type: to rent the same room by the hour AND by the day, create two services.
+ */
+function buildRental(s) {
+  const unit = s.unit === "DAY" ? "DAY" : "HOUR";
+  const durationRange =
+    unit === "DAY"
+      ? { unitType: "DAY", dayOptions: { minDurationInDays: s.min ?? 1, maxDurationInDays: s.max ?? 5 } }
+      : { unitType: "HOUR", hourOptions: { minDurationInMinutes: s.min ?? 60, maxDurationInMinutes: s.max ?? 480 } };
+
+  return {
+    type: "APPOINTMENT",
+    appId: RENTALS_APP_ID,
+    name: s.name,
+    description: s.description ?? "",
+    ...(s.tagLine ? { tagLine: s.tagLine } : {}),
+    hidden: false,
+    // A rental is priced as a RATE per unit of time — the number below is per hour or per day,
+    // and Wix multiplies it by the length the customer picks.
+    payment: {
+      rateType: "FIXED",
+      fixed: { price: { value: String(s.price ?? 0), currency: s.currency ?? "USD" } },
+      options: { online: true, inPerson: false },
+    },
+    schedule: { availabilityConstraints: { durationRange } },
+    // Without serviceResources the create fails MISSING_APPOINTMENT_RESOURCES, and the error
+    // text sends you to check the resource type's contents — a dead end, since it fails even
+    // when the type is fully populated. The docs' Create Service parameter list omits it.
+    serviceResources: [{ resourceType: { id: s.resourceTypeId } }],
+    primaryResourceType: { id: s.resourceTypeId },
+    locations: [{ type: "BUSINESS" }],
+  };
+}
+
+/**
+ * Create rental services. Additive — an existing service with the same name is left alone.
+ * @returns {Promise<{ id: string, name: string, unit: string, revision: string }[]>}
+ */
+async function createRentals(ctx, rentals) {
+  const existing = await req(ctx, "/bookings/v2/services/query", {
+    body: { query: { filter: { appId: RENTALS_APP_ID } } },
+  }).catch(() => ({ services: [] }));
+  const byName = new Map((existing.services ?? []).map((s) => [s.name, s]));
+
+  const out = [];
+  for (const spec of rentals) {
+    const already = byName.get(spec.name);
+    if (already) {
+      out.push({
+        id: already.id ?? already._id,
+        name: already.name,
+        unit: already.schedule?.availabilityConstraints?.durationRange?.unitType ?? null,
+        revision: already.revision,
+        created: false,
+      });
+      continue;
+    }
+    const res = await req(ctx, "/bookings/v2/services", { body: { service: buildRental(spec) } });
+    const svc = res?.service ?? {};
+    out.push({
+      id: svc.id ?? svc._id,
+      name: svc.name ?? spec.name,
+      unit: svc.schedule?.availabilityConstraints?.durationRange?.unitType ?? null,
+      revision: svc.revision,
+      created: true,
+    });
+  }
+  return out;
+}
+
+/**
+ * Read the rentals back and confirm each one is actually a rental. A service created without
+ * `appId` or without `durationRange` still returns 200 — it is simply a plain Bookings service
+ * from then on, permanently, and this is the only check that catches it.
+ * @returns {Promise<{ ok: boolean, problems: string[] }>}
+ */
+async function verifyRentals(ctx, expectedNames) {
+  const res = await req(ctx, "/bookings/v2/services/query", {
+    body: { query: { filter: { appId: RENTALS_APP_ID } } },
+  });
+  const live = new Map((res?.services ?? []).map((s) => [s.name, s]));
+  const problems = [];
+  for (const name of expectedNames) {
+    const svc = live.get(name);
+    if (!svc) {
+      problems.push(`${name}: not returned by an appId-filtered query — it was not created as a rental`);
+      continue;
+    }
+    if (!svc.schedule?.availabilityConstraints?.durationRange) {
+      problems.push(`${name}: no durationRange — created as a plain service, and appId is immutable`);
+    }
+    if (!svc.primaryResourceType?.id) problems.push(`${name}: no primaryResourceType — availability will be empty`);
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+/**
+ * The whole rentals seed, in the one order that works.
+ * @param {object} ctx
+ * @param {{ resourceTypeName: string, resources: string[], rentals: object[] }} plan
+ */
+async function setupRentals(ctx, { resourceTypeName, resources = [], rentals = [] }) {
+  await installRentalsApp(ctx);
+  const type = await ensureResourceType(ctx, resourceTypeName);
+  const created = await createResources(ctx, type.id, resources);
+  const services = await createRentals(ctx, rentals.map((r) => ({ ...r, resourceTypeId: type.id })));
+  const check = await verifyRentals(ctx, rentals.map((r) => r.name));
+  return { resourceType: type, resources: created, services, ...check };
+}
+
+module.exports = {
+  RENTALS_APP_ID,
+  installRentalsApp,
+  createResourceType,
+  queryResourceTypes,
+  ensureResourceType,
+  createResources,
+  buildRental,
+  createRentals,
+  verifyRentals,
+  setupRentals,
+};


### PR DESCRIPTION
Syncs the rentals capability from #1178 into `wix-vibe-headless`. It goes **inside the bookings vertical**, not beside it.

## Why not its own vertical

Wix's own mapping page opens with it: *"Wix Rentals has no APIs of its own. It stores its services, bookings, and calendar events in the same entities as Wix Bookings, using field values and restrictions specific to rentals."* There is no `@wix/rentals` package, and its absence is not a missing capability.

A rental is a Bookings service with six field values:

| | rental | ordinary booking |
|---|---|---|
| `type` | always `APPOINTMENT` | `APPOINTMENT` or `CLASS` |
| `appId` | `ff5d6eb1-…` (Rentals) | `13d21c63-…` (Bookings) |
| availability | `durationRange` (`HOUR` 30–1440 min / `DAY` 1–8) | `sessionDurations` |
| who/what | `primaryResourceType` — a resource type, not staff | staff members |
| price | rate × units, per-minute granularity | flat per session |

So the catalog read, the booking form, and the whole `createBooking → cart → checkout` chain are reused **unchanged**. A separate vertical would have shipped a second copy of the checkout chain — and a site can plausibly have both (a studio that rents rooms *and* books consultations), where two copies would run side by side.

This mirrors what the vertical already does for `APPOINTMENT` vs `CLASS`: two kinds that hit different availability APIs, dispatched on `service.type`, normalized into one slot shape, with components that don't branch.

## Telling a rental apart — data, never the brief

`sessionDurations` and `durationRange` are mutually exclusive, so this is reliable:

```js
isRental(service)   // true only when schedule.availabilityConstraints.durationRange is present
```

Verified across the four kinds that could be confused:

```
hourly rental               isRental=true   {"unit":"HOUR","min":60,"max":480}   $10.00 / hour
daily rental                isRental=true   {"unit":"DAY","min":1,"max":5}       $120.00 / day
yoga CLASS                  isRental=false  null
60-min massage APPOINTMENT  isRental=false  null
```

The massage matters: it is `type: APPOINTMENT` exactly like a rental, and is correctly not one. A yoga brief cannot slide into rental behaviour, because a class has no duration range to pick within.

## What was added

| file | what it is |
|---|---|
| `rest/wix-bookings-rentals.js` | `isRental`, `rentalDuration`, `queryRentals` (appId-filtered), `listEndOptions`, `dailyEndOptions`, `previewRentalPrice`, `rentalRateLabel` |
| `hooks/useRentalDuration.js` | the second choice — composes with `useServiceDetail`, doesn't replace it |
| `components/RentalDurationPicker.jsx` | length options + the running total |
| `seed/seed-rentals.js` | resource type → resources → services, with a read-back check |

## Verified without a live site

- Endpoint shapes read from the **live spec index**, not from prose: end-options takes `serviceId` + `localStartDate` + `maxLocalEndDate`; `previewPrice` takes `bookingLineItems` carrying `localStartDate`, `localEndDate`, `timeZone`.
- The **consecutive-day walk** against a gap (truncates), a `min` of 3 days (drops shorter options), a busy start day (empty), and a month rollover (Sep 29 start, Sep 30 busy → 1 day only).
- The seed's generated payload **round-tripped** through the app-side discriminator: no `sessionDurations`, no category, `appId` and `primaryResourceType` set, and the app reads back the right unit and rate label.
- All four files syntax/parse-checked.

### A docs disagreement worth recording

The end-options page's prose refers to `durationRange.hourConfig`; Services V2 uses `hourOptions`. I checked the live Services V2 schema — `hourOptions` is present, `hourConfig` is absent — so the code reads `hourOptions`. Same call #1178 made.

## Not included

No live end-to-end run: nothing has seeded a rental on a real site, listed end options against it, and booked one. #1178's author did run the equivalent **backend** flow live and it found two real bugs, so this is the half that has been exercised in principle but not here.

`wix-headless-fast` still lacks rentals — that is the remaining sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)