### PR TITLE
wix-vibe-headless: compact base44.md + report rentals alias

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -120,8 +120,13 @@ const flagArgs = new Set(['--client-id', '--metasite-id', clientId, metaSiteId].
 // `rentals` is an alias of the Bookings vertical — Wix Rentals runs on the Bookings APIs. A rental
 // business picks `rentals` and gets the bookings scaffolds; it resolves to bookings everywhere.
 const ALIASES = { rentals: 'bookings' };
-const requested = [...new Set(argv.filter((a) => !flagArgs.has(a)).map((a) => ALIASES[a] || a))];
+const positional = argv.filter((a) => !flagArgs.has(a));
+const requested = [...new Set(positional.map((a) => ALIASES[a] || a))];
 const deployed = { verticals: [] };
+// Report any alias resolution so the caller sees an intended mapping (rentals -> bookings), not a
+// silent `bookings` result it might read as "rentals unsupported" and wastefully re-deploy.
+const aliased = [...new Set(positional.filter((a) => ALIASES[a]))].map((a) => `${a} -> ${ALIASES[a]}`);
+if (aliased.length) deployed.aliased = aliased;
 
 // Shared transport — always (app/rest/wix-client.js, wix-config.js -> src/rest/).
 if (existsSync(`${REF}/shared/app`)) cpSync(`${REF}/shared/app`, '/app/src', COPY);

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -12,14 +12,7 @@ Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **excep
 
 ## STEP 1 — Install the Wix skills locally
 
-Install three skills — they land under `.agents/skills/`:
-- **`wix-vibe-headless`** — the client build **and** seed guide (STEPs 3–4): your main source of
-  truth. Seeding lives here too, per-vertical under `references/<vertical>/seed/`.
-- **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
-  catalogs, business setup).
-- **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
-  contracts, and the docs **fallback** — find + read the Wix API docs for anything
-  `wix-vibe-headless` doesn't cover.
+Install three skills under `.agents/skills/`: **`wix-vibe-headless`** (the client build + seed guide — your main source of truth), **`wix-manage`** (REST recipes to manage/configure the site), and **`wix-base44-connector`** (site context + API-doc discovery, the fallback for anything the others don't cover).
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
 
@@ -36,18 +29,16 @@ Run this through exec_tool, exactly as written — installs all three skills, de
 | `pricing-plans` | sell memberships or subscriptions |
 | `restaurants` | show a menu, take orders, book tables |
 | `members` | let visitors sign in — this is **auth** |
-| `forms` | any visitor-fillable form — contact/enquiry, lead, signup, waitlist, application, feedback/survey, quote request, intake or registration. **Any "contact form" request is this row.** **Not `forms` — an RSVP is `events`**: confirming attendance to an event or occasion (a wedding, party, or gathering) uses events' built-in RSVP registration form, even for a single occasion with no tickets. **Not `forms` — a per-service booking form is `bookings`**: the form attached to a bookable service belongs there. Pick `forms` only when neither an event nor a bookable service is involved. |
-| `cms` | keep its own structured content that the app READS BACK — galleries, listings, "my submissions", anything the rows above don't already cover. **Not `cms` — a visitor-fillable form is `forms`**: a CMS collection can take a submission, but gives up the dashboard form builder, spam protection, notifications and the optional CRM contact mapping, and needs the owner to set collection permissions by hand first. Pick `cms` only when the app must read the entries back — a visitor can't read Forms submissions. |
+| `forms` | any visitor-fillable form: contact, signup, waitlist, application, survey, quote request (an event RSVP is `events`; a per-service booking form is `bookings`) |
+| `cms` | structured content the app reads back — galleries, listings, "my submissions" (a visitor-fillable form is `forms`) |
+
+`rentals` installs and deploys the `bookings` vertical — a `bookings` result is expected; don't re-deploy.
 
 ```js
 const { execSync } = require('child_process');
 const { existsSync, readdirSync } = require('fs');
-const VERTICALS = ['storefront'];         // ← set from the prompt; list every vertical the app uses
-// const VERTICALS = ['forms'];           // ← e.g. "create contact form" — a visitor-submitted form
-// const VERTICALS = ['members', 'cms'];  // ← e.g. visitors sign in AND the app stores what they submit
-// COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js, so never
-// retype either one into a file by hand afterwards.
-const WIX_CLIENT_ID = '<client id from the prompt>';
+const VERTICALS = ['storefront'];         // ← set from the prompt; list every vertical the app uses (e.g. ['members','cms'])
+const WIX_CLIENT_ID = '<client id from the prompt>';   // copy both from the prompt — deploy writes them into src/rest/wix-config.js
 const WIX_METASITE_ID = '<site id from the prompt>';
 const results = {};
 for (const skill of ['wix-vibe-headless', 'wix-manage', 'wix-base44-connector']) {
@@ -104,53 +95,21 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 ## STEP 4 — Manage and seed the business
 
-**Never delete or clean up anything on the user's site — seeding is additive only.** It's a live
-user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
-cleanup truly seems needed, ask the user first.
-
 Seed by calling your vertical's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and load its `seed-*.js` (if present) via
-its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
-shape → the **`wix-base44-connector`** skill's doc discovery.
+`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and follow it (the loader
+snippet, admin connector token, entity images with the final `media.base44.com` url, and every field
+shape are there). Gaps or an unexpected shape → the **`wix-base44-connector`** skill's doc discovery.
+Seeding is **admin-only** — not part of the client, which is built solely per the `wix-vibe-headless` skill.
 
-**Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
-access token and send it as a bearer token:
-
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-// then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
-```
-
-Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
-`@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
-inline it throws *"Identifier 'base44' has already been declared."*).
-
-**Entity images.** For image-bearing entities (store products, blog covers, bookings services,
-restaurant items, portfolio projects, event heroes, CMS items), generate with **Base44's built-in
-image generation**, then attach via the vertical seed module's image-attach step —
-`wix-base44-connector` doc discovery if the module doesn't cover that entity.
-
-**Seed images with the FINAL url, in one call.** Seeding writes to Wix, so use the real
-`https://media.base44.com/...` url from the **completed** `generate_image` result and pass it straight
-into your single `setupStore`/seed call (images included). A still-generating `/__generating__/<id>.png`
-placeholder is not a real url — Wix can't fetch it. `generate_image` runs in the background while you
-build the client, so the urls are ready by the time you seed.
-
-The connector + seeding are **admin-only** (STEP 4) — **not** part of the client, which is built
-solely per the `wix-vibe-headless` skill.
+- **Additive only:** never delete or overwrite the user's content, even apparent sample data; ask first if a cleanup truly seems needed.
+- Inline in exec_tool, `base44` is already declared — use it directly; do **not** `import @base44/sdk`, re-declare it, or call `createClient()` (throws *"Identifier 'base44' has already been declared."*).
 
 ## STEP 5 — Wrap up
 
