### PR TITLE
forms: wix-headless base44 / wix-headless / wix-manage fixes + evals

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-forms.md
+++ b/skills/wix-headless/references/inline-recipes/setup-forms.md
@@ -71,11 +71,24 @@ exhaust the site's form allowance (read it from
 [List Forms Providers Configs](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms-providers-configs)),
 which is also why you must **never create throwaway forms to probe the shape.**
 
+> **⚠️ `providers-config` tells you which namespaces the site can create in — NOT its limits.** A
+> provider app declares `restrictions` **once, for all sites**, in its app dashboard; the Wix Forms
+> app separately derives the site's real form/field/step limits from its **premium plan** and
+> enforces them on every create. (A missing `restrictions` means default platform limits, not
+> unlimited.) That is why free and unpublished sites report `maxFields: 150` / `maxForms: 150` here
+> while the create rejects with `Field count reached its limit of 10` and
+> `Steps count reached its limit of 3`. **The create call is the only authority** — when it returns
+> a count error, go to "Plan gates" below.
+
 ### STEP 2: Create each form schema
 
 **One POST per form** to `https://www.wixapis.com/form-schema-service/v4/forms`. How many forms, and
 each form's fields and labels, come from the request you're fulfilling; this step gives the call and
 the required format. Forms are independent (no shared revision), so concurrent creates are safe.
+
+**Every body carries `"namespace": "wix.form_app.form"`** — the same literal the reads below take as
+their required `?namespace=`. A form created under anything else is reachable over the API and
+invisible in the dashboard and Editor.
 
 **⚠️ Generate every `id` in the shell as a lowercase UUID v4 — never type one from memory**
 (`uuidgen | tr 'A-Z' 'a-z'`). Supply them at create rather than omitting them: `steps` must
@@ -96,9 +109,18 @@ step unless the request needs multiple pages.
 beside `target`/`inputType`:
 
 ```jsonc
-"inputOptions": { "target": "full_name", "required": true, "inputType": "STRING",
-  "stringOptions": { "validation": {}, "componentType": "TEXT_INPUT",
-                     "textInputOptions": { "label": "Full Name", "showLabel": true } } }
+"inputOptions": {
+  "target": "first_name",
+  "required": true,                                    // HERE — beside target/inputType
+  "pii": true,
+  "contactMapping": { "contactField": "FIRST_NAME" },  // per field; this is what creates the contact
+  "inputType": "STRING",
+  "stringOptions": {
+    "validation": {},                                  // always present, even empty — never `required`
+    "componentType": "TEXT_INPUT",
+    "textInputOptions": { "label": "First name", "showLabel": true }
+  }
+}
 ```
 
 A `required` key inside `stringOptions.validation` — or any `<inputType>Options.validation`, since no
@@ -126,12 +148,21 @@ surface in the dashboard or on the first real submission.
 Three plan-tier limits return a real `400` on create. **Do not work around any of them; tell the user
 to reduce or upgrade.**
 
