### PR TITLE
stores: steer the agent to choose DIGITAL when the buyer receives a file

### DIFF
--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -45,6 +45,10 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
   this machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
   `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
   that product text-only. Seed text-only only when the user explicitly asks.
+- **Product type follows what the buyer receives:** a shipped item is physical (default); a
+  downloadable file they keep (ebook, PDF, template, preset pack, track, downloadable video) is
+  **digital**; selling *access* — a membership, subscription, or online course/program the buyer
+  enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded here.
 - `digitalFilePath` (a file on this machine) or `digitalFileUrl` — makes the product a digital
   download, uploaded and created with both the file and stock (`quantity` is ignored). It's also the
   only way in: a file-less digital product is created successfully, reads back healthy, and is then

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -94,6 +94,7 @@ Storefront product queries (`searchProducts` / `queryProducts`) return **only vi
 **⚠️ CRITICAL FORMAT REQUIREMENTS:**
 - **Description MUST be rich-text nodes**, not a plain string — a plain string causes an `"Expected an object"` error. Use the `{ "nodes": [...], "metadata": {...} }` shape shown.
 - **Media — gated by the `imagery` policy (`SEED.md` § "Entity images"), no exception for stores.** **Always create products text-only here** — omit `media`. When `imagery` is **on**, the **Attach images** step below writes generated brand images in a second pass; it does **not** happen at create time.
+- **Choose the product type from what the buyer receives:** a shipped item is `PHYSICAL` (default); a downloadable file they keep — ebook, PDF, template, preset pack, track, downloadable video — is `DIGITAL`. Selling *access* rather than a file — a membership, subscription, or an online course/program the buyer enrolls in — is **Pricing Plans**, not a Stores product.
 - **Physical products MUST set `"productType": "PHYSICAL"` and an empty `"physicalProperties": {}`** (on the product and on each variant).
 - **Digital products (`"productType": "DIGITAL"`) drop `physicalProperties` and are sellable only when each variant carries both a file and stock** — miss either and the product is created fine, reads back `visible: true`, and is rejected at add-to-cart. Upload the file first (`POST /site-media/v1/files/generate-upload-url` → `PUT` the bytes → `file.id`):
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -64,6 +64,12 @@ options: [
 
 ## Digital downloads
 
+**Pick the product type from what the buyer receives.** A shipped physical item is the default. A
+**downloadable file the buyer keeps** — ebook, PDF guide, template, preset pack, printable, music
+track, downloadable video — is a **digital** product: pass its file as `digitalFileUrl`. Selling
+*access* rather than a file — a membership, subscription, or an online course/program the buyer
+enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded here.
+
 `digitalFileUrl` (plus `digitalFileName` when the url carries no filename) makes a product a digital
 download — uploaded and created with both the file and stock, which is what the cart requires
 (`quantity` is ignored). It's also the only way in: a file-less digital product is created


### PR DESCRIPTION
Follow-up to #1204. That PR made a `DIGITAL` product **sellable when chosen** (file + stock by construction), but nothing tells the agent **when to choose digital** — so online-course / downloadable stores get seeded `PHYSICAL`. Verified on two live "online course" store builds: both came out **100% physical** (price + quantity), digital path never triggered, despite the seed already carrying #1204's digital support.

Adds a product-type **decision** (the missing *when*) to each storefront seed guide — mechanics untouched:
- **wix-vibe-headless** `storefront/seed/SEED.md`
- **wix-headless-fast** `storefront/seed/SEED.md`
- **wix-headless** `inline-recipes/setup-online-store.md`

The steer: shipped item → **physical** (default); a downloadable file the buyer keeps (ebook, PDF, template, preset pack, track, downloadable video) → **digital** via `digitalFileUrl`; selling *access* (membership, subscription, online course/program enrollment) → **Pricing Plans**, not a Stores product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)