### PR TITLE
fix(wix-headless): remove the false "omit resourceIds" claim

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-rentals.md
+++ b/skills/wix-headless/references/inline-recipes/setup-rentals.md
@@ -139,7 +139,7 @@ Create the services **one at a time** with `POST https://www.wixapis.com/booking
 
 **List the concrete `resourceIds`** — the service's availability comes from them. Verified on a live site: identical services returned **48** time-slots with `resourceIds` and **0** without. Add resources later by updating the service's `resourceIds`.
 
-**⚠️ Price decides how many services you create.** The rate lives on the **service**, not the resource, so resources that rent at **different rates must be separate services**, each pinning its own resource in `resourceIds`. Three meeting rooms at ₪60, ₪120 and ₪250 per hour are **three services** sharing one resource type — not one service with three resources. Resources that rent at the **same** rate can share a single service, and then you can omit `resourceIds` and let the whole type be bookable.
+**⚠️ Price decides how many services you create.** The rate lives on the **service**, not the resource, so resources that rent at **different rates must be separate services**, each pinning its own resource in `resourceIds`. Three meeting rooms at ₪60, ₪120 and ₪250 per hour are **three services** sharing one resource type — not one service with three resources. Resources that rent at the **same** rate can share a single service.
 
 **For a daily rental**, swap the duration range (everything else is identical):
 


### PR DESCRIPTION
## Summary

`setup-rentals.md` contradicts itself. Three places state, correctly:

> Availability comes from the listed ids: identical services return 48 time-slots with them and 0 without.

One sentence, a few lines below the third of those, says the opposite:

> Resources that rent at the **same** rate can share a single service, and then you can omit `resourceIds` and let the whole type be bookable.

That's false — Ayal Gelles reproduced it on a live site: identical services, same resource type, same resources; the one with `resourceIds` returns 48 slots, the one without returns 0. Omitting `resourceIds` never makes "the whole type bookable" — it makes the service permanently unbookable, with no error.

Root cause (per Ayal's investigation): the availability builder links schedules only from explicit `resourceIds` (`AvailabilityTimeSlotsConfigurationMapper.scala#L26`), while a plain `GET` on the service falls back to every resource of the type (`ServiceMappers.scala#L231`) — so the service looks fully configured on read, while availability silently stays empty. That's a platform inconsistency between two code paths, not something this recipe can route around; it's flagged for the service-availability owners separately.

## Changes

- `setup-rentals.md` — removes the trailing clause claiming `resourceIds` can be omitted. The preceding reasoning ("same rate can share one service") is correct and kept; that service still needs `resourceIds` listing every resource it covers, which the rest of the file already says three times.

Documentation only, one sentence.

## Feature Toggle ([create release](https://wix-bo.com/dev/tool/feature-toggle/new-feature-release))

N/A — documentation only.

## Rollback

`git revert`. One sentence removed, no dependents.

## Testing

- [x] Confirmed the contradiction by reading the merged file directly — three "48 with / 0 without" statements vs. this one "omit is fine" claim, same file, ~15 lines apart.
- [x] Reproduced by Ayal Gelles on a live site (fresh headless site, Rentals installed, one resource type, one resource, two otherwise-identical services differing only in `resourceIds`): 0 slots vs. 48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
