### PR TITLE
sync(editor-react-component): Forbid usage of fallback values in CSS variables for branded components

### DIFF
--- a/skills/wix-app/references/editor-react-component/BRANDED-COMPONENTS.md
+++ b/skills/wix-app/references/editor-react-component/BRANDED-COMPONENTS.md
@@ -26,6 +26,7 @@ using CSS Modules `@value`, then consume with `var()`.
 **Body:** `wst-paragraph-1..3-font` / `wst-paragraph-1..3-color`
 
 - Do not use `var(--wst-*)` directly; import the `@value` alias first.
+- Do not pass a fallback as `var()`'s second argument
 - Do not use `@import`; CSS Modules resolves theme aliases through `@value`.
 - Do not use `wst-base-1-color` for text. Prefer heading/paragraph color tokens,
   or `wst-base-2-color` when a base contrast color is required.

--- a/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
@@ -177,6 +177,22 @@ A dynamic runtime value that cannot be represented statically may use a narrowly
 scoped CSS custom property set from JSX, but keep the actual style rule in CSS
 and do not expose a visual prop solely for that purpose.
 
+```css
+/* Typography: zero config builds the `font` control from both longhands.
+   A part with a size but no family gets a control with no default. */
+.cta {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+/* Avoid: a module-only wrapper is not an editor element. A size here is
+   uneditable and silently overrides the parent's typography control. */
+.cta-label {
+  font-size: 14px;
+}
+```
+
 ## Interaction and Motion
 
 - Set `pointer-events: auto` on the root and each interactive element.
@@ -198,7 +214,7 @@ When creating a component and the request has no visual direction, use a
 restrained accessible default. When editing an existing component, preserve its
 visual language unless the request changes it.
 
-- body text at least 16px and labels at least 14px
+- body text at least 16px and labels at least 14px, with an explicit `font-family`
 - WCAG AA contrast (4.5:1 body text, 3:1 large text and UI controls)
 - touch targets at least 44 by 44px
 - clear hierarchy and visible focus states
@@ -220,4 +236,6 @@ than hardcoded generic color choices.
 - [ ] A sizing chain exists only on bounded growing axes.
 - [ ] Layout is container-driven and uses logical inline properties.
 - [ ] Static styling stays in CSS; custom properties exist only when needed.
+- [ ] Every part that sets `font-size` also sets `font-family`, on the part that
+      should own the typography control.
 - [ ] Interactive elements expose pointer events and accessible design states.

--- a/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
+++ b/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
@@ -66,6 +66,9 @@ state class is the **prefixed** global one.
 ```css
 .cta {
   background: #6366f1;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: #ffffff;
 } /* resting */
 .cta:global(.pricing-card-cta--hover),
 .cta:hover {


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/97: Forbid usage of fallback values in CSS variables for branded components

### What was synced
- Editor React Component entry and references managed by the private source repo
- Editor React Component a11y scanner scripts
- local paths mapped to the public wix/skills layout

Auto-generated by GitHub Actions.