### PR TITLE
base44-ecom-light: hand off to Dashboard → Store at wrap-up

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -87,7 +87,9 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+**Do NOT add the `<WixManageBanner/>` component** and do not link the user to `manage.wix.com` — this flow has no manage banner and no Wix back-office handoff.
+
+**Hand off to `Dashboard → Store` instead.** Close by telling the user two things: the products you seeded are **mock data** — placeholder catalog, prices and stock, there to make the store look real — and everything is theirs to change from their Base44 app's **Dashboard**, under the **Store** entry in the sidebar. That's where they edit or replace the mock products and manage discounts and coupons, orders, inventory, shipping, tax and the rest of the store settings. Name that path — do **not** give them a url.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -56,7 +56,9 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+**Do NOT add the `<WixManageBanner/>` component** and do not link the user to `manage.wix.com` — this flow has no manage banner and no Wix back-office handoff.
+
+**Hand off to `Dashboard → Store` instead.** Close by telling the user that products, discounts and coupons, orders, inventory, shipping, tax and the rest of the store settings are all managed from their Base44 app's **Dashboard**, under the **Store** entry in the sidebar. Name that path — do **not** give them a url.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 


### PR DESCRIPTION
## Summary

- Both Base44 ecom-light handoff prompts (`base44-ecom-light.md`, `base44-ecom-light-seed.md`) ended their wrap-up with "do not send the user Wix dashboard links" and no alternative, so the builder agent finished a storefront and left the user with nowhere to manage it. Each wrap-up now hands off to the app's own **Dashboard → Store** entry and lists what lives behind it: products, discounts and coupons, orders, inventory, shipping, tax, store settings. Those rows come from the sidebar hierarchy in `headless-commerce-dashboard`.
- The agent is told to name the path, not a url. It has no metasite dashboard link to give in these flows, and left to itself it would invent one.
- The seed flow additionally states that the seeded products are **mock data** — placeholder catalog, prices and stock — and that the user edits or replaces them in the same place. The seed generates convincing-looking products and images; without this, a user may not realize they are meant to be replaced.

Not changed: `base44.md` (the full flow keeps its `manage.wix.com` handoff and `<WixManageBanner/>`), `generic.md`, and every other platform file. The `<WixManageBanner/>` prohibition stays in both light files; I narrowed its wording to what it actually forbids — linking to `manage.wix.com` — so the new handoff is not read as a banned dashboard link.

`base44-ecom-light.md` seeds nothing, so it deliberately carries no mock-data note.

## Test plan

Prompt-only change, no code paths and nothing to build or run. Verified by reading:

- `git diff origin/main` touches only the two wrap-up sections; both files are otherwise byte-identical.
- The `<WixManageBanner/>` rule and the "don't chase images" paragraph survive in both files.
- `version:` markers are unaffected — only `base44.md` carries one, and it is untouched.
- Sidebar rows named in the new text match the hierarchy table in `headless-bo/packages/headless-commerce-dashboard/README.md`.

Real validation is behavioral: run an ecom-light build in Base44 and confirm the agent closes by naming Dashboard → Store, gives no url, and (seed flow) calls the seeded products mock data.