### PR TITLE
wix-vibe-headless: add a rentals vertical that maps to bookings

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -117,7 +117,10 @@ const clientId = flag('client-id');
 const metaSiteId = flag('metasite-id');
 // Verticals are the positional args — drop the flags and their values.
 const flagArgs = new Set(['--client-id', '--metasite-id', clientId, metaSiteId].filter(Boolean));
-const requested = [...new Set(argv.filter((a) => !flagArgs.has(a)))];
+// `rentals` is an alias of the Bookings vertical — Wix Rentals runs on the Bookings APIs. A rental
+// business picks `rentals` and gets the bookings scaffolds; it resolves to bookings everywhere.
+const ALIASES = { rentals: 'bookings' };
+const requested = [...new Set(argv.filter((a) => !flagArgs.has(a)).map((a) => ALIASES[a] || a))];
 const deployed = { verticals: [] };
 
 // Shared transport — always (app/rest/wix-client.js, wix-config.js -> src/rest/).

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -28,7 +28,8 @@ Run this through exec_tool, exactly as written — installs all three skills, de
 | vertical | pick it when the app needs to |
 |---|---|
 | `storefront` | sell products |
-| `bookings` | take appointments, service bookings, or rentals |
+| `bookings` | take appointments or service bookings |
+| `rentals` | rent out an item, room or vehicle for a length the customer picks (by the hour or by the day) |
 | `blog` | publish articles |
 | `events` | publish events with RSVPs or ticket sales |
 | `portfolio` | showcase creative work |

--- a/skills/wix-vibe-headless/references/rentals/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/rentals/INSTRUCTIONS.md
@@ -1,0 +1,13 @@
+---
+name: rentals
+description: Rentals — renting out an item, room or vehicle for a length the customer picks. Runs on the Bookings vertical.
+---
+
+# Rentals
+
+Rentals is **the Bookings vertical** — Wix Rentals runs on the Bookings APIs. There is nothing
+separate to build here.
+
+Read and follow `.agents/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md` (its
+**Rentals** section), and use the bookings scaffolds under `references/bookings/app/`. The install
+already deploys those for you when `rentals` is selected.


### PR DESCRIPTION
A rental business kept routing to `storefront` because the base44 picker only offered 'sell products' and 'appointments'. This adds a first-class `rentals` row the agent can pick directly; `deploy.cjs` aliases `rentals`→`bookings` (Wix Rentals runs on the Bookings APIs), and `references/rentals/INSTRUCTIONS.md` points at the bookings guide. Resolves to bookings on every path (pick, deploy, instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)