### PR TITLE
stores: make the product-type decision up-front (strengthen #1205)

### DIFF
--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -5,6 +5,15 @@ the REST calls. The script mints its own site token via the Wix CLI (requires a 
 session and a `wix.config.json` in the working directory), installs the Stores app if needed,
 waits for the V3 catalog, and creates everything in the right order.
 
+**Decide the product type before you seed — match it to what the buyer RECEIVES, not to the word
+"product".** A shipped physical item is physical (the default, with `quantity`). A **downloadable
+file the buyer keeps** — ebook, PDF, template, preset pack, music track, downloadable video — is
+**digital**: give it `digitalFilePath`/`digitalFileUrl`, never a `quantity`. Selling **access**
+rather than a file — a membership, a subscription, or an **online course/program the buyer enrolls
+in** — is **Pricing Plans**, not a Wix Stores product. So an "online course" sold as **downloadable
+videos** is digital; one that **streams on enrollment** is Pricing Plans. Don't default
+course/download catalogs to physical-with-quantity.
+
 ```bash
 # from the project root (where wix.config.json lives):
 node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -31,6 +31,8 @@ A freshly provisioned Wix Stores app comes pre-seeded with demo/sample products.
 
 Create the products in a **single bulk request** to `POST https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create`. **How many products, and which are in or out of stock, are set by the request you're fulfilling — this step only gives the call and the required format.** Each product needs a real web image URL relevant to it, and `price` via `actualPrice` (+ optional `compareAtPrice`).
 
+**First decide each product's type from what the buyer RECEIVES, not the word "product":** a shipped item → `PHYSICAL` (default); a **downloadable file the buyer keeps** (ebook, PDF, template, preset pack, track, downloadable video) → `DIGITAL` (carries a file, no `quantity` — see the format block below); selling **access** rather than a file — a membership, subscription, or an **online course/program the buyer enrolls in** — is **Pricing Plans**, not a Stores product. Don't default a course/download catalog to physical-with-inventory.
+
 **⚠️ CRITICAL: PRODUCT & VARIANT VISIBILITY — set `"visible": true` explicitly.**
 Storefront product queries (`searchProducts` / `queryProducts`) return **only visible products** to site visitors. A product created without `"visible": true` is created successfully but will **NOT appear** on the live site — the catalog looks empty. So:
 - Set `"visible": true` on **every product** (product level).

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -4,6 +4,15 @@ Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write th
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
 
+**Decide the product type before you seed — match it to what the buyer RECEIVES, not to the word
+"product".** A shipped physical item is physical (the default below, with `quantity`). A
+**downloadable file the buyer keeps** — ebook, PDF, template, preset pack, music track, downloadable
+video — is **digital**: give it a `digitalFileUrl`, never a `quantity`. Selling **access** rather
+than a file — a membership, a subscription, or an **online course/program the buyer enrolls in** — is
+**Pricing Plans**, not a Wix Stores product; seed that with the `pricing-plans` vertical, not here.
+So an "online course" sold as **downloadable videos** is a digital product; one that **streams on
+enrollment** is Pricing Plans. Don't default course/download catalogs to physical-with-quantity.
+
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");


### PR DESCRIPTION
#1205 added the "when to choose digital" steer, but only inside a later section. A fresh build **3.5 min after #1205 merged** — with the updated `SEED.md` in the skill it read — still seeded an online-course store as **100% physical** (app `6a97210eeea277b40ff10fac`): the agent matched the physical `setupStore` example at the top and ignored the buried note.

This moves the decision **up-front** so the agent sees it before writing the product spec — three seed guides, prose only:
- **wix-vibe-headless** `storefront/seed/SEED.md` — bold callout right before the `setupStore` example.
- **wix-headless-fast** `storefront/seed/SEED.md` — same, before the plan example.
- **wix-headless** `inline-recipes/setup-online-store.md` — at the top of STEP 2 (create products), not only in the format bullets.

The steer: match the type to **what the buyer receives** — shipped → physical; downloadable file kept by the buyer → **digital** (no `quantity`); **access** (membership, subscription, online course/program enrollment) → **Pricing Plans**, not a Stores product. A course sold as downloadable videos is digital; one that streams on enrollment is Pricing Plans.

(No base44.md / vertical-picker change — that risked mis-routing an explicit "online store" request and conflating Pricing Plans with Online Programs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)