### PR TITLE
wix-vibe-headless: ecom-light wrap-up ends with a docs-search handoff

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -87,11 +87,9 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Do NOT add the `<WixManageBanner/>` component** and do not paste Wix dashboard links or spell out a path — you hand the user off through the docs tool instead, and it ships the link itself.
+**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path — the docs tool hands the user off for you.
 
-**Make that call before you write the closing message** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. That's how the user reaches the catalog you just seeded, and it's all mock data — placeholder products, prices and stock, there to make the store look real. Tell them that, and that they can edit, replace or delete any of it. The call is what renders the dashboard shortcut in chat, so answering from your own head robs the user of it, and anything you type first lands above your real answer.
-
-**The result names the dashboard page to send them to.** Keep the closing message to those two points — the catalog is placeholder, and they manage the store from that page — using the name the result gives, and stop there. No path, no URL, no steps, and no mention of a button or shortcut — that renders on its own.
+**Call it before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the shortcut in chat; text you type first lands above your real answer. The result names a dashboard page — tell the user the catalog you seeded is mock data they can edit, replace or delete from that page, name it, stop. No path, no URL, no steps, no mention of a button.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -87,9 +87,9 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path — the docs tool hands the user off for you.
+**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
 
-**Call it before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the shortcut in chat; text you type first lands above your real answer. The result names a dashboard page — tell the user the catalog you seeded is mock data they can edit, replace or delete from that page, name it, stop. No path, no URL, no steps, no mention of a button.
+**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It renders the shortcut; anything you write first lands above your real answer. The result names a dashboard page — say the catalog you seeded is mock data they can edit, replace or delete there, name the page, stop. No path, no URL, no steps, no button talk.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -89,7 +89,7 @@ urls are ready by the time you seed.
 
 **Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
 
-**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It renders the shortcut; anything you write first lands above your real answer. The result names a dashboard page — say the catalog you seeded is mock data they can edit, replace or delete there, name the page, stop. No path, no URL, no steps, no button talk.
+**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -87,7 +87,11 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+**Do NOT add the `<WixManageBanner/>` component** and do not paste Wix dashboard links or spell out a path — you hand the user off through the docs tool instead, and it ships the link itself.
+
+**Make that call before you write the closing message** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. That's how the user reaches the catalog you just seeded, and it's all mock data — placeholder products, prices and stock, there to make the store look real. Tell them that, and that they can edit, replace or delete any of it. The call is what renders the dashboard shortcut in chat, so answering from your own head robs the user of it, and anything you type first lands above your real answer.
+
+**The result names the dashboard page to send them to.** Keep the closing message to those two points — the catalog is placeholder, and they manage the store from that page — using the name the result gives, and stop there. No path, no URL, no steps, and no mention of a button or shortcut — that renders on its own.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -58,7 +58,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
 
-**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It renders the shortcut; anything you write first lands above your real answer. The result names a dashboard page — say they manage the store there, name it, stop. No path, no URL, no steps, no button talk.
+**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -56,9 +56,9 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path — the docs tool hands the user off for you.
+**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
 
-**Call it before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the shortcut in chat; text you type first lands above your real answer. The result names a dashboard page — tell the user they manage the store from that page, name it, stop. No path, no URL, no steps, no mention of a button.
+**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It renders the shortcut; anything you write first lands above your real answer. The result names a dashboard page — say they manage the store there, name it, stop. No path, no URL, no steps, no button talk.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -56,11 +56,9 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Do NOT add the `<WixManageBanner/>` component** and do not paste Wix dashboard links or spell out a path — you hand the user off through the docs tool instead, and it ships the link itself.
+**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path — the docs tool hands the user off for you.
 
-**Make that call before you write the closing message** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the dashboard shortcut in chat, so answering from your own head robs the user of it, and anything you type first lands above your real answer.
-
-**The result names the dashboard page to send them to.** Say in one short sentence that they manage the store from that page, using the name the result gives, and stop there. No path, no URL, no steps, and no mention of a button or shortcut — that renders on its own.
+**Call it before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the shortcut in chat; text you type first lands above your real answer. The result names a dashboard page — tell the user they manage the store from that page, name it, stop. No path, no URL, no steps, no mention of a button.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -56,7 +56,11 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+**Do NOT add the `<WixManageBanner/>` component** and do not paste Wix dashboard links or spell out a path — you hand the user off through the docs tool instead, and it ships the link itself.
+
+**Make that call before you write the closing message** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. The call is what renders the dashboard shortcut in chat, so answering from your own head robs the user of it, and anything you type first lands above your real answer.
+
+**The result names the dashboard page to send them to.** Say in one short sentence that they manage the store from that page, using the name the result gives, and stop there. No path, no URL, no steps, and no mention of a button or shortcut — that renders on its own.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 


### PR DESCRIPTION
## Summary

- Both Base44 ecom-light handoff prompts ended by telling the builder agent to send **no** back-office link, leaving the user with a finished storefront and nowhere to run it from. The wrap-up now ends by calling Base44's own docs tool instead:

  ```
  search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)
  ```

  On a hit that returns the dashboard page the question maps to and attaches a client artifact rendering a 1-click shortcut in chat, so the agent never names a path or builds a URL. The registry page it lands on is `Store`, gated on `wix_stores_installed` — the flag `WixStoresService.install_store` sets on exactly the apps these two guides are installed into.

- The tool result is itself a directive (name the page, one short sentence, no URL, no steps, never claim a button is shown, since the shortcut is suppressed per-viewer at render time). The wrap-up mirrors those constraints and makes the call **before** any closing text, because text written ahead of a tool call lands above the real answer. The `<WixManageBanner/>` rule is unchanged.

- Seed flow only: the closing message now also says the seeded catalog is mock data the user can edit, replace or delete. The non-seed flow seeds nothing and says nothing about catalog state.

## Test plan

- Prompt-text change only; no code paths, so nothing to build or type-check. CI's `typecheck`/`test` jobs do work only for `skills/wix-app/` and evalforge paths and report success here having done none.
- Signature verified against `apper` rather than assumed: `search_base44_docs(query: str, prefer_dashboard: bool = False)` in `backend/app/user_apps/builder/agent/tools/documentation.py`; the `Store` page and its gate in `dashboard_registry.json`; the `Searched docs for "…"` row in `SearchBase44Docs.tsx` and the label-plus-chevron button in `dashboardCtaResourceCardRenderer.tsx`.
- Read both wrap-ups end to end for house voice and for the seed/non-seed split.

## Known limitation

`prefer_dashboard` and the CTA are behind `FeatureFlag.BUILDER_DASHBOARD_CONTEXT`. For a user outside that flag the param is absent from the tool schema and the call degrades to a plain docs search — no shortcut and no page name, so that user gets less than the prose-path alternative would have given them. Worth weighing before this leaves draft.