-- **`FIELDS_COUNT_RESTRICTIONS_ERROR`** — the form exceeds the plan's per-form field cap. **Do NOT
-  split the form into multiple schemas** to dodge it. Reduce the field count, or upgrade.
+- **Field count — two caps, counting different things.** `Field count reached its limit of N` is the
+  **premium** cap the Wix Forms app enforces from the site's plan, and it counts **`INPUT` fields
+  only** (display elements and the `SUBMIT_BUTTON` don't count). `FORM_FIELDS_COUNT_EXCEEDED` /
+  `FIELDS_COUNT_RESTRICTIONS_ERROR` is the schema-service cap, which counts **every** field
+  including display elements. **Do NOT split the form into multiple schemas** to dodge either — that
+  trades one submission record for several and consumes more of the site's form allowance. Reduce
+  the field count, or upgrade.
+- **`Steps count reached its limit of N`** — the premium cap on `steps.length`. Collapse the form
+  into fewer pages, or upgrade. Conditions (`formRules`) are capped the same way. Neither has a
+  schema-service equivalent, so neither appears in the Create Form error table.
 - **`FILE_UPLOAD_RESTRICTIONS_ERROR`** — a file upload, signature, or payment field on a plan below
   Core. **Do NOT suggest inlining files as base64** — it stores no real file, gives the owner nothing
   usable, and blows past submission size limits. Drop the field, or upgrade.
-- **`FORMS_COUNT_RESTRICTIONS_ERROR`** — the site hit its plan's total-form cap. Upgrade, or free a
+- **`FORMS_COUNT_RESTRICTIONS_ERROR`** / **`NAMESPACE_FORMS_COUNT_EXCEEDED`** (and
+  `NAMESPACE_DELETED_FORMS_COUNT_EXCEEDED` for the trash bin) — the site hit its plan's total-form cap. Upgrade, or free a
   slot (STEP 1's list-then-delete — but only delete forms that are clearly install sample data; ask
   before deleting anything that could be the owner's real form).
 
@@ -167,10 +198,19 @@ A `200` on create is not proof the form is queryable or that the dashboard will 
    `formSummary.fields` is NON-EMPTY**, with a count equal to **every input field you sent** (i.e.
    `formFields[]` minus the `SUBMIT_BUTTON`). A 6-input form returns all 6 — **including non-contact
    `DROPDOWN` and `TEXT_AREA` fields** — so do *not* expect only the contact-mapped ones. This is
-   the reliable dashboard-truth check: the summary returns exactly the fields the Wix dashboard
-   shows. A `summary.fields: []`, or a count short of your inputs, means the form renders blank (or
-   partly blank) for the owner even though the public site submits fine — **do not report success;
-   fix the `identifier`s and re-create.**
+   the dashboard-truth check for *placement*. A `summary.fields: []`, or a count short of your
+   inputs, means the form renders blank (or partly blank) for the owner even though the public site
+   submits fine — **do not report success; fix the layout placement or the GUID casing and
+   re-create.**
+
+   **⚠️ This step does NOT prove the `identifier`s are right, so check them in step 1.** An
+   unrecognized `identifier` is accepted and stored: it comes back in `formFields[]` and accepts
+   submissions, so every API-level check passes — but the **Wix Forms editor cannot render a field
+   it doesn't recognize**, so the owner can't see or edit it, and a form built entirely from
+   invented identifiers opens **empty** in the editor. Whether such a field is also omitted from
+   `formSummary.fields` is unverified, so don't rely on this count to catch it. Assert every
+   returned `formFields[].identifier` against the known values in About Form Fields — a plain string
+   comparison, no extra call.
 
 3. **⚠️ If the form has a multi-choice ARRAY field (`CHECKBOX_GROUP` / `TAGS`), the two checks above
    are NOT enough — send one real `createSubmission`.** A malformed `arrayOptions.validation.items`
@@ -201,8 +241,15 @@ To change a form the request has since revised — add a field, relabel one, tig
 [Update Form](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form):
 
 ```
+GET   https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds={formId}
 PATCH https://www.wixapis.com/form-schema-service/v4/forms/{formId}
+{ "form": { …the whole object you just read, with your change…, "revision": "<its current revision>" } }
 ```
+
+**Read the form back first** — the `PATCH` needs its current `revision`, and `formFields` is replaced
+wholesale (anything missing from the array you send moves to `deletedFormFields`), so the read-back
+*is* the body. The read needs the **required** `?namespace=wix.form_app.form`; without it it `400`s
+with `namespace must not be empty` — a violation naming a field, so it misreads as a body problem.
 
 **Prefer updating over delete-and-recreate.** An update keeps the `formId` the handoff already
 carries and consumes no additional slot against the site's form cap. **Re-run STEP 3 after any update**

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -250,7 +250,10 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Forms
 
 ### [Create Form](references/forms/create-form.md)
-**Technical:** Creates a form with fields (name, email, etc.) using the Form Schemas API. Covers field configuration, layout, and post-submission triggers.
+**Technical:** Creates a visitor-fillable form with Form Schemas v4 — contact, enquiry, signup, waitlist, application, survey, quote request.
+
+### [Update Form](references/forms/update-form.md)
+**Technical:** Changes a form that already exists with a Form Schemas v4 `PATCH` — add, remove a field or change its settings (label, required, order, etc.), keeping the `formId`.
 
 ### [Forms Dashboard Navigation](references/forms/forms-dashboard-navigation.md)
 **Technical:** Direct links to Wix Forms dashboard pages on manage.wix.com (forms list, submissions table, form builder for a specific form, standalone forms, templates, settings), pairing forms and submissions with their read APIs for "view it in your dashboard" links.

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "REST recipes to configure and manage a Wix site's business solutions — stores, bookings, payments, CMS, and more. Open the matching recipe for the exact endpoint, method, and payload before calling — never guess a Wix API. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, google-business-profile, analytics, accessibility, seo, dashboard-navigation."
+description: "REST recipes to configure and manage a Wix site's business solutions — stores, bookings, payments, CMS, and more. Open the matching recipe for the exact endpoint, method, and payload before calling — never guess a Wix API, never write Wix dashboard URL from memory. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, google-business-profile, analytics, accessibility, seo, dashboard-navigation."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -169,6 +169,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## Dashboard Navigation
 
+**Dashboard URLs are recipe data, not general knowledge.** A `manage.wix.com` route is an app-registered slug that appears in no API reference and cannot be derived from the entity's name or its API path (Forms pages live under `wix-forms`, not `contacts/forms`; Stores products under `wix-stores/products`). So for **every** request for a dashboard link — even one that needs no API call, and even when a route feels obvious — open the solution's dashboard-navigation recipe below and copy the route from its table. Answering from memory is the one failure mode these recipes exist to prevent.
+
 ### [Dashboard Navigation](references/dashboard-navigation/dashboard-navigation.md)
 **Index** — for any "where do I manage X in the dashboard" / "give me a dashboard link" request: the shared URL structure for all dashboard pages (`https://manage.wix.com/dashboard/{metaSiteId}/{route}`, app-ID fallback, legacy redirects, entity deep links), routing to the per-business-solution recipes (e.g. [Bookings](references/bookings/bookings-dashboard-navigation.md), [Stores](references/stores/stores-dashboard-navigation.md)) which live in their solution's section below.
 
@@ -256,7 +258,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Technical:** Changes a form that already exists with a Form Schemas v4 `PATCH` — add, remove a field or change its settings (label, required, order, etc.), keeping the `formId`.
 
 ### [Forms Dashboard Navigation](references/forms/forms-dashboard-navigation.md)
-**Technical:** Direct links to Wix Forms dashboard pages on manage.wix.com (forms list, submissions table, form builder for a specific form, standalone forms, templates, settings), pairing forms and submissions with their read APIs for "view it in your dashboard" links.
+**Technical:** Direct links to Wix Forms dashboard pages on manage.wix.com — every one under the `wix-forms` namespace (forms list `wix-forms`, a form's builder `wix-forms/form/{formId}`, that form's submissions `wix-forms/form/{formId}/submissions`, standalone forms), never under `contacts/forms` or the legacy `wix-forms-and-payments`. Read it before answering any "link me to my form / its submissions" request; also pairs forms and submissions with their read APIs for "view it in your dashboard" links.
 
 ---
 

--- a/skills/wix-manage/references/dashboard-navigation/routes.json
+++ b/skills/wix-manage/references/dashboard-navigation/routes.json
@@ -1,5 +1,5 @@
 {
- "$comment": "Live dashboard page routes per Wix app. Site pages: https://manage.wix.com/dashboard/{metaSiteId}/{path}. Pages with accountLevel=true instead live at https://manage.wix.com/account/{path} (no metaSiteId). legacyAliases redirect to path. Where a page shows a single entity, deepLink gives the path with the entity-ID placeholder appended; pages without deepLink take no ID segment or the pattern is undocumented. Generated from the app registrations, enriched from the per-solution recipes.",
+ "$comment": "Live dashboard page routes per Wix app. Site pages: https://manage.wix.com/dashboard/{metaSiteId}/{path}. Pages with accountLevel=true instead live at https://manage.wix.com/account/{path} (no metaSiteId). legacyAliases redirect to path. Where a page shows a single entity, deepLink gives the path with the entity-ID placeholder appended, optionally followed by a sub-page segment (e.g. wix-forms/form/{formId}/submissions); pages without deepLink take no ID segment or the pattern is undocumented. Generated from the app registrations, enriched from the per-solution recipes.",
  "apps": [
   {
    "app": "Analytics",
@@ -1107,6 +1107,12 @@
    "slug": "wix-forms",
    "pages": [
     {
+     "path": "wix-forms",
+     "inSidebar": true,
+     "title": "menu.wix-forms",
+     "legacyAliases": []
+    },
+    {
      "path": "wix-forms/form",
      "inSidebar": false,
      "title": "menu.wix-forms",
@@ -1117,62 +1123,16 @@
      "deepLink": "wix-forms/form/{formId}"
     },
     {
+     "path": "wix-forms/form",
+     "inSidebar": false,
+     "title": "submissions",
+     "legacyAliases": [],
+     "deepLink": "wix-forms/form/{formId}/submissions"
+    },
+    {
      "path": "wix-forms/standalone-form",
      "inSidebar": false,
      "title": "menu.wix-forms",
-     "legacyAliases": []
-    }
-   ]
-  },
-  {
-   "app": "Wix Forms (management pages)",
-   "appDefinitionId": "14ce1214-b278-a7e4-1373-00cebd1bef7c",
-   "slug": "wix-forms-and-payments",
-   "pages": [
-    {
-     "path": "wix-forms-and-payments",
-     "inSidebar": true,
-     "title": "menu.wix-forms",
-     "legacyAliases": [
-      "wix-forms",
-      "app/14ce1214-b278-a7e4-1373-00cebd1bef7c",
-      "wix-forms-and-payments"
-     ]
-    },
-    {
-     "path": "wix-forms-and-payments/edit",
-     "inSidebar": false,
-     "title": "edit",
-     "legacyAliases": []
-    },
-    {
-     "path": "wix-forms-and-payments/removed",
-     "inSidebar": false,
-     "title": "removed",
-     "legacyAliases": []
-    },
-    {
-     "path": "wix-forms-and-payments/settings",
-     "inSidebar": false,
-     "title": "settings",
-     "legacyAliases": []
-    },
-    {
-     "path": "wix-forms-and-payments/submission-pdf",
-     "inSidebar": false,
-     "title": "submission-id",
-     "legacyAliases": []
-    },
-    {
-     "path": "wix-forms-and-payments/submissions",
-     "inSidebar": false,
-     "title": "submissions",
-     "legacyAliases": []
-    },
-    {
-     "path": "wix-forms-and-payments/templates",
-     "inSidebar": false,
-     "title": "templates",
      "legacyAliases": []
     }
    ]

--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -1,18 +1,129 @@
 ---
 name: "Create Form"
-description: Creates a form with fields (name, email, etc.) using the Form Schemas API. Covers field configuration, layout, and post-submission triggers.
+description: "Creates a visitor-fillable Wix form with Form Schemas v4 — a contact or enquiry form, a signup or waitlist, an application, a survey, a quote request, and forms whose submissions create a contact. Ships a complete create request, plus the field table for every kind Wix supports — dropdown, choice, file upload, rating, address, payment, and the silent breakers that produce an empty or invisible form. Changing a form that already exists is Update Form."
 ---
 # RECIPE: Create a Wix Form
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`. Send `wix-site-id: <SITE_ID>` when the token is account-scoped.
 
-Create a form on a Wix site that appears in the Forms & Submissions dashboard. The form collects visitor information (e.g., name, email) and can automatically upsert contacts on submission.
+Create a form on a Wix site that appears in the **Forms & Submissions** dashboard and can be placed in the Editor. Wix Forms backs **any form a visitor fills in** — a contact or enquiry form, a signup or waitlist, an application, a survey, a quote request, a registration questionnaire, etc. Whether a submission also becomes a CRM contact is the optional per-field `contactMapping` (§ Contact fields).
+
+**Two exceptions — route there instead:**
+
+| The ask                   | Owner |
+|---------------------------|-------|
+| RSVP to an event          | **Wix Events**, which ships its own registration form — [Create Event](../events/create-wix-event.md) |
+| A bookable service's form | **Wix Bookings** |
+
+**Flow:** STEP 0 confirm the app, read the caps → STEP 1 compose the fields → STEP 2 one POST, all fields → STEP 3 verify the read-back (**mandatory** — the `200` proves nothing).
 
 ---
 
-## Create the form
+## Silent breakers
 
-Call the Create Form endpoint with the `wix.form_app.form` namespace. The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) is usually already installed on sites.
+Four things are accepted with a **`200`** and produce a form that is empty, wrong, or invisible. There is no error to react to, so get them right on the first call — each is settled in the step named after it.
+
+1. **App — Wix Forms (New) `225dd912-7dea-4738-8688-4b8c6955ffc2` (STEP 0 · 1).** `14ce1214-b278-a7e4-1373-00cebd1bef7c` is the **Old** app: never install it, and never treat its presence as satisfying this API. *Get it wrong:* `UNSUPPORTED_FORM_NAMESPACE`; automations whose trigger belongs to the new app report "Forms app is not installed" even though *an* app named Wix Forms is installed.
+
+2. **Namespace — `wix.form_app.form` (STEP 2).** *Get it wrong:* a form under any other namespace (notably the **non-existent `wix.form_platform.form`**) reads back fine over the API and is **completely invisible** in the Forms dashboard and the Editor.
+
+3. **`identifier` — one of the predefined values in [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types.** *Get it wrong:* the field works over the API but the **Wix Forms editor cannot render it**, so the owner can't see or edit it. A form whose fields all carry invented identifiers opens **empty** in the editor.
+
+4. **Layout — every field, `SUBMIT_BUTTON` included, placed in `steps[].layout`, with lowercase GUIDs on both sides.** *Get it wrong:* the form appears in the Editor's form picker but renders **empty** — fields still store values, but nothing shows.
+
+**Never create throwaway "test" forms to probe the shape.** The site's form allowance is finite (§ Plan caps), and probing burns it. Assemble the whole form and POST once, then verify (STEP 3).
+
+---
+
+## STEP 0: Preflight — confirm the app, then read the caps
+
+**1 · Confirm Wix Forms (New) is installed.**
+
+```bash
+curl -X GET \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instances' \
+  -H 'Authorization: <AUTH>'
+```
+
+Look for `225dd912-7dea-4738-8688-4b8c6955ffc2` in the response — see [List Installed Apps](../app-installation/list-installed-apps.md). If it isn't installed, install **`225dd912-7dea-4738-8688-4b8c6955ffc2`** via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe. A fresh install returns `appInstance.status: "UNKNOWN"` until it propagates; if the first create fails with an identity/propagation error, retry **once** — do not loop.
+
+**2 · Confirm the namespace is available** — [List Forms Providers Configs](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms-providers-configs):
+
+```bash
+curl -X GET \
+  'https://www.wixapis.com/form-schema-service/v4/forms/providers-config' \
+  -H 'Authorization: <AUTH>'
+```
+
+Use this to confirm `wix.form_app.form` is among the namespaces the site can create form schemas in. **Do not use it to decide how many fields you can build.**
+
+> **⚠️ `restrictions` here are NOT the site's limits.** A provider app declares them **once, for all sites**, in its app dashboard — so `maxForms` / `maxFields` / `maxDeletedForms` describe the app, not this site. The Wix Forms app separately derives the site's **real** form, field, step, condition and email-recipient limits (and whether premium-only field types are allowed) from its **premium plan**, and enforces them itself on every create and update. A missing `restrictions` object means default platform limits apply — not "unlimited".
+>
+> This is why free and unpublished sites have been seen reporting `maxFields: 150` / `maxForms: 150` here while the create rejects with **`Field count reached its limit of 10`** and **`Steps count reached its limit of 3`**. The config is not wrong; it answers a different question. **The create call is the only authority on what a site allows** — build the form you were asked for, and if it returns a count error, go to § Plan caps and put the choice to the user. A rejected create costs nothing: it consumes no form slot, so reading its errors is not "probing" (that rule is about leaving throwaway forms behind).
+
+**3 · Only if you need a free slot:** list what exists — `GET https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&fieldsets=METADATA` (repeat with `&enabled=false`) — and `DELETE https://www.wixapis.com/form-schema-service/v4/forms/{formId}` **only** for forms that are obviously the install's own default sample (a "Get in touch" form with `first_name` / `email` / `message`). The site may hold the owner's **real** forms. If it isn't obviously sample data, **ask the user first** — never delete real content unprompted.
+
+---
+
+## STEP 1: Compose the fields
+
+**Read [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) before composing anything.** It is the authority on every field-level rule and is not repeated here: the `identifier` / `inputType` / `componentType` table for every field kind, how the two nested block names are derived, choice fields' twin declarations, Ricos checkbox labels, display fields, the `contactField` values and their extra-detail keys, the layout that orders fields (including matching a lowercase `id` with a lowercase `fieldId`), and which fields need a premium plan or another Wix app. Value shapes on the way back out are [About Submission Values](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values).
+
+The rules below are the ones those articles don't state.
+
+> **⚠️ "Must agree" is literal, and this is the one thing that really does make a field vanish.** The server builds a field's renderable view by dispatching on its `componentType` *within* its `inputType`. A pair that isn't valid together — `inputType: STRING` with `componentType: CHECKBOX_GROUP`, say — produces no view, and the field disappears without an error. Take both values from the same row of § Field types; never mix rows.
+
+- **`required` goes at `inputOptions.required`** — beside `target` and `inputType` — **NOT** inside `validation`. A `required` key inside `stringOptions.validation` (or any `<inputType>Options.validation`) is accepted at create and **silently discarded**: the form ships with nothing mandatory and no error anywhere. `validation` carries value constraints only (`format`, `enum`, `minimum`, `minLength`, `items`). The one exception is the multi-line address field, whose per-subfield flags genuinely live at `addressOptions.validation.fields.<sub>.required` (subfield **visibility** is separate, at `multilineAddressOptions.fieldSettings.addressLine2.show`).
+- **`id` must be a fresh lowercase GUID.** Generate them in the shell (`uuidgen | tr 'A-Z' 'a-z'`) — never type one from memory, never reuse the examples here. The server stores `id` lowercase: an **uppercase** `id` still saves, but the layout's `fieldId` no longer matches it, so the field is **silently unplaced** and the form renders empty.
+- **`target` is the immutable submission key** — a unique lowercase `snake_case` string per field (e.g. `first_name_f409`). It is the contract every submission and every frontend binding uses.
+- **Every example value you author is visitor-visible.** A `placeholder`, label or hint carrying a phone number, postcode, currency or date must follow the **site's** country, not a US/UK default.
+
+### Choice fields — the identifier is what routes the renderer
+
+**A choice field declares its choices twice, and both declarations are required.** Every option carries its own lowercase GUID `id`, a `value` and a `label`; `validation.enum` (for `STRING`) or `validation.items.stringOptions.enum` + `itemType` (for `ARRAY`) lists every one of those `value`s. **An empty `validation` is a free-text field, not a dropdown** — the general "always include `validation`, even as `{}`" rule does not apply to a choice field, and getting this wrong is accepted with a `200`.
+
+> **⚠️ A choice field whose `identifier` isn't the choice kind is stored as a plain text input.** `identifier: "TEXT_INPUT"` with `componentType: "DROPDOWN"` returns `200` and comes back as a `TEXT_INPUT` carrying `textInputOptions`: the identifier, not the `componentType`, routes the field to its renderer. **Diagnose it by which options block came home** — `textInputOptions` where you sent `dropdownOptions`, with a well-formed block and `enum`, means the `identifier`. Re-sending it, or delete-and-re-add with the same identifier, reproduces it.
+
+> **⚠️ ARRAY fields fail *after* creation.** A malformed `arrayOptions.validation.items` (missing `itemType`, empty or omitted `items`) lists fine and counts in the summary, so STEP 3's checks 1–2 both pass — but **every** submission to the form then `400`s. STEP 3 check 3 (a live test submission) is the only proof.
+
+A dropdown, in full — copy this and swap the label, target, options and every GUID:
+
+```json
+{
+  "id": "a4f0c9d2-1e77-4b3e-9a52-7c1d8f6b4e30",
+  "identifier": "DROPDOWN",
+  "fieldType": "INPUT",
+  "inputOptions": {
+    "target": "job_industry_7f2b",
+    "required": false,
+    "inputType": "STRING",
+    "stringOptions": {
+      "validation": { "enum": ["Technology", "Healthcare", "Finance", "Other"] },
+      "componentType": "DROPDOWN",
+      "dropdownOptions": {
+        "label": "Job industry",
+        "showLabel": true,
+        "options": [
+          { "id": "1b8e5a71-3c04-4f9a-9d62-08b7a5cf3e41", "label": "Technology", "value": "Technology" },
+          { "id": "6d29c4b8-7f15-4a20-8e93-b04d7e2a9c58", "label": "Healthcare", "value": "Healthcare" },
+          { "id": "c37fa910-52d6-4e8b-b1a7-9f4c60d38e2b", "label": "Finance", "value": "Finance" },
+          { "id": "e8b1d6c4-90a3-42f7-8c05-3d7e15b9a642", "label": "Other", "value": "Other" }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Contact fields
+
+> **⚠️ Never use `postSubmissionTriggers.upsertContact` to map contacts** Older recipes and samples used it, but it is a noop / response-only. Use per-field `contactMapping` instead.
+
+---
+
+## STEP 2: Create the form — one POST, all fields
+
+**[Create Form](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form) ships complete request examples** for a dozen form types (contact, survey, order, job application, booking, donation, waiver, billing …) — start from the closest one rather than assembling from scratch.
 
 ```bash
 curl -X POST \
@@ -21,151 +132,116 @@ curl -X POST \
   -H 'Authorization: <AUTH>' \
   -d '{
     "form": {
-      "name": "Contact Form",
+      "name": "Contact form",
       "namespace": "wix.form_app.form",
-      "enabled": true,
-      "spamFilterProtectionLevel": "ADVANCED",
       "formFields": [
         {
-          "id": "c1a2b3d4-0001-4a00-b000-000000000001",
-          "hidden": false,
+          "id": "d7665e98-a7c4-4829-c104-fb856883e043",
           "identifier": "CONTACTS_FIRST_NAME",
           "fieldType": "INPUT",
           "inputOptions": {
-            "target": "first_name_0001",
+            "target": "first_name_f409",
             "pii": true,
-            "required": false,
+            "contactMapping": { "contactField": "FIRST_NAME" },
             "inputType": "STRING",
-            "readOnly": false,
             "stringOptions": {
-              "validation": {
-                "format": "UNKNOWN_FORMAT",
-                "enum": []
-              },
+              "validation": {},
               "componentType": "TEXT_INPUT",
-              "textInputOptions": {
-                "label": "First name",
-                "showLabel": true
-              }
+              "textInputOptions": { "label": "First name", "showLabel": true }
             }
           }
         },
         {
-          "id": "c1a2b3d4-0002-4a00-b000-000000000002",
-          "hidden": false,
+          "id": "740e294e-6ee4-4cda-c902-823002064985",
           "identifier": "CONTACTS_LAST_NAME",
           "fieldType": "INPUT",
           "inputOptions": {
-            "target": "last_name_0002",
+            "target": "last_name_b88c",
             "pii": true,
-            "required": false,
+            "contactMapping": { "contactField": "LAST_NAME" },
             "inputType": "STRING",
-            "readOnly": false,
             "stringOptions": {
-              "validation": {
-                "format": "UNKNOWN_FORMAT",
-                "enum": []
-              },
+              "validation": {},
               "componentType": "TEXT_INPUT",
-              "textInputOptions": {
-                "label": "Last name",
-                "showLabel": true
-              }
+              "textInputOptions": { "label": "Last name", "showLabel": true }
             }
           }
         },
         {
-          "id": "c1a2b3d4-0003-4a00-b000-000000000003",
-          "hidden": false,
+          "id": "19768973-65be-4a6f-b3de-57cfb1da48db",
           "identifier": "CONTACTS_EMAIL",
           "fieldType": "INPUT",
           "inputOptions": {
-            "target": "email_0003",
+            "target": "email_673d",
             "pii": true,
             "required": true,
+            "contactMapping": { "contactField": "EMAIL", "emailInfo": { "tag": "UNTAGGED" } },
             "inputType": "STRING",
-            "readOnly": false,
             "stringOptions": {
-              "validation": {
-                "format": "EMAIL",
-                "enum": []
-              },
+              "validation": { "format": "EMAIL" },
               "componentType": "TEXT_INPUT",
-              "textInputOptions": {
-                "label": "Email",
-                "showLabel": true
-              }
+              "textInputOptions": { "label": "Email", "showLabel": true }
             }
           }
         },
         {
-          "id": "c1a2b3d4-0004-4a00-b000-000000000004",
-          "hidden": false,
-          "identifier": "TEXT_INPUT",
+          "id": "95d528a8-8f3d-4692-7363-44db1f96ca18",
+          "identifier": "CONTACTS_PHONE",
           "fieldType": "INPUT",
           "inputOptions": {
-            "target": "message_0004",
-            "pii": false,
-            "required": false,
+            "target": "phone_6a4b",
+            "pii": true,
+            "contactMapping": { "contactField": "PHONE", "phoneInfo": { "tag": "UNTAGGED" } },
             "inputType": "STRING",
-            "readOnly": false,
             "stringOptions": {
-              "validation": {
-                "format": "UNKNOWN_FORMAT",
-                "enum": []
-              },
-              "componentType": "TEXT_INPUT",
-              "textInputOptions": {
-                "label": "Message",
-                "showLabel": true
-              }
+              "validation": { "format": "PHONE" },
+              "componentType": "PHONE_INPUT",
+              "phoneInputOptions": { "label": "Phone", "showLabel": true }
             }
           }
         },
         {
-          "id": "c1a2b3d4-0005-4a00-b000-000000000005",
-          "hidden": false,
+          "id": "bbecbd37-ca52-4fa6-a92c-90e70aa4ec2a",
+          "identifier": "TEXT_AREA",
+          "fieldType": "INPUT",
+          "inputOptions": {
+            "target": "message_7634",
+            "inputType": "STRING",
+            "stringOptions": {
+              "validation": {},
+              "componentType": "TEXT_INPUT",
+              "textInputOptions": { "label": "Your message", "showLabel": true }
+            }
+          }
+        },
+        {
+          "id": "2e56791e-926e-48fd-37d0-0ad60a27736d",
           "identifier": "SUBMIT_BUTTON",
           "fieldType": "DISPLAY",
           "displayOptions": {
             "displayFieldType": "PAGE_NAVIGATION",
-            "pageNavigationOptions": {
-              "nextPageText": "Next",
-              "previousPageText": "Back",
-              "submitText": "Submit"
-            }
+            "pageNavigationOptions": { "submitText": "Send" }
           }
         }
       ],
       "steps": [
         {
-          "id": "d1e2f3a4-0001-4b00-c000-000000000001",
+          "id": "a26d12fc-ed7a-4b7f-90e4-994f3ad56e4b",
           "name": "Page 1",
-          "hidden": false,
           "layout": {
             "large": {
               "items": [
-                { "fieldId": "c1a2b3d4-0001-4a00-b000-000000000001", "row": 0, "column": 0, "width": 6, "height": 1 },
-                { "fieldId": "c1a2b3d4-0002-4a00-b000-000000000002", "row": 0, "column": 6, "width": 6, "height": 1 },
-                { "fieldId": "c1a2b3d4-0003-4a00-b000-000000000003", "row": 1, "column": 0, "width": 12, "height": 1 },
-                { "fieldId": "c1a2b3d4-0004-4a00-b000-000000000004", "row": 2, "column": 0, "width": 12, "height": 1 },
-                { "fieldId": "c1a2b3d4-0005-4a00-b000-000000000005", "row": 3, "column": 6, "width": 6, "height": 1 }
-              ],
-              "sections": []
+                { "fieldId": "d7665e98-a7c4-4829-c104-fb856883e043", "row": 0, "column": 0, "width": 6,  "height": 1 },
+                { "fieldId": "740e294e-6ee4-4cda-c902-823002064985", "row": 0, "column": 6, "width": 6,  "height": 1 },
+                { "fieldId": "19768973-65be-4a6f-b3de-57cfb1da48db", "row": 1, "column": 0, "width": 12, "height": 1 },
+                { "fieldId": "95d528a8-8f3d-4692-7363-44db1f96ca18", "row": 2, "column": 0, "width": 12, "height": 1 },
+                { "fieldId": "bbecbd37-ca52-4fa6-a92c-90e70aa4ec2a", "row": 3, "column": 0, "width": 12, "height": 1 },
+                { "fieldId": "2e56791e-926e-48fd-37d0-0ad60a27736d", "row": 4, "column": 6, "width": 6,  "height": 1 }
+              ]
             }
           }
         }
       ],
-      "postSubmissionTriggers": {
-        "upsertContact": {
-          "fieldsMapping": {
-            "first_name_0001": { "contactField": "FIRST_NAME" },
-            "last_name_0002": { "contactField": "LAST_NAME" },
-            "email_0003": { "contactField": "EMAIL", "emailInfo": { "tag": "UNTAGGED" } }
-          },
-          "labels": []
-        }
-      },
       "submitSettings": {
         "submitSuccessAction": "THANK_YOU_MESSAGE",
         "thankYouMessageOptions": {
@@ -174,29 +250,13 @@ curl -X POST \
             "nodes": [
               {
                 "type": "PARAGRAPH",
-                "id": "ty1",
+                "id": "ctf1a20",
                 "nodes": [
-                  {
-                    "type": "TEXT",
-                    "id": "",
-                    "nodes": [],
-                    "textData": {
-                      "text": "Thanks, we received your submission.",
-                      "decorations": []
-                    }
-                  }
+                  { "type": "TEXT", "id": "", "nodes": [], "textData": { "text": "Thanks for reaching out. We will get back to you soon.", "decorations": [] } }
                 ],
-                "paragraphData": {
-                  "textStyle": { "textAlignment": "CENTER" }
-                }
+                "paragraphData": { "textStyle": { "textAlignment": "CENTER" } }
               }
-            ],
-            "metadata": {
-              "version": 1,
-              "createdTimestamp": "2025-01-01T00:00:00.000Z",
-              "updatedTimestamp": "2025-01-01T00:00:00.000Z",
-              "id": "thank-you-msg-001"
-            }
+            ]
           }
         }
       }
@@ -204,107 +264,135 @@ curl -X POST \
   }'
 ```
 
-The response includes the created form with its `id`. Store this ID to manage the form later.
+Read `form.id` from the response — that is the `formId` to keep. Also read back `form.name`: **names are unique per namespace**, and a colliding name is silently saved as a numbered variation rather than erroring.
 
-Verify the form in the dashboard: `https://manage.wix.com/dashboard/{siteId}/forms`
+> `spamFilterProtectionLevel` defaults to `ADVANCED`; set it only to change that.
 
-## Key Details
+**A `200` proves nothing. Always run STEP 3.** Every failure mode in § Silent breakers returns `200`.
 
-### Field Configuration
+---
 
-- All `id` fields (for `formFields`, `steps`) and all `fieldId` references in the layout **must be valid UUIDs**. Generate fresh UUIDs for each form you create — do not reuse the example UUIDs above.
-- Each field needs a unique `id` and a unique `target` value. The `target` is used to map submissions to contact fields.
-- **CRITICAL: The `identifier` must be a recognized Wix value.** Custom identifiers like `"product_name"` or `"color_preference"` will cause the field to be silently dropped from the form — no error is thrown. For any generic/custom text field, use `"TEXT_INPUT"` as the identifier and set the display name via the `label` property in `textInputOptions`.
-- For plain text fields, use `"format": "UNKNOWN_FORMAT"`. For email fields, use `"format": "EMAIL"`. For phone fields, use `"format": "PHONE"`. Valid format values: `UNKNOWN_FORMAT`, `DATE`, `TIME`, `DATE_TIME`, `EMAIL`, `URL`, `UUID`, `PHONE`, `URI`, `HOSTNAME`, `COLOR_HEX`, `CURRENCY`, `LANGUAGE`, `DATE_OPTIONAL_TIME`.
-- The submit button is a `DISPLAY` field with `identifier: "SUBMIT_BUTTON"`.
-- **Build the complete form in one call — do not create throwaway "test" forms to probe field shapes.** A site has a **low form cap (~4 forms)**; iterative probing hits the cap (`maximum number of forms reached`), forcing you to `GET` the form list and `DELETE` the test forms before the real create can succeed. Assemble all fields (including any RADIO_GROUP/DROPDOWN per § "Choice fields") and POST once.
+## STEP 3: Verify the form persisted (mandatory)
 
-### Field Types Reference
+**1 · List it back** and diff against what you sent:
 
-| Identifier | componentType | format | Use case |
-|---|---|---|---|
-| `TEXT_INPUT` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Generic single-line text (use `label` for display name) |
-| `CONTACTS_FIRST_NAME` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Contact first name |
-| `CONTACTS_LAST_NAME` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Contact last name |
-| `CONTACTS_EMAIL` | `TEXT_INPUT` | `EMAIL` | Contact email |
-| `CONTACTS_PHONE` | `TEXT_INPUT` | `PHONE` | Contact phone |
-| `SUBMIT_BUTTON` | N/A (`DISPLAY` field) | N/A | Submit button |
-| `TEXT_INPUT` | `RADIO_GROUP` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (radio buttons) — see § "Choice fields" |
-| `TEXT_INPUT` | `DROPDOWN` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (dropdown) — same shape as RADIO_GROUP |
-
-> **Note:** `LONG_TEXT_INPUT` is not supported as a `componentType` via REST — it throws `INVALID_ARGUMENT`. Use `TEXT_INPUT` for all text fields.
-
-### Choice fields (RADIO_GROUP / DROPDOWN)
-
-A single-choice field (radio buttons or a dropdown — e.g. an RSVP "Will you attend?") is a **`STRING` input field**, not a separate field type. It uses `identifier: "TEXT_INPUT"`, `inputType: "STRING"`, and sets `componentType` to `RADIO_GROUP` (or `DROPDOWN`) **inside `stringOptions`**. Two things must agree or the field breaks:
-
-1. **`stringOptions.validation.enum`** must list every option `value` (an empty `enum` is for free-text only).
-2. **`stringOptions.radioGroupOptions.options[]`** carries the rendered choices — each option needs its own **UUID `id`**, a `value`, and a `label`. (For `DROPDOWN`, use `dropdownOptions` with the same `{id, value, label}` shape.)
-
-> **CRITICAL — silent fallback to TEXT_INPUT.** If `radioGroupOptions` is missing/malformed (wrong key like `choices` instead of `options`, an option missing its `id`, or an empty `validation.enum`), the API does **not** error — it silently creates the field as a plain `TEXT_INPUT`. If a choice field renders as a text box, this is why. Build it correctly on the first call; do not probe.
-
-```json
-{
-  "id": "a1b2c3d4-1002-4e00-8001-000000000002",
-  "hidden": false,
-  "identifier": "TEXT_INPUT",
-  "fieldType": "INPUT",
-  "inputOptions": {
-    "target": "attending_0002",
-    "pii": false,
-    "required": true,
-    "inputType": "STRING",
-    "readOnly": false,
-    "stringOptions": {
-      "validation": {
-        "format": "UNKNOWN_FORMAT",
-        "enum": ["Joyfully accepts", "Regretfully declines"]
-      },
-      "componentType": "RADIO_GROUP",
-      "radioGroupOptions": {
-        "label": "Will you attend?",
-        "showLabel": true,
-        "numberOfColumns": "ONE",
-        "options": [
-          { "id": "c3d4e5f6-3001-4a00-8001-000000000001", "value": "Joyfully accepts", "label": "Joyfully accepts" },
-          { "id": "c3d4e5f6-3001-4a00-8001-000000000002", "value": "Regretfully declines", "label": "Regretfully declines" }
-        ]
-      }
-    }
-  }
-}
+```bash
+curl -X GET \
+  'https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds=<formId>' \
+  -H 'Authorization: <AUTH>'
 ```
 
-`numberOfColumns` is a string enum (`"ONE"`, `"TWO"`, `"THREE"`) controlling the radio layout — omit it and the field still works (defaults to one column).
+Confirm the `id` appears, that `formFields[]` covers **every** field you sent, that `steps` is non-empty and **places every field**, and that each field's `inputOptions.required` matches what you sent — a misplaced `required` is dropped silently and this read-back is the only signal.
 
-### Layout
+**Also assert every returned `formFields[].identifier` is a value from [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types.** An invented identifier survives this read-back intact — it is stored and returned like any other — so nothing else here flags it, and the field is invisible to the owner in the editor. This is a pure string comparison against the table; it needs no extra call.
 
-The `steps[].layout.large.items` array controls how fields are positioned:
-- `row` and `column` set the position (0-based grid)
-- `width` sets the column span (max 12 for full width, 6 for half)
-- `height` is typically 1
+**2 · Verify the dashboard and Editor will actually render it:**
 
-### Post-Submission Triggers
+```bash
+curl -X GET \
+  'https://www.wixapis.com/form-schema-service/v4/forms/<formId>/summary' \
+  -H 'Authorization: <AUTH>'
+```
 
-The `postSubmissionTriggers.upsertContact` object maps form field targets to contact fields, so each submission automatically creates or updates a contact. The `fieldsMapping` keys must match the `target` values from the form fields.
+**Assert `formSummary.fields` is NON-EMPTY, with a count equal to every input field you sent** (`formFields[]` minus `SUBMIT_BUTTON` and any other `DISPLAY` field). A 5-input form returns all 5 — **including non-contact dropdowns and long-answer fields**, so do not expect only the contact-mapped ones.
 
-### Prerequisites
+**This is the dashboard-truth check for *placement*.** `summary.fields: []`, or a count short of your inputs, means the owner opens the Editor's form picker and sees an **empty form**. **Do not report success** — fix the layout placement or the GUID casing, then re-verify.
 
-The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be installed on the site. It is usually pre-installed, but if the API returns a "missing installed app" error, install it first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
+> **⚠️ Do not lean on this check to catch a bad `identifier`.** Whether an unrecognized identifier is omitted from `formSummary.fields` is **unverified** — it may well be counted here and still be unrenderable in the editor. Check `identifier`s explicitly in step 1; treat this step as covering placement only.
+
+**3 · If the form has an ARRAY field (`CHECKBOX_GROUP` / `TAGS` / `IMAGE_CHOICE`), send one real submission.** Checks 1–2 both pass on a malformed `arrayOptions.validation.items` while every submission `400`s:
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/form-submission-service/v4/submissions' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  -d '{ "submission": { "formId": "<formId>", "submissions": { "email_673d": "test@example.com", "multi_choice_a1b2": ["Option 1"] } } }'
+```
+
+Assert `200`, not `400 SUBMISSION_VALIDATION`. Then delete the test submission (`DELETE https://www.wixapis.com/form-submission-service/v4/submissions/{submissionId}`) so the owner's dashboard stays clean.
+
+**4 · Hand back the dashboard links** (see [Forms Dashboard Navigation](./forms-dashboard-navigation.md)):
+
+```
+Edit it here:      https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}
+See submissions:   https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}/submissions
+```
+
+---
+
+## Changing a form that already exists
+
+Adding, relabelling, re-requiring, reordering or retiring a field on a live form is a `PATCH`, not a second create — see **[Update Form](./update-form.md)**. Never delete-and-recreate: the `formId` is what everything downstream holds.
+
+---
+
+## Plan caps — surface the choice, never engineer around it
+
+These limits return a real `400` on create. **Do not work around any of them. Put the choice to the user — reduce, or upgrade — with the MSID and the upgrade link, wait for their answer, then create and verify.**
+
+- **Field count** — **two different caps count two different things, so check which error you got:**
+  - `Field count reached its limit of N` — the **premium** cap, enforced by the Wix Forms app from
+    the site's plan. It counts **`INPUT` fields only** — display elements and the `SUBMIT_BUTTON` do
+    **not** count against it. This is the one free sites hit at 10.
+  - `FORM_FIELDS_COUNT_EXCEEDED` — the schema-service cap (`providers-config`'s `maxFields`), which
+    counts **all** fields **including** display elements and the submit button.
+
+For either: **do NOT split the form across several schemas** to dodge it — that trades one submission record for several and consumes more of the site's form allowance. Reduce the field count, or upgrade.
+- **Step count** (`Steps count reached its limit of N`) — the premium cap on `steps.length`. Collapse the form into fewer pages, or upgrade. There is **no schema-service equivalent**, so this error never appears in the Create Form error table.
+- **Condition count** (`formRules.length`) — also premium-capped, and also absent from the Create Form error table.
+- **Form count** (`NAMESPACE_FORMS_COUNT_EXCEEDED`, `NAMESPACE_DELETED_FORMS_COUNT_EXCEEDED`, or `FORM_SIZE_EXCEEDED` for a single oversized schema) — the site hit its total-form (or trash-bin) cap. Independently of the plan, `formFields` has a hard ceiling of 500 items. Upgrade, or free a slot per STEP 0 · 3 — deleting only what is clearly install sample data.
+- **Premium fields** — file upload, signature and all four payment fields need a **Core plan or higher**; payment fields additionally need **Wix eCommerce**. Appointment needs **Wix Meetings**; the service pickers need **Wix Services**. A create including one of these on a site without the plan or app **fails**. **Do NOT suggest inlining files as base64** — it stores no real file, gives the owner nothing usable, and blows past submission size limits. Drop the field, or upgrade.
+
+> **⚠️ A plan cap is a hard block on the run, not a "note it and continue" precondition.** The schema does not exist, so neither does its `formId` or its field `target`s. Nothing that depends on the form — a frontend binding, an automation, a submissions view — can be built "in the meantime" without guessing.
+
+---
+
+## Automations on form submission
+
+To auto-respond to submissions, the automation's trigger belongs to the **app that owns the form** — and the two Forms apps have different trigger keys:
+
+| App | `appId` | Trigger key for "Form submitted" |
+|---|---|---|
+| **Wix Forms (New)** | `225dd912-7dea-4738-8688-4b8c6955ffc2` | `wix_form_app-form_submitted` |
+
+**The app and the key must be the same generation.** A form created on Form Schemas v4 belongs to the New app, so its automation must use `wix_form_app-form_submitted` **and** the New app must be the installed one. `FAILED_PRECONDITION: "Forms app is not installed on the site"` on an automation create, on a site where Wix Forms visibly *is* installed, means the **Old** app is installed and the New one isn't — fix that at STEP 0 · 1, not by swapping trigger keys.
+
+Confirm the pair against the site rather than typing it from memory: [Query Triggers](https://dev.wix.com/docs/api-reference/business-management/automations/triggers/trigger-catalog/query-triggers) filtered by `appId`, or [Get Trigger By App Id And Key](https://dev.wix.com/docs/api-reference/business-management/automations/triggers/trigger-catalog/get-trigger-by-app-id-and-key).
+
+---
 
 ## Troubleshooting
 
-| Error | Cause | Fix |
+| Error / symptom | Cause | Fix |
 |---|---|---|
-| `Unrecognized value passed for enum` | Invalid `componentType` value (e.g., `LONG_TEXT_INPUT`) | Use only `componentType` values from the schema: `TEXT_INPUT`, `RADIO_GROUP`, `DROPDOWN`, `DATE_TIME`, `PHONE_INPUT`, `DATE_INPUT`, `TIME_INPUT`, `DATE_PICKER`, `PASSWORD` |
-| Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) | Use a recognized identifier like `TEXT_INPUT` and set display name via `label` |
-| Choice field rendered as a plain text box | `radioGroupOptions`/`dropdownOptions` malformed (wrong key, option missing `id`, empty `validation.enum`) — API silently falls back to `TEXT_INPUT` | Match the § "Choice fields" shape exactly: `componentType` in `stringOptions`, `options[]` each with a UUID `id`, and `validation.enum` listing all option values |
-| `maximum number of forms reached` / form-cap error | Sites cap at ~4 forms; reached by creating throwaway test forms | `GET form-schema-service/v4/forms` then `DELETE` the unwanted forms; build the real form in one call (don't probe) |
-| `Permissions for given namespace not found` | `wix.form_app.form` namespace not active | Ensure the Wix Forms app is installed; try creating a form through the UI first to activate the namespace |
-| `missing installed app` | Wix Forms app not installed | Install app `14ce1214-b278-a7e4-1373-00cebd1bef7c` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
+| `UNSUPPORTED_FORM_NAMESPACE`, or `Permissions for given namespace not found` | Wix Forms **(New)** not installed, or a namespace other than `wix.form_app.form` | Install `225dd912-7dea-4738-8688-4b8c6955ffc2`; use `wix.form_app.form` |
+| Form reads back fine over the API but is **invisible** in the Forms dashboard and Editor | Created under a non-dashboard namespace — typically the non-existent `wix.form_platform.form` | Re-create under `wix.form_app.form`. A namespace query returning **0 results is not proof it is unusable** — it may simply be empty |
+| Automation create fails `FAILED_PRECONDITION: Forms app is not installed` although Wix Forms is installed | The **Old** Forms app (`14ce1214-…`) is installed; the New app's trigger `wix_form_app-form_submitted` needs `225dd912-…` | Install `225dd912-…` — do **not** try to fix it by swapping in the Old app's key `wix_forms-form_submit`. See § Automations on form submission |
+| Form appears in the Editor's form picker but renders **empty** | Fields not placed in `steps[].layout`, or an **uppercase** `id` whose stored lowercase form no longer matches `fieldId` | Place every field (incl. `SUBMIT_BUTTON`); use lowercase GUIDs on both sides; re-verify with `/summary` |
+| Field is returned by the API and accepts submissions, but the owner **cannot see or edit it in the Wix Forms editor** (a whole form of them opens **empty**) | Invented `identifier` (e.g. `"product_name"`) — accepted and stored, but unrecognized by the editor | Use a value from [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types; put the user's wording in the component's `label`. Assert identifiers in STEP 3 · 1 — no other check catches this |
+| Field vanishes entirely from the created form | `componentType` not valid for the field's `inputType` — the server builds no view for it | Match the `inputType` / `componentType` pair in [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types |
+| Choice field renders as a plain text box, and reads back with `textInputOptions` | `identifier` was `TEXT_INPUT` rather than `DROPDOWN` / `RADIO_GROUP` — `componentType` alone doesn't route the renderer | Set `identifier` to the choice kind and re-send the field. Deleting and re-adding it with the same `identifier` reproduces the fallback |
+| `options[N].id is not a valid GUID` on a create or `PATCH` | Option `id`s were readable slugs (`tech-opt-1`) or omitted — each needs its own lowercase GUID, client-generated | Generate one GUID per option (`uuidgen`); the field's own `id` being a GUID is not enough |
+| Choice field renders as a plain text box | `radioGroupOptions` / `dropdownOptions` malformed — wrong key (`choices` instead of `options`), an option missing its GUID `id`, or an empty `validation.enum` | Match [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Choice fields exactly: `componentType` inside the `inputType` block, every option with a lowercase GUID `id`, `validation.enum` listing all values |
+| Form lists and summarizes fine, but **every** submission returns `400` | ARRAY field with malformed `arrayOptions.validation.items` — missing `itemType`, or empty/omitted `items` | Set both `items.itemType` and `items.stringOptions.enum`; prove it with STEP 3 · 3 |
+| Every field reads back `required: false` | `required` placed inside `validation` instead of `inputOptions` | Move it to `inputOptions.required`; fix with a `PATCH` ([Update Form](./update-form.md)) rather than re-creating |
+| Contacts are never created or updated on submission | Used `postSubmissionTriggers.upsertContact` (absent from the current v4 contract — it configures nothing) | Set per-field `inputOptions.contactMapping.contactField` + `pii: true` |
+| `400 namespace has size 0, expected 10 or more` / `namespace must not be empty` on a read | The `namespace` **query parameter** was omitted from `GET .../v4/forms` (or from the `query` filter) — it is required on every read, and the violation naming a field makes it look like a body problem | Add `?namespace=wix.form_app.form` to the read; leave the payload alone |
+| `Unrecognized value passed for enum` | Invented `componentType` (e.g. `LONG_TEXT_INPUT`) | Use the `componentType` from [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types — a long answer is `identifier: TEXT_AREA` with `componentType: TEXT_INPUT` |
+| `Field count reached its limit of N` / `FORM_FIELDS_COUNT_EXCEEDED` | The site's premium-plan field cap, enforced by the Wix Forms app — unrelated to the app-declared `maxFields` in `providers-config` | § Plan caps: reduce or upgrade. Never split across schemas |
+| `Steps count reached its limit of N` | Plan's per-form step cap | Collapse to fewer pages, or upgrade |
+| `NAMESPACE_FORMS_COUNT_EXCEEDED` | Site hit its total-form cap | § Plan caps: upgrade, or free a slot (STEP 0 · 3) |
+| `DUPLICATED_FIELD_TARGETS` / `DUPLICATED_FIELD_IDS` / `MISSING_FIELD_TARGETS` | Reused `target` or `id`, or omitted `target` | Give every field a unique lowercase GUID `id` and a unique `snake_case` `target` |
+| Form saved under a different name than requested | Names are unique per namespace; a collision saves a numbered variation | Read `name` from the response and report the actual name |
+
+---
 
 ## Related Documentation
 
-- [Form Schemas API Introduction](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/introduction)
-- [Create Form API Reference](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form)
-- [Form Submissions API](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction)
+- [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) — the authoritative field-composition guide
+- [Create Form](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form) — complete request examples for a dozen form types
+- [Form object](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object) · [Update Form](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form) · [Get Form Summary](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/get-form-summary) · [List Forms Providers Configs](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms-providers-configs)
+- [Form Schemas API Introduction](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/introduction) — including the namespaces of apps made by Wix
+- [Form Submissions API](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction) · [About Submission Values](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values)
+- [Forms Dashboard Navigation](./forms-dashboard-navigation.md) · [Install Wix Apps](../app-installation/install-wix-apps.md)

--- a/skills/wix-manage/references/forms/forms-dashboard-navigation.md
+++ b/skills/wix-manage/references/forms/forms-dashboard-navigation.md
@@ -1,6 +1,6 @@
 ---
 name: "Forms Dashboard Navigation"
-description: "Builds direct links to Wix Forms dashboard pages on manage.wix.com — the forms list, the submissions table, the form builder for a specific form, standalone forms, templates, and forms settings. Pairs each main Forms entity (form, submission) with its read API so you can fetch an entity and hand back a 'view it in your dashboard' link. Use when the user asks where something is in the Wix dashboard, wants a direct link to a dashboard page, or you need a dashboard URL to include with the result of an API operation."
+description: "Builds direct links to Wix Forms dashboard pages on manage.wix.com. The paths are not guessable and appear in no API reference, so take them from here: under `https://manage.wix.com/dashboard/{metaSiteId}/`, the forms list is `wix-forms`, a form's builder is `wix-forms/form/{formId}`, and that form's submissions are `wix-forms/form/{formId}/submissions` — there is no site-wide submissions page, and nothing lives under `forms`, `form-builder` or `wix-forms-and-payments` (the legacy app). Also standalone forms, and each Forms entity paired with its read API so you can fetch one and hand back a 'view it in your dashboard' link."
 ---
 
 # Forms Dashboard Navigation
@@ -13,32 +13,33 @@ Build direct links into the Wix Forms pages of a site's dashboard. For the gener
 |---|---|---|
 | Forms list | `wix-forms` | All forms on the site |
 | Form builder | `wix-forms/form/{formId}` | Edit a specific form (fields, rules, submit settings) |
+| Submissions | `wix-forms/form/{formId}/submissions` | That form's submissions table |
 | Standalone form | `wix-forms/standalone-form` | Create a standalone form (has its own shareable page, not embedded in a site page) |
-| Submissions | `wix-forms-and-payments/submissions` | Submissions table across forms |
-| Templates | `wix-forms-and-payments/templates` | Create a form from a template |
-| Forms settings | `wix-forms-and-payments/settings` | Forms-level settings |
 
-Two URL namespaces appear here because the forms management pages and the form builder are registered by two apps (`14ce1214-b278-a7e4-1373-00cebd1bef7c` and `225dd912-7dea-4738-8688-4b8c6955ffc2`); `wix-forms` also redirects to the forms list, so it's the stable entry point.
+**Every Forms page is under `wix-forms`** — the namespace **Wix Forms (New)** `225dd912-7dea-4738-8688-4b8c6955ffc2` registers, the app that owns the Form Schemas v4 API. A `wix-forms-and-payments/...` path belongs to the legacy **Wix Forms (Old)** app `14ce1214-b278-a7e4-1373-00cebd1bef7c`: don't build one, and never install or target that app (see [Create Form](./create-form.md) § Silent breakers).
 
-Entity-specific links (`{formId}`) accept the entity's ID appended as an extra path segment. Query params can follow.
+**Submissions are per form**, hanging off that form's builder path — there is no site-wide submissions page to link to. With no `{formId}` in hand, link the forms list and let the owner pick.
+
+Entity-specific links (`{formId}`) take the entity's ID as a path segment, and query params can follow. The dashboard appends its own view state to the submissions URL — `folder` (a JSON-encoded breadcrumb), `sort` (e.g. `createdDate+desc`) and `selectedColumns` (a comma-separated list of field **`target`**s) — none of which you need to construct: the bare path opens the table with the owner's defaults.
 
 ## Pairing Entities with Their Read APIs
 
-Fetch the entity via REST, then link the matching dashboard page. All calls use `https://www.wixapis.com` with an `Authorization` header. Dashboard forms use the `wix.form_app.form` namespace.
+Fetch the entity via REST, then link the matching dashboard page. All calls use `https://www.wixapis.com` with an `Authorization` header. Dashboard forms live in the **`wix.form_app.form`** namespace — every Forms call that takes a namespace, as a query parameter or inside a filter, takes that exact value.
 
 | Entity | Read API | Dashboard link |
 |---|---|---|
 | Form | `GET /form-schema-service/v4/forms` · `POST /form-schema-service/v4/forms/query` · `GET /form-schema-service/v4/forms/{formId}` | `wix-forms/form/{formId}` (edit) or `wix-forms` (list) |
-| Submission | `POST /form-submission/v4/submissions/namespace/query` (filter must include the `namespace`) · `GET /form-submission/v4/submissions/{submissionId}` | `wix-forms-and-payments/submissions` |
+| Submission | `POST /form-submission-service/v4/submissions/namespace/query` (the filter must carry `"namespace": "wix.form_app.form"`) · `GET /form-submission-service/v4/submissions/{submissionId}` | `wix-forms/form/{formId}/submissions` — the `formId` comes off the submission |
 
 Example — after creating a form, hand back its links:
 
 ```
 Created "Contact Form".
 Edit it here: https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}
-See submissions: https://manage.wix.com/dashboard/{metaSiteId}/wix-forms-and-payments/submissions
+See submissions: https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}/submissions
 ```
 
 ## Notes
 
-- Creating forms via the [Create Form](./create-form.md) recipe (Form Schemas API) makes them appear in the forms list above.
+- Creating forms via the [Create Form](./create-form.md) recipe (Form Schemas API) makes them appear in the forms list above — **but only when the form was created under the `wix.form_app.form` namespace with Wix Forms (New) installed.** A form created under any other namespace is reachable over the API and completely absent from these pages.
+- **Before handing back a `wix-forms/form/{formId}` link, confirm the form actually renders**: `GET https://www.wixapis.com/form-schema-service/v4/forms/{formId}/summary` must return a non-empty `formSummary.fields` whose count matches every input field. An empty summary means the owner will open this link to a blank form (Create Form, STEP 3).

--- a/skills/wix-manage/references/forms/forms-dashboard-navigation.md
+++ b/skills/wix-manage/references/forms/forms-dashboard-navigation.md
@@ -1,6 +1,6 @@
 ---
 name: "Forms Dashboard Navigation"
-description: "Builds direct links to Wix Forms dashboard pages on manage.wix.com. The paths are not guessable and appear in no API reference, so take them from here: under `https://manage.wix.com/dashboard/{metaSiteId}/`, the forms list is `wix-forms`, a form's builder is `wix-forms/form/{formId}`, and that form's submissions are `wix-forms/form/{formId}/submissions` — there is no site-wide submissions page, and nothing lives under `forms`, `form-builder` or `wix-forms-and-payments` (the legacy app). Also standalone forms, and each Forms entity paired with its read API so you can fetch one and hand back a 'view it in your dashboard' link."
+description: "Builds direct links to Wix Forms dashboard pages on manage.wix.com. The paths are not guessable and appear in no API reference, so take them from here: under `https://manage.wix.com/dashboard/{metaSiteId}/`, the forms list is `wix-forms`, a form's builder is `wix-forms/form/{formId}`, and that form's submissions are `wix-forms/form/{formId}/submissions` — there is no site-wide submissions page, and nothing lives under `contacts/forms`, `forms`, `form-builder` or `wix-forms-and-payments` (the legacy app). Also standalone forms, and each Forms entity paired with its read API so you can fetch one and hand back a 'view it in your dashboard' link."
 ---
 
 # Forms Dashboard Navigation
@@ -8,6 +8,8 @@ description: "Builds direct links to Wix Forms dashboard pages on manage.wix.com
 Build direct links into the Wix Forms pages of a site's dashboard. For the general URL contract (metaSiteId, fallbacks, redirects), see [Dashboard Navigation](../dashboard-navigation/dashboard-navigation.md).
 
 ## Main Pages
+
+**Never goess or answer a Forms dashboard-link request from memory** because the routes below are the only correct ones.
 
 | Page | URL after `/dashboard/{metaSiteId}/` | What it manages |
 |---|---|---|

--- a/skills/wix-manage/references/forms/update-form.md
+++ b/skills/wix-manage/references/forms/update-form.md
@@ -1,0 +1,122 @@
+---
+name: "Update Form"
+description: "Changes a Wix form that already exists, with Form Schemas v4 `PATCH` — add a field to my form, add a dropdown, make a field required or optional, rename a label, reorder or retire a question. Covers reading the form back for its `revision` (and the required `namespace` query parameter), the whole-form body that a `PATCH` needs, the wholesale `formFields` replace that silently soft-deletes anything you omit, changing a field's component type in place, retiring a field that already has submissions, and the read-back that proves what was stored. Use whenever the form exists and the request changes what it collects; use Create Form when there is no form yet."
+---
+# RECIPE: Update a Wix Form
+
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`. Send `wix-site-id: <SITE_ID>` when the token is account-scoped.
+
+Change what a form collects — **add a field, relabel one, tighten a rule, reorder, retire one** — on a form that already exists. **Composing the field itself is not here**: [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) owns the `identifier` / `inputType` / `componentType` table and the options/enum shapes, and [Create Form](./create-form.md) § Silent breakers apply to an added field exactly as to a created one.
+
+**A `PATCH`, never a delete-and-recreate.** An update keeps the `formId` everything downstream already holds — a frontend binding, an automation, a saved dashboard view — and spends no slot against the site's form cap.
+
+---
+
+## The call
+
+```bash
+# 1 · read the form back: you need its current revision, and every field you intend to keep
+curl -X GET \
+  'https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds={formId}' \
+  -H 'Authorization: <AUTH>'
+
+# 2 · send that form back with your change applied
+curl -X PATCH \
+  'https://www.wixapis.com/form-schema-service/v4/forms/{formId}' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  -d '{ "form": {
+      "id": "{formId}",
+      "revision": "<the revision you just read>",
+      "name": "<the form name>",
+      "namespace": "wix.form_app.form",
+      "formFields": [ ...every field, with your change applied... ],
+      "steps": [ ...every step, with the layout item for a new field... ]
+  } }'
+```
+
+- **⚠️ `namespace` is a REQUIRED query parameter on the read, and this is what a revise run trips over.** Without it the read returns `400 namespace has size 0, expected 10 or more, namespace must not be empty` — a violation naming a *field*, so it reads like a body problem. Fix the call, don't reshape the payload. (The filter on `POST .../v4/forms/query` needs it too.)
+- **The read-back is the body.** Apply your change to what the `GET` returned and send that as `form`. `namespace` is **immutable** and travels along; **there is no `fieldMask`**, and no `revision` outside `form` — inventing either is a silent partial write.
+- **⚠️ Append to `formFields`; never rebuild the entries you read.** `[...form.formFields, newField]` works. Mapping the array to "clean up" each field — dropping `fieldType`, re-shaping an options block — fails with `fieldType cannot be provided with any these fields: input_options, display_options` on **every** field at once. The read-back's field objects are already a valid write shape: pass them through untouched and touch only the one field you are changing.
+- **`formFields` is replaced wholesale.** Wix: *"Any field that's missing from the array you send is moved to `deletedFormFields`, so resend every field you want to keep."* Same for `steps[].layout` — miss an item and that field goes unplaced, which renders empty. Drops are recoverable from `deletedFormFields`, but nothing announces them.
+- **A stale `revision` is rejected** — re-`GET` and re-apply; never guess or increment it.
+- **Plan caps apply to an added field.** `Field count reached its limit of N` on a `PATCH` is the site's premium cap: reduce or upgrade, with the choice put to the user ([Create Form](./create-form.md) § Plan caps). Never split the form across schemas to dodge it.
+
+---
+
+## Adding a field
+
+**Start by reading [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) § Field types and § Choice fields** for the field kind you're adding: it gives the `identifier` / `inputType` / `componentType` triple — take all three from one row, and note that a dropdown or radio is `inputType: "STRING"` — plus the options/enum shape and the GUID every option needs. [Create Form](./create-form.md) § Choice fields carries a complete dropdown body to copy. Composing a field from memory is what turns one `PATCH` into eight.
+
+Then four things are yours to generate:
+
+- **`id`** — a fresh lowercase GUID (`uuidgen | tr 'A-Z' 'a-z'`), unique in the form.
+- **`target`** — the immutable submission key, unique across the form: snake_case plus a short random suffix (`job_industry_7f2b`). **A duplicate `target` is accepted and silently stores nothing** for every field but one.
+- **one GUID per choice option** — `options[]` each need their own, exactly like the field's; a readable slug is rejected ([Create Form](./create-form.md) § Choice fields). Generate them with `uuidgen`, never by hand.
+- **the choices, declared twice** — every option needs `id` + `value` + `label`, and `validation.enum` must list every one of those `value`s. **An empty `validation` is a free-text field, not a dropdown**; the general "always include `validation`, even as `{}`" rule does not apply here, and getting it wrong is accepted with a `200`.
+- **the layout item** — append to `steps[<n>].layout.large.items`, mirroring into `medium` / `small` if the form has them:
+
+```json
+{ "fieldId": "<the new field's id>", "row": <next row>, "column": 0, "width": 12, "height": 1 }
+```
+
+A field missing from the layout isn't dropped, but it sorts last and has no defined position in the owner's builder. To place it mid-form, insert at that `row` and bump every item at or after it — `row` restarts at 0 in each step.
+
+**A choice field's `identifier` is its kind** — `DROPDOWN`, `RADIO_GROUP`, `CHECKBOX_GROUP`, `TAGS` — never `TEXT_INPUT`, which is accepted and stored as a plain text input ([Create Form](./create-form.md) § Choice fields).
+
+---
+
+## The other changes
+
+| Change | How |
+|---|---|
+| Label, placeholder, options, validation, order | Patch them and stop — nothing downstream needs updating |
+| A field's component type, in place | Send that field with the **choice `identifier`** and only the new options block; leaving `textInputOptions` beside `dropdownOptions` reads back as the text-input fallback |
+| Retire a field the form has submissions for | Set `hidden: true` — "hidden from submitters": the field stops rendering, and the submissions already collected under it keep their meaning. Dropping it from the array soft-deletes it instead |
+| Remove a field added by mistake this run | Drop it from `formFields`; it lands on `deletedFormFields` |
+| Rename a `target` | **Never.** It is the storage key, so a rename orphans every submission already collected under the old one. Change the *label* instead |
+
+---
+
+## Verify — an update regresses a form exactly as a create can
+
+**A `200` on the `PATCH` proves the body parsed, nothing about what was stored.** Read the form back, every time:
+
+```
+GET https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds={formId}
+GET https://www.wixapis.com/form-schema-service/v4/forms/{formId}/summary
+```
+
+Assert on that read-back, not on the `PATCH` response:
+
+- the changed field is there, carrying the `identifier` and `componentType` you sent — **a choice field with a non-empty `options[]`**, which is where a dropdown that degraded to a text input shows up;
+- every field you meant to keep is still present, and every `inputOptions.required` still reads back as sent;
+- `formSummary.fields` still holds one entry per input field — that is what the owner's dashboard renders.
+
+Then hand back the dashboard links ([Forms Dashboard Navigation](./forms-dashboard-navigation.md)): the form builder at `wix-forms/form/{formId}`, and that form's submissions at `wix-forms/form/{formId}/submissions`. New submissions carry the new field; past ones don't.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `400 namespace has size 0, expected 10 or more` / `namespace must not be empty` on a read | The `namespace` **query parameter** was omitted — it is required on every listing read, and the violation naming a field makes it look like a body problem | Add `?namespace=wix.form_app.form` to the read; leave the payload alone |
+| `fieldType cannot be provided with any these fields: input_options, display_options` — on every field | The read-back's `formFields` were re-mapped or "cleaned" before sending | Send the fields exactly as read and append the new one: `[...form.formFields, newField]` |
+| `inputType enum must be in [UNKNOWN_INPUT_TYPE, STRING, NUMBER, …]` | An invented `inputType` such as `ENUM` (with an `enumOptions` block) for a choice field | A dropdown or radio is `inputType: "STRING"` with `stringOptions.componentType`; multi choice is `ARRAY` |
+| The `PATCH` is rejected for a `revision` mismatch | Someone (or an earlier call) updated the form since your read | Re-`GET` and re-apply the change; never increment the revision yourself |
+| Fields that were on the form are gone after the update | `formFields` was sent partial — the omitted fields moved to `deletedFormFields` | Re-send them in a further `PATCH`, from `deletedFormFields` in the read-back; always send the whole array |
+| Surviving fields render empty for the owner | `steps[].layout` was sent without their items | Re-send every layout item, including `SUBMIT_BUTTON`'s; re-verify with `/summary` |
+| The added dropdown/radio reads back as a text input with `textInputOptions` | `identifier` was `TEXT_INPUT` rather than the choice kind — `componentType` alone doesn't route the renderer | Set `identifier` to the choice kind and re-send. Deleting and re-adding the field with the same `identifier` reproduces it ([Create Form](./create-form.md) § Choice fields) |
+| The update lands but the field never appears in submissions | The new field shares a `target` with an existing one — the server keeps one and the rest store nothing | Give it a unique `target` and `PATCH` again |
+| `Field count reached its limit of N` | The site's premium field cap, counting `INPUT` fields | Reduce, or put the upgrade choice to the user ([Create Form](./create-form.md) § Plan caps) |
+
+---
+
+## Related Documentation
+
+- [Create Form](./create-form.md) — composing fields, the identifier table, choice fields, the layout rules, plan caps
+- [Forms Dashboard Navigation](./forms-dashboard-navigation.md) — the builder and submissions links to hand back
+- [Update Form](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form) — the `PATCH` contract and its replace semantics
+- [Form object](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object) — `revision`, `hidden`, `deletedFormFields`, `steps[].layout`
+- [About Form Fields](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/about-form-fields) — every field-level rule

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -114,4 +114,8 @@ Seeding is **admin-only** — not part of the client, which is built solely per 
 For any later admin/management request, work as in STEP 4: your vertical's seed module first, else
 `wix-base44-connector` doc discovery — all over the connector.
 
+**A change to what the business data COLLECTS is one of these, however UI it sounds** — a new form
+field, product option or service setting. Change it on Wix first per the vertical's `seed/SEED.md`,
+then edit the client against the verified result.
+
 version: v1341

--- a/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
@@ -15,6 +15,12 @@ field — the shipped utils supply the schema behind it, the state, the validati
 > Use **`cms`** only when the app must **read the entries back** (a gallery, a listing, "my
 > submissions") — a visitor cannot read Forms submissions. Submit-only → forms.
 
+> **⚠️ "Add a field" is a SCHEMA change.** *"Add a dropdown for job industry"*, *"make the phone
+> optional"*, *"drop the budget question"* — all reads like UI work and all are a `PATCH` to the live
+> schema (`seed/SEED.md`, REVISE): patch it, verify, rewrite `wix-forms.config.js`, **then** wire the
+> control. A field the visitor can fill that isn't in the schema is **silent data loss** — the value
+> reaches no submission, inbox or contact, and the submit still resolves `true`.
+
 ## What ships (utils only)
 
 | file | what it is |
@@ -24,7 +30,7 @@ field — the shipped utils supply the schema behind it, the state, the validati
 | `rest/wix-forms-submissions.js` | Write transport: `toSubmissionValues`, `createSubmission`, `SUBMITTED_OK`, the file flow (`getMediaUploadUrl`, `uploadSubmissionFile`, `uploadFormFiles`), `submissionViolations`. |
 | `hooks/useWixForm.js` | The form's non-visual half: `useWixForm(formId)` → `{ form, values, setValues, bind, submit, validate, errors, loading, read }`. Also exports `validateField`, `mapSubmissionErrors`, `FORM_ERROR`. Not on React? Those plus `lib/` are the load-bearing part; port the state around them. |
 | `wix-config.js` *(shared)* | the two ids, written by the install step. |
-| `wix-forms.config.js` *(generated)* | **the gate** — `WIX_FORMS`: each form's `formId` + read-back `targets`, written by the seed after verification. |
+| `wix-forms.config.js` *(generated)* | **the gate** — `WIX_FORMS`: each form's `formId` + read-back `targets`, written by the seed after verification. Its one later edit is a verified schema change (REVISE), never a hand-typed field. |
 | `WixManageBanner` *(shared)* | Dev-only manage banner — mount it in your Layout. |
 
 ## Prerequisites — a HARD GATE
@@ -384,6 +390,9 @@ Don't reach for `role="form"`, an `aria-label` on an input that already has a `<
 ## Hard rules
 
 - A visitor-fillable form is this vertical, not `cms`.
+- **Never hold a form field in local component state** — a value outside the hook's `values` submits
+  nothing. Adding a field is a schema change: `seed/SEED.md`, REVISE.
+- **Never answer a field request with a dashboard link** — that link is for the owner's own edits.
 - Read and write only through the shipped helpers — never hand-build a Wix Forms URL.
 - Never invent a `target`, label, option or constraint — every one comes from the schema (authored
   markup included). Never detect a control by its `target` name either.
@@ -412,8 +421,8 @@ Don't reach for `role="form"`, an `aria-label` on an input that already has a `<
 
 Three sources answer what this file doesn't: the **JSDoc** in `hooks/useWixForm.js` and
 `lib/wix-form-schema-utils.js`; the **Wix reference** below; and `seed/SEED.md` for how a field was
-authored. Calling an endpoint the helpers don't wrap is fine via `wixApiRequest` — look up the exact
-method and body first (or use the `wix-docs` skill), never guess.
+authored, and REVISE for changing one. Calling an endpoint the helpers don't wrap is fine via
+`wixApiRequest` — look up the exact method and body first (or the `wix-docs` skill), never guess.
 
 - Form object (the shape `form` and its fields arrive in): https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md
 - Form Schemas API: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md
@@ -438,21 +447,28 @@ checks the dashboard summary, sends and deletes one real submission), then write
 `src/rest/wix-forms.config.js`. Needs an elevated credential, and **does not run in parallel with the
 client** — see Prerequisites.
 
+**Changing a form that already exists** — a new field, a relabel, a tightened rule — is that doc's
+**REVISE** action: `PATCH` on the current `revision`, re-verify, rewrite the config, wire the
+control. Never a second create.
+
 ## Point the user to their dashboard
 
 Substitute the site's `metaSiteId`:
 
 - **Forms list** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms`
-- **Form builder** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}` → add,
-  relabel, reorder or require fields; every change reflects on the site with no code change.
-- **Submissions** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms-and-payments/submissions`
-- **Forms settings** (incl. notifications) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms-and-payments/settings`
+- **Form builder** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}` → where
+  the **owner** edits fields; a relabel or new option reaches a looped form with no code change, a new
+  field still needs a control. **Asked to change the form yourself? REVISE, not this link.**
+- **Submissions** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-forms/form/{formId}/submissions`
+  → per form, off its builder path; there's no site-wide submissions page to link
 - **Contacts** — `https://manage.wix.com/dashboard/{metaSiteId}/contacts` → contact-mapped fields
   create or update a contact automatically.
 
 ## Verify
 
 - [ ] `wix-forms.config.js` exists; every `formId` comes from `WIX_FORMS`, none typed by hand.
+- [ ] Every control's `name` inside the `<form>` is a target in `WIX_FORMS.<key>.targets`, and its
+      value lives in the hook's `values` — **no field is backed by local state**.
 - [ ] `WIX_CLIENT_ID` set (not the placeholder).
 - [ ] Looped form: relabel a field in the dashboard, reload, the new label appears with no code
       change. Authored form: every `target` in the JSX matches `WIX_FORMS.<key>.targets` exactly.

--- a/skills/wix-vibe-headless/references/forms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/forms/seed/SEED.md
@@ -1,11 +1,23 @@
 # Forms — seeding (Form Schemas v4 REST)
 
-Creating a form is an **admin/build-time** job, in six sequential steps. Each has a section below.
+**Two actions live in this doc — decide which one you're doing before reading on.** Both are
+**admin/build-time** work over an elevated credential, and both run through the same six steps:
+
+| action | when | the steps it uses |
+|---|---|---|
+| **CREATE a form** — `POST` | there's no form yet: the app needs a contact / quote / application form and nothing has been created for it | all six, in order |
+| **REVISE a form** — `PATCH` | the form already exists and a request changes **what it collects**: *"add a dropdown for job industry"*, *"make the phone optional"*, *"add a file upload"*, *"drop the budget question"* | 1 (auth) → 3 (author just the new field) → **4b · Revising a form later** → 5 (re-verify) → 6 (rewrite the config, then wire the control) |
+
+A field the visitor can fill that isn't in the schema is **silent data loss** — no submission, no
+inbox, no contact, and the submit still resolves `true`. So never local component state, and never
+delete-and-recreate a live form: **`PATCH` it**, keeping the `formId` the UI already imports.
+
+The six steps, each with a section below:
 
 1. **Authenticate** — get an elevated credential; the public client ID cannot write.
-2. **Install the Wix Forms app** — idempotent, and nothing works until it's there.
+2. **Install the Wix Forms app** — idempotent, and nothing works until it's there. *(create only.)*
 3. **Author the form body** — adapt the every-field payload to what the request asks for.
-4. **Create the form** — POST each body; a `200` here means almost nothing.
+4. **Create the form** — POST each body; a `200` here means almost nothing. *(revising: **4b**.)*
 5. **Verify it works** — read the form back, and **submit to it once** for real.
 6. **Hand off** — the verified `formId` + field `target`s are written to a file the UI imports.
 
@@ -22,7 +34,7 @@ live Wix API reference.
 | 3 | Create Form | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form.md | the create call, plus 10 complete request examples — the source of the payload below |
 | 3 | Form object | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md | each property individually, incl. form-level settings this doc doesn't cover |
 | 4 | Form Schemas API | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md | every schema method (get, list, delete, enable/disable) |
-| 4 | Update Form | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form.md | revising a form without losing its `formId` |
+| 4b | Update Form | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/update-form.md | the `PATCH`: revising a form without losing its `formId`, and the whole-array replace semantics |
 | 4 | List Forms Providers Configs | https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms-providers-configs.md | the Forms **app's** ceiling on fields and forms — **not** the site's plan cap, which this call cannot tell you (see step 4) |
 | 5 | Create Submission | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/create-submission.md | the submission call used to prove the form accepts data |
 | 5 | About Submission Values | https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/about-submission-values.md | the value shape each `inputType` submits — string, array, address object, … |
@@ -77,8 +89,10 @@ costs nothing.
 ## 3 · Author the form body — every field type
 
 There is **one** create call:
-`POST https://www.wixapis.com/form-schema-service/v4/forms` with `{ "form": { … } }`.
-**You author that body**, starting from the payload below and adapting it to the request.
+`POST https://www.wixapis.com/form-schema-service/v4/forms` with
+`{ "form": { "namespace": "wix.form_app.form", … } }` — that namespace is the Wix Forms app's, and
+the only one the owner's dashboard shows. **You author that body**, starting from the payload below
+and adapting it to the request.
 
 The payload is one form holding **every field type Wix Forms supports**. Each field block is copied
 verbatim from the official Create Form examples, so the `identifier` / `inputType` / `componentType`
@@ -155,10 +169,18 @@ owner's dashboard, or on the first real submission.
 - **`required` lives at `inputOptions.required`**, never inside a validation block.
 - **`validation` is always present**, even as `{}`, and nests under the **`inputType`** options
   object — not the `componentType` one.
+- **A choice field's `identifier` IS its kind** — `DROPDOWN`, `RADIO_GROUP`, `CHECKBOX_GROUP`,
+  `TAGS` — matching the `componentType`, never `TEXT_INPUT`: the identifier routes the field to its
+  renderer, so `TEXT_INPUT` + `componentType: DROPDOWN` is accepted and stored as a text input. (A
+  long answer is `TEXT_AREA` for the same reason.)
 - **A choice field declares its options twice** — the component's `options[]` and the validation
   `enum` (`STRING`) or `items.stringOptions.enum` + `itemType` (`ARRAY`) — and the two must agree.
   Get it wrong and the create still returns `200`: the field is created as a **plain text box**,
   losing its choices. Only the 5a component check catches it.
+- **A choice field that came back as a text box: read which options block came home.**
+  `textInputOptions` where you sent `dropdownOptions` is that fallback — and with a well-formed block
+  and `enum`, the cause is the `identifier`. Re-sending it, or delete-and-re-add with the same
+  identifier, reproduces it.
 - **`target` is the immutable submission key**: starts with an ASCII letter, letters/digits/`_`
   only, no `__`, unique within the form. Use field's label converted to snake_case with _ and 6 random alphanumeric  
   characters as the field target, e.g. "First name" -> `first_name_a689be`.
@@ -1578,7 +1600,7 @@ always on the public host, never `/_api/`:
 
 ```
 POST https://www.wixapis.com/form-schema-service/v4/forms
-{ "form": { … the body from step 3 … } }
+{ "form": { "namespace": "wix.form_app.form", … the rest of the body from step 3 … } }
 ```
 
 Read **`form.id`** from the response — that's the `formId` the rest of the run carries. **Record it
@@ -1625,16 +1647,64 @@ proves the form works. Two failures worth recognizing before you retry:
   than discovering the limit after a full authoring pass, and count every entry in `formFields`, the
   `SUBMIT_BUTTON` included.
 
-**Revising a form later** — add a field, relabel one, tighten a rule:
+## 4b · Revising a form later
+
+Add a field, relabel one, tighten a rule, retire one — a `PATCH`, never a second create. Everything
+above still applies; this is the delta.
+
+**Read the form back first — you need its `revision`.** The `formId` comes from
+`src/rest/wix-forms.config.js` (`WIX_FORMS.<key>.formId`), never typed by hand:
 
 ```
+GET https://www.wixapis.com/form-schema-service/v4/forms?namespace=wix.form_app.form&formIds=<formId>
 PATCH https://www.wixapis.com/form-schema-service/v4/forms/<formId>
-{ "form": { …, "revision": "<the form's current revision>" } }
+{ "form": { …the whole object you just read, with your change…, "revision": "<its current revision>" } }
 ```
 
-Never delete-and-recreate: a `PATCH` keeps the `formId` the UI already holds and spends no extra slot
-against the site's form cap. Re-run step 5 afterwards — an update regresses a layout exactly as a
-create can.
+- **`namespace` is a required query parameter on the read**, hence the `?namespace=` above. Without it
+  the read `400`s with `namespace has size 0, expected 10 or more` — a violation naming a *field*, so
+  it reads like a body problem. Fix the call, not the payload.
+- **The read-back is the `PATCH` body.** Apply the change to what the `GET` returned and send that.
+  `namespace` is immutable and travels along; **there is no `fieldMask`**, and no `revision` outside
+  `form`. Inventing either is a silent partial write.
+- **`formFields` replaces wholesale.** Wix: *"Any field that's missing from the array you send is
+  moved to `deletedFormFields`, so resend every field you want to keep."* `steps` behaves the same
+  way. Drops are recoverable from `deletedFormFields` — if you notice, which is step 5's job.
+- **A stale `revision` is rejected** — re-`GET` and re-apply; never guess or increment it.
+- **A new field needs three things generated**: a fresh UUID `id`, a `target` unique in the form
+  (`job_industry_7f2b`), and — for a choice field — an options block whose `enum` and `options[]`
+  agree. Step 3 is the shape, and its warnings still hold.
+
+**Add the layout item too** — append to `steps[<n>].layout.large.items`, mirroring into `medium` /
+`small` if the form has them:
+
+```json
+{ "fieldId": "<the new field's id>", "row": <next row>, "column": 0, "width": 12, "height": 1 }
+```
+
+A field missing from the layout isn't dropped, but it sorts last and has no defined position in the
+owner's builder. To place it mid-form, insert at that `row` and bump every item at or after it — `row`
+restarts at 0 per step.
+
+**Changing a field's component type in place** — a text input that should have been a dropdown — means
+the choice `identifier` and **only** the new options block; don't leave `textInputOptions` beside
+`dropdownOptions`. A read-back still showing `textInputOptions` is the identifier, not the block.
+
+**The other revisions:**
+
+- **label, placeholder, options, validation, order** — patch and stop. The client reads all of those
+  live from the schema, so no config rewrite and no code change follows.
+- **retiring a field the form has submissions for** — set `hidden: true` ("hidden from submitters":
+  the field stops being rendered, and the submissions already collected under it keep their meaning)
+  rather than dropping it from the array. Drop only a field added by mistake in this same run.
+- **never rename a `target`** — it's the storage key, so a rename orphans every submission already
+  collected under the old one. Change the *label* instead.
+
+**Then re-run step 5 in full** — a `PATCH` regresses a form exactly as a create does, and §5a is where
+a dropdown that silently became a text input gets caught. Then step 6, revising: add the read-back
+`target` to `src/rest/wix-forms.config.js` (the one sanctioned edit to that file outside a seed run,
+and only *after* step 5 passes) and wire the control per `INSTRUCTIONS.md`. The field is live for new
+submissions; past ones don't carry it. Step 4's plan gates apply to an added field too.
 
 ## 5 · Verify it works
 
@@ -1670,6 +1740,9 @@ against the returned `form.formFields`:
 ```
 GET https://www.wixapis.com/form-schema-service/v4/forms/<formId>/summary
 ```
+
+*(The summary and the single-form `GET` take the id in the path, so neither needs the `namespace`
+query parameter — every **listing** read does.)*
 
 Assert `formSummary.fields` is **non-empty**, with one entry per input field you sent (everything in
 `formFields` except the `SUBMIT_BUTTON`). The summary is exactly what the Wix dashboard renders, so a
@@ -1735,8 +1808,8 @@ DELETE https://www.wixapis.com/form-submission-service/v4/submissions/<id>
 The id comes from the 5c response as **`submission.id`**: REST returns `id`, not the `_id` the
 reference schema shows (that's the SDK's shape). Do this every time — the owner's inbox is a real
 business inbox, and a probe left in it looks like a real enquiry. If a probe ever escapes, find it
-with `POST /form-submission-service/v4/submissions/namespace/query` filtered by `formId` +
-`namespace`.
+with `POST /form-submission-service/v4/submissions/namespace/query`, filtered by `formId` and
+`"namespace": "wix.form_app.form"`.
 
 ## 6 · Hand off
 
@@ -1745,8 +1818,9 @@ form, keyed by the form's name lowercased with each run of non-alphanumerics col
 `_` (`"Quote request"` → `quote_request`):
 
 ```js
-// Written by the seed run once step 5 passed. Do not hand-edit, and do not create it early:
-// its existence is what proves the form schemas were created AND verified.
+// Written by the seed run once step 5 passed. Do not create it early: its existence is what proves
+// the form schemas were created AND verified. Its only later edit is a verified schema change —
+// see step 4b; never a hand-typed field.
 export const WIX_FORMS = {
   contact: { formId: "…", name: "Contact", targets: { email: true, message: true } },
 };

--- a/yaml/wix-manage-evals/forms/create-form.yml
+++ b/yaml/wix-manage-evals/forms/create-form.yml
@@ -1,0 +1,97 @@
+name: forms/create-form
+description: >-
+  Verifies the agent reads the create-form recipe when asked to build a Wix
+  form with custom fields, and produces a Form Schemas v4 request that uses
+  the Wix Forms (New) app, the wix.form_app.form namespace, predefined field
+  identifiers, a well-formed choice field, per-field contactMapping, and a
+  layout placing every field — then verifies the result rather than trusting
+  the 200.
+triggerPrompt: >-
+  Build a contact form on my Wix site that collects first name, last name,
+  email, a "How did you hear about us?" dropdown with the options Google,
+  Instagram and Friend, and a message box. Email should be required, and
+  submissions should create contacts.
+tags: [forms]
+maxTokens: 800000
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install Wix Forms (New) — a blank site has no forms app, and the create 400s without it
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 225dd912-7dea-4738-8688-4b8c6955ffc2
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/forms/skills/create-form
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked for a Wix contact form with first name, last name, a
+      required email, a "How did you hear about us?" dropdown (Google,
+      Instagram, Friend), and a message box, with submissions creating
+      contacts.
+
+      Pass if the response builds the form on the Form Schemas v4 API
+      (POST /form-schema-service/v4/forms) AND:
+      - uses namespace "wix.form_app.form", AND
+      - names the Wix Forms app as 225dd912-7dea-4738-8688-4b8c6955ffc2 if it
+        names one at all, AND
+      - uses predefined identifiers for the fields (CONTACTS_FIRST_NAME,
+        CONTACTS_LAST_NAME, CONTACTS_EMAIL, DROPDOWN, TEXT_AREA or TEXT_INPUT,
+        SUBMIT_BUTTON) rather than invented strings like "how_did_you_hear", AND
+      - builds the dropdown as inputType STRING with componentType DROPDOWN,
+        every option carrying its own id/value/label AND
+        stringOptions.validation.enum listing the same three values, AND
+      - puts the required flag at inputOptions.required (NOT inside
+        validation), AND
+      - maps contacts with per-field inputOptions.contactMapping.contactField
+        (NOT postSubmissionTriggers / upsertContact), AND
+      - includes a steps[].layout placing every field including the
+        SUBMIT_BUTTON, with lowercase GUIDs matching the field ids, AND
+      - verifies the created form afterwards (list read-back and/or
+        GET /form-schema-service/v4/forms/{formId}/summary) rather than
+        treating the 200 as proof.
+
+      Fail if the response:
+      - targets the old Wix Forms app 14ce1214-b278-a7e4-1373-00cebd1bef7c, OR
+      - uses any namespace other than wix.form_app.form (e.g.
+        wix.form_platform.form), OR
+      - invents an identifier for the dropdown or the message field, OR
+      - emits the dropdown as a plain text input, or omits option ids or the
+        validation enum, OR
+      - uses postSubmissionTriggers.upsertContact for contact mapping, OR
+      - omits the layout, or leaves the submit button unplaced, OR
+      - proposes creating throwaway test forms to probe the field shape, OR
+      - works around a field-count or plan limit by splitting the form across
+        several schemas instead of telling the user to reduce or upgrade.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Judge the quality of the tool-call path, not just the final answer.
+
+      Pass if:
+      - the agent opened the create-form recipe from the recipes index before
+        composing the request, AND
+      - it assembled the whole form in a single create call rather than
+        iterating with probe forms, AND
+      - every Wix API detail it states (endpoint, identifiers, enums, where
+        `required` goes) traces to a doc it read, not to memory, AND
+      - it verified the created form by reading it back, rather than treating
+        the create's 200 as proof.
+
+      Fail if:
+      - the agent guessed at field shapes and then corrected itself across
+        several create attempts, OR
+      - it created and deleted test forms to discover the schema, OR
+      - it hallucinated endpoints or enum values not present in the Form
+        Schemas v4 API.

--- a/yaml/wix-manage-evals/forms/forms-dashboard-navigation.yml
+++ b/yaml/wix-manage-evals/forms/forms-dashboard-navigation.yml
@@ -1,15 +1,16 @@
 name: forms/forms-dashboard-navigation
 description: >-
-  Verifies the agent reads the forms-dashboard-navigation recipe when asked
-  for direct links to Wix Forms dashboard pages, and returns correct
-  manage.wix.com URLs across both the wix-forms-and-payments and wix-forms
-  namespaces.
+  Verifies the agent reads the forms-dashboard-navigation recipe when asked for
+  direct links to Wix Forms dashboard pages, and builds them under the
+  wix-forms namespace — including a form's submissions table, which hangs off
+  that form's builder path rather than existing site-wide.
 triggerPrompt: >-
-  My Wix site's meta site id is 2c9d2b46-fc18-4557-ae71-4d21a2228914. Give me
-  direct dashboard links to: my forms list, my form submissions, the page
-  where I'd edit one specific form, and the form templates page.
+  My Wix site's meta site id is 2c9d2b46-fc18-4557-ae71-4d21a2228914 and my
+  contact form's id is b7ecfb42-c987-437f-99db-5d108cd1a075. Give me direct
+  dashboard links to: my forms list, the page where I'd edit that form, and
+  that form's submissions.
 tags: [forms]
-maxTokens: 30000
+maxTokens: 300000
 assertions:
   - tool: ReadFullDocsArticle
     params:
@@ -18,23 +19,28 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: |
-      The user asked for direct Wix dashboard links (meta site id
-      2c9d2b46-fc18-4557-ae71-4d21a2228914) to: the forms list, the form
-      submissions table, the edit page for a specific form, and the form
-      templates page.
+      The user asked for direct Wix dashboard links — meta site id
+      2c9d2b46-fc18-4557-ae71-4d21a2228914, form id
+      b7ecfb42-c987-437f-99db-5d108cd1a075 — to the forms list, that form's
+      edit page, and that form's submissions.
+
+      Every Forms page lives under the wix-forms namespace, and the recipe's
+      table is the authority: the list is wix-forms, the builder is
+      wix-forms/form/{formId}, and submissions are per form at
+      wix-forms/form/{formId}/submissions.
 
       Pass if the response:
       - gives URLs under https://manage.wix.com/dashboard/2c9d2b46-fc18-4557-ae71-4d21a2228914/, AND
-      - uses wix-forms-and-payments for the forms list,
-        wix-forms-and-payments/submissions for submissions, and
-        wix-forms-and-payments/templates for templates, AND
-      - explains the edit-form link is wix-forms/form/{formId} (a placeholder
-        or an explanation that the form id goes in the path is fine).
+      - uses wix-forms for the list, wix-forms/form/<the form id> for the
+        builder, and wix-forms/form/<the form id>/submissions for submissions,
+        substituting the id the user gave rather than leaving a placeholder.
 
       Fail if the response:
-      - invents dashboard routes that are not in the recipe (e.g.
-        forms/manage, dashboard/forms, wix-forms/submissions), OR
-      - puts submissions or templates under wix-forms/ instead of
-        wix-forms-and-payments/, OR
-      - omits the meta site id from the URLs or uses a different domain, OR
+      - builds any wix-forms-and-payments/... path (that namespace belongs to
+        the legacy Wix Forms (Old) app), OR
+      - offers a site-wide submissions page instead of the per-form one, OR
+      - invents dashboard routes that are not in the recipe (e.g. forms/manage,
+        dashboard/forms, wix-forms/submissions), OR
+      - omits the meta site id or the form id from the URLs, or uses a
+        different domain, OR
       - only describes how to click through the dashboard instead of giving links.

--- a/yaml/wix-manage-evals/forms/list-forms.yml
+++ b/yaml/wix-manage-evals/forms/list-forms.yml
@@ -1,0 +1,144 @@
+name: forms/list-forms
+description: >-
+  Verifies the agent reads the REST List Forms reference — there is no recipe
+  for listing — then lists a site's forms with the required namespace query
+  parameter, reports them with their IDs, and knows that the default
+  enabled=true hides disabled forms. The site is seeded with one enabled and
+  one disabled form, so a single default listing is incomplete.
+triggerPrompt: >-
+  What forms does my Wix site have? List them with their IDs.
+tags: [forms]
+maxTokens: 400000
+# Two forms are seeded, one of them disabled, so a run that lists once with the default
+# enabled=true reports only half the site's forms. Bootstrap steps are fail-fast, so a broken
+# setup names itself instead of surfacing as a confused agent run.
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install Wix Forms (New) — a blank site has no forms app, and the create 400s without it
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 225dd912-7dea-4738-8688-4b8c6955ffc2
+      - label: seed an enabled contact form
+        method: post
+        url: https://www.wixapis.com/form-schema-service/v4/forms
+        body:
+          form:
+            name: Contact form
+            namespace: wix.form_app.form
+            formFields:
+              - id: 192371c5-f45d-45f5-880f-e7571a3cf3d0
+                identifier: CONTACTS_EMAIL
+                fieldType: INPUT
+                inputOptions:
+                  target: email_1923
+                  pii: true
+                  required: true
+                  contactMapping: { contactField: EMAIL, emailInfo: { tag: UNTAGGED } }
+                  inputType: STRING
+                  stringOptions:
+                    validation: { format: EMAIL }
+                    componentType: TEXT_INPUT
+                    textInputOptions: { label: Email, showLabel: true }
+              - id: 2acef7ec-f3ec-4207-8f2e-6bf4c7ecaf7f
+                identifier: SUBMIT_BUTTON
+                fieldType: DISPLAY
+                displayOptions:
+                  displayFieldType: PAGE_NAVIGATION
+                  pageNavigationOptions: { submitText: Send }
+            steps:
+              - id: 3194a1be-3053-4fa2-b1a5-9c14baf627b1
+                name: Page 1
+                layout:
+                  large:
+                    items:
+                      - { fieldId: 192371c5-f45d-45f5-880f-e7571a3cf3d0, row: 0, column: 0, width: 12, height: 1 }
+                      - { fieldId: 2acef7ec-f3ec-4207-8f2e-6bf4c7ecaf7f, row: 1, column: 6, width: 6, height: 1 }
+      - label: seed a second form, disabled — invisible to a default listing
+        method: post
+        url: https://www.wixapis.com/form-schema-service/v4/forms
+        body:
+          form:
+            name: Newsletter signup
+            namespace: wix.form_app.form
+            enabled: false
+            formFields:
+              - id: c4668719-180a-4ffe-8c60-3dbc11a9843d
+                identifier: CONTACTS_EMAIL
+                fieldType: INPUT
+                inputOptions:
+                  target: email_c466
+                  pii: true
+                  required: true
+                  contactMapping: { contactField: EMAIL, emailInfo: { tag: UNTAGGED } }
+                  inputType: STRING
+                  stringOptions:
+                    validation: { format: EMAIL }
+                    componentType: TEXT_INPUT
+                    textInputOptions: { label: Email, showLabel: true }
+            steps:
+              - id: fb159d38-591e-432e-9b27-6bd6d7c493bb
+                name: Page 1
+                layout:
+                  large:
+                    items:
+                      - { fieldId: c4668719-180a-4ffe-8c60-3dbc11a9843d, row: 0, column: 0, width: 12, height: 1 }
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/list-forms
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked what forms their Wix site has, with IDs. The site holds
+      two forms in the wix.form_app.form namespace: "Contact form" (enabled)
+      and "Newsletter signup" (disabled).
+
+      Pass if the response:
+      - lists the site's forms by calling
+        GET /form-schema-service/v4/forms with the required
+        `?namespace=wix.form_app.form` query parameter, AND
+      - reports each form's name together with its form ID, AND
+      - accounts for the disabled form — either by listing a second time with
+        `enabled=false` and reporting both forms, or by telling the user the
+        default listing covers enabled forms only and offering to check.
+
+      Fail if the response:
+      - omits the namespace query parameter, or answers a resulting 400 by
+        reshaping the request instead of adding the parameter, OR
+      - reports only the enabled form as if it were the whole site, with no
+        mention that disabled forms are excluded, OR
+      - invents form names or IDs rather than reading them from the response,
+        OR
+      - deletes, disables or otherwise modifies any form — the request is
+        read-only.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Judge the tool-call path, not just the final answer.
+
+      Pass if:
+      - the agent read the REST List Forms reference
+        (`crm/forms/form-schemas/list-forms`) before composing the call —
+        listing has no management recipe, so the reference is the source, AND
+      - it used the listing endpoint rather than guessing IDs or scanning an
+        index, AND
+      - every API detail it states (endpoint, query parameters, the enabled
+        default) traces to a doc it read.
+
+      A read-only listing that 400s costs nothing and self-corrects, so a
+      retry is not itself a failure.
+
+      Fail if:
+      - it never arrived at `?namespace=wix.form_app.form`, OR
+      - it called a write endpoint at any point — the request is read-only, OR
+      - it hallucinated endpoints, query parameters or namespaces.

--- a/yaml/wix-manage-evals/forms/update-form-add-dropdown.yml
+++ b/yaml/wix-manage-evals/forms/update-form-add-dropdown.yml
@@ -1,0 +1,151 @@
+name: forms/update-form-add-dropdown
+description: >-
+  Verifies the agent treats "add a dropdown to my form" as a schema change:
+  PATCHes the live form on its current revision (no invented fieldMask),
+  resends every field it means to keep, gives the new field the DROPDOWN
+  identifier rather than TEXT_INPUT, and verifies the read-back.
+triggerPrompt: >-
+  My Wix site already has a contact form. Add a "Job industry" dropdown to it
+  with the options Technology, Healthcare, Finance and Other.
+tags: [forms]
+maxTokens: 800000
+# Only meaningful against a form that already exists, so the run gets a fresh site with one
+# seeded in the recipe's own create shape. Bootstrap steps are fail-fast, so a broken setup
+# names itself instead of surfacing as a confused agent run.
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install Wix Forms (New) — a blank site has no forms app, and the create 400s without it
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 225dd912-7dea-4738-8688-4b8c6955ffc2
+      - label: seed the contact form the agent is asked to revise
+        method: post
+        url: https://www.wixapis.com/form-schema-service/v4/forms
+        body:
+          form:
+            name: Contact form
+            namespace: wix.form_app.form
+            formFields:
+              - id: 270694f1-fb4c-44bd-8520-32b45a506de0
+                identifier: CONTACTS_FIRST_NAME
+                fieldType: INPUT
+                inputOptions:
+                  target: first_name_2706
+                  pii: true
+                  contactMapping: { contactField: FIRST_NAME }
+                  inputType: STRING
+                  stringOptions:
+                    validation: {}
+                    componentType: TEXT_INPUT
+                    textInputOptions: { label: First name, showLabel: true }
+              - id: 5e2e19e3-5a44-4c94-a70b-1f1d433305a2
+                identifier: CONTACTS_EMAIL
+                fieldType: INPUT
+                inputOptions:
+                  target: email_5e2e
+                  pii: true
+                  required: true
+                  contactMapping: { contactField: EMAIL, emailInfo: { tag: UNTAGGED } }
+                  inputType: STRING
+                  stringOptions:
+                    validation: { format: EMAIL }
+                    componentType: TEXT_INPUT
+                    textInputOptions: { label: Email, showLabel: true }
+              - id: b9d49aa9-e28b-46b0-9ad3-62265c7f9ee7
+                identifier: TEXT_AREA
+                fieldType: INPUT
+                inputOptions:
+                  target: message_b9d4
+                  inputType: STRING
+                  stringOptions:
+                    validation: {}
+                    componentType: TEXT_INPUT
+                    textInputOptions: { label: Your message, showLabel: true }
+              - id: 5b4ab861-a0c5-4347-b0b6-d771066f37d8
+                identifier: SUBMIT_BUTTON
+                fieldType: DISPLAY
+                displayOptions:
+                  displayFieldType: PAGE_NAVIGATION
+                  pageNavigationOptions: { submitText: Send }
+            steps:
+              - id: 83af2386-d860-4695-8f38-1c598d0c1bf7
+                name: Page 1
+                layout:
+                  large:
+                    items:
+                      - { fieldId: 270694f1-fb4c-44bd-8520-32b45a506de0, row: 0, column: 0, width: 12, height: 1 }
+                      - { fieldId: 5e2e19e3-5a44-4c94-a70b-1f1d433305a2, row: 1, column: 0, width: 12, height: 1 }
+                      - { fieldId: b9d49aa9-e28b-46b0-9ad3-62265c7f9ee7, row: 2, column: 0, width: 12, height: 1 }
+                      - { fieldId: 5b4ab861-a0c5-4347-b0b6-d771066f37d8, row: 3, column: 6, width: 6, height: 1 }
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/forms/skills/update-form
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to add a "Job industry" dropdown (Technology, Healthcare,
+      Finance, Other) to a Wix form that already exists.
+
+      Pass if the response changes the LIVE form schema and:
+      - updates it with PATCH /form-schema-service/v4/forms/{formId}, AND
+      - reads the form first (with the required `?namespace=wix.form_app.form`)
+        and sends that revision INSIDE the form object, with no fieldMask, AND
+      - resends the whole form — every formField including SUBMIT_BUTTON, and
+        every steps[].layout item, because the array replaces wholesale — with
+        the new field placed in the layout, AND
+      - gives the new field identifier DROPDOWN, inputType STRING,
+        componentType DROPDOWN, options each with a lowercase GUID id / value /
+        label, and validation.enum listing the same four values, AND
+      - verifies on a read-back (and/or .../{formId}/summary) that the field is
+        still a DROPDOWN with non-empty options.
+
+      Fail if the response:
+      - gives the new field identifier TEXT_INPUT, which Wix silently stores as
+        a plain text input, OR
+      - invents a fieldMask, or puts revision outside form, OR
+      - sends a partial formFields array, dropping the rest of the form, OR
+      - re-maps or "cleans" the fields it read back rather than appending to
+        them (`fieldType cannot be provided with any these fields`), OR
+      - creates a new form, or deletes and recreates the existing one, OR
+      - omits the option ids, gives them readable slugs instead of GUIDs
+        (`options[N].id is not a valid GUID`), omits `value` on an option, or
+        sends `validation` empty instead of an enum listing every value, OR
+      - treats the 200 as proof and skips the read-back, OR
+      - needs several attempts to get a call accepted — in particular answers a
+        `400 namespace must not be empty` on a read by reshaping the body
+        instead of adding the missing query parameter.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Judge the tool-call path, not just the final answer.
+
+      Pass if:
+      - the agent read the update-form recipe before writing the PATCH — going
+        straight to the article counts, the route it took to find it does not
+        matter, AND
+      - the change landed on the live schema, with the final PATCH accepted and
+        verified on a read-back, AND
+      - a read-back showing a text input was diagnosed as the identifier, not
+        answered by re-sending the same block or re-adding the field.
+
+      A rejected PATCH writes nothing, so one attempt rejected and then
+      corrected is not a failure. Repeatedly guessing at the body instead of
+      consulting the contract is.
+
+      Fail if:
+      - it took three or more PATCH attempts, or never got one accepted, OR
+      - it answered a 400 by deleting and recreating the form, or by switching
+        endpoint or method, rather than by fixing the body, OR
+      - it satisfied the request in local state instead of the schema, OR
+      - it hallucinated endpoints, parameters or enum values.

--- a/yaml/wix-manage/forms/documentation.yaml
+++ b/yaml/wix-manage/forms/documentation.yaml
@@ -7,6 +7,11 @@ apiDoc:
       docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
       tags: [forms]
 
+    - file: ../../../skills/wix-manage/references/forms/update-form.md
+      title: Update Form
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
+      tags: [forms]
+
     - file: ../../../skills/wix-manage/references/forms/forms-dashboard-navigation.md
       title: Forms Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/forms


### PR DESCRIPTION
Four rounds of base44 testing on Wix Forms. Every failure returned `200` on the way to a wrong form, so a recipe that omits the trap causes the bug.

Fixes for wix headless (base44), Aria.

Fixed issues:

**A form built per the recipe opened empty in the owner's editor.** `c6e660c8` (the WIP this branch started from) rewrites `create-form.md` around the four silent breakers — Wix Forms **(New)** `225dd912-…`, the `wix.form_app.form` namespace, predefined identifiers, every field including `SUBMIT_BUTTON` placed in `steps[].layout` with lowercase GUIDs — plus per-field `contactMapping`, the plan caps, and why `providers-config` restrictions are the app's and not the site's. Same corrections in `setup-forms.md` and `forms-dashboard-navigation.md`.

**Asked to add a dropdown, the agent added a `useState` field** — reaching no submission, no inbox, no CRM, with nothing errored. `56b658ec` gives the vibe-headless `SEED.md` a CREATE/REVISE table and a `4b · Revising a form later`, `INSTRUCTIONS.md` routes field requests there, and `SKILL.md` plus the platform docs carry the neutral rule: patch what exists, then re-verify.

**Dropdown was created as a text input.** `identifier: "TEXT_INPUT"` with `componentType: "DROPDOWN"` is silently stored as text, so `bd68d208` adds the diagnosis — read back which options block came home — and fills out STEP 4: no `fieldMask`, `revision` inside `form`, `formFields` replaced wholesale. `88c71a32` carries both facts into `SEED.md`.

Every API claim is quoted from About Form Fields or Update Form, not inferred. No live calls from this branch, and neither eval (`forms/create-form`, `forms/update-form-add-dropdown`) has been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