-Once the site is built and seeded:
+1. **Mount `<WixManageBanner/>`** (required) in your Layout's fixed top region, above the header, per your vertical's INSTRUCTIONS — it links the app to its Wix back office, self-gates to the preview, and never shows on the published site.
+2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (your metasite id) to complete setup in Wix.
 
-1. **Mount the preview-only manage banner** (required; links the app to its Wix back office; shipped,
-   self-gates to the preview, never on the published site): render the `<WixManageBanner/>` component
-   in your Layout's fixed top region, above the header, per your vertical's INSTRUCTIONS STEP 4.
-2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (substitute your
-   metasite id) to complete setup in Wix (required), and mention that the preview shows a dismissible
-   top banner linking to this same dashboard.
-
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit, re-seed, or debug image urls.** Leave them and finish.
+**Don't chase images.** A `/__generating__/…` placeholder is swapped for the final url automatically at turn end — do **not** edit, re-seed, or debug image urls.
 
 ## Later admin requests
 


### PR DESCRIPTION
base44.md overflowed the fetch cap (~11.7K) and arrived truncated at agents. This compacts it to ~8K: STEP 4 collapses to a pointer at each vertical's SEED.md (verified every piece lives there per-vertical; kept the two that don't — the base44 'already declared' footgun and a one-line additive-only guardrail), terse forms/cms rows (SKILL.md holds the full disambiguation), one-line skill list, trimmed comments + STEP 5.

Also: deploy.cjs reports `aliased: ['rentals -> bookings']` and base44.md notes it, so a rentals build sees an intended mapping instead of a bare `bookings` result it wastefully re-deploys over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)