### PR TITLE
wix-vibe-headless(base44): route rental businesses to bookings

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -28,7 +28,7 @@ Run this through exec_tool, exactly as written — installs all three skills, de
 | vertical | pick it when the app needs to |
 |---|---|
 | `storefront` | sell products |
-| `bookings` | take appointments or service bookings |
+| `bookings` | take appointments, service bookings, or rentals |
 | `blog` | publish articles |
 | `events` | publish events with RSVPs or ticket sales |
 | `portfolio` | showcase creative work |


### PR DESCRIPTION
The base44 vertical picker table had no rental signal, so a rental business (e.g. "rent old anime tapes") defaulted to `storefront` and missed the rentals feature that lives in the bookings vertical. This adds `rentals` as a peer in the bookings row. The main SKILL.md already routes rentals→bookings; this brings the base44 entry point (where VERTICALS is set at install) in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)