### PR TITLE
stores: trim the digital steer to code + pricing-plans route disclaimer

### DIFF
--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -5,14 +5,10 @@ the REST calls. The script mints its own site token via the Wix CLI (requires a 
 session and a `wix.config.json` in the working directory), installs the Stores app if needed,
 waits for the V3 catalog, and creates everything in the right order.
 
-**Decide the product type before you seed — match it to what the buyer RECEIVES, not to the word
-"product".** A shipped physical item is physical (the default, with `quantity`). A **downloadable
-file the buyer keeps** — ebook, PDF, template, preset pack, music track, downloadable video — is
-**digital**: give it `digitalFilePath`/`digitalFileUrl`, never a `quantity`. Selling **access**
-rather than a file — a membership, a subscription, or an **online course/program the buyer enrolls
-in** — is **Pricing Plans**, not a Wix Stores product. So an "online course" sold as **downloadable
-videos** is digital; one that **streams on enrollment** is Pricing Plans. Don't default
-course/download catalogs to physical-with-quantity.
+**Set each product's type by what the buyer receives** — physical (shipped, has `quantity`) or
+digital (a file they keep, `digitalFilePath`/`digitalFileUrl`, no `quantity`); the plan below shows
+both. *Access* — a membership or an online course/program the buyer enrolls in — is Pricing Plans,
+not a store product.
 
 ```bash
 # from the project root (where wix.config.json lives):
@@ -54,10 +50,6 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
   this machine — uploaded to Wix Media) or `imageUrl` (their own hosted URL; verify it with
   `curl -sI` → 200) — never a stock-photo or guessed URL. Images resolve in parallel and never block the seed; a failed image leaves
   that product text-only. Seed text-only only when the user explicitly asks.
-- **Product type follows what the buyer receives:** a shipped item is physical (default); a
-  downloadable file they keep (ebook, PDF, template, preset pack, track, downloadable video) is
-  **digital**; selling *access* — a membership, subscription, or online course/program the buyer
-  enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded here.
 - `digitalFilePath` (a file on this machine) or `digitalFileUrl` — makes the product a digital
   download, uploaded and created with both the file and stock (`quantity` is ignored). It's also the
   only way in: a file-less digital product is created successfully, reads back healthy, and is then

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -31,7 +31,7 @@ A freshly provisioned Wix Stores app comes pre-seeded with demo/sample products.
 
 Create the products in a **single bulk request** to `POST https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create`. **How many products, and which are in or out of stock, are set by the request you're fulfilling — this step only gives the call and the required format.** Each product needs a real web image URL relevant to it, and `price` via `actualPrice` (+ optional `compareAtPrice`).
 
-**First decide each product's type from what the buyer RECEIVES, not the word "product":** a shipped item → `PHYSICAL` (default); a **downloadable file the buyer keeps** (ebook, PDF, template, preset pack, track, downloadable video) → `DIGITAL` (carries a file, no `quantity` — see the format block below); selling **access** rather than a file — a membership, subscription, or an **online course/program the buyer enrolls in** — is **Pricing Plans**, not a Stores product. Don't default a course/download catalog to physical-with-inventory.
+**First decide each product's type by what the buyer receives:** shipped → `PHYSICAL` (the JSON below); a file the buyer downloads and keeps → `DIGITAL` (the digital block below — carries a file, no `quantity`). *Access* — a membership or an online course/program the buyer enrolls in — is **Pricing Plans**, not a Stores product.
 
 **⚠️ CRITICAL: PRODUCT & VARIANT VISIBILITY — set `"visible": true` explicitly.**
 Storefront product queries (`searchProducts` / `queryProducts`) return **only visible products** to site visitors. A product created without `"visible": true` is created successfully but will **NOT appear** on the live site — the catalog looks empty. So:

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -26,7 +26,7 @@ Run this through exec_tool, exactly as written — installs all three skills, de
 | `blog` | publish articles |
 | `events` | publish events with RSVPs or ticket sales |
 | `portfolio` | showcase creative work |
-| `pricing-plans` | sell memberships or subscriptions |
+| `pricing-plans` | sell memberships or subscriptions, incl. paid enrollment/access to an online course or program — but an "online store selling courses" is still `storefront` |
 | `restaurants` | show a menu, take orders, book tables |
 | `members` | let visitors sign in — this is **auth** |
 | `forms` | any visitor-fillable form: contact, signup, waitlist, application, survey, quote request (an event RSVP is `events`; a per-service booking form is `bookings`) |
@@ -114,4 +114,4 @@ Seeding is **admin-only** — not part of the client, which is built solely per 
 For any later admin/management request, work as in STEP 4: your vertical's seed module first, else
 `wix-base44-connector` doc discovery — all over the connector.
 
-version: v1340
+version: v1341

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -4,14 +4,9 @@ Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write th
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
 
-**Decide the product type before you seed — match it to what the buyer RECEIVES, not to the word
-"product".** A shipped physical item is physical (the default below, with `quantity`). A
-**downloadable file the buyer keeps** — ebook, PDF, template, preset pack, music track, downloadable
-video — is **digital**: give it a `digitalFileUrl`, never a `quantity`. Selling **access** rather
-than a file — a membership, a subscription, or an **online course/program the buyer enrolls in** — is
-**Pricing Plans**, not a Wix Stores product; seed that with the `pricing-plans` vertical, not here.
-So an "online course" sold as **downloadable videos** is a digital product; one that **streams on
-enrollment** is Pricing Plans. Don't default course/download catalogs to physical-with-quantity.
+**Match each product's type to what the buyer receives** (the example shows both). *Access* — a
+membership, or an online course/program the buyer enrolls in — isn't a store product at all; that's
+the `pricing-plans` vertical, not here.
 
 ```js
 // build-time exec_tool
@@ -31,13 +26,14 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // generate_image runs in the background while you build, so the urls are ready by seed time.
 const result = await seed.setupStore(ctx, {
   products: [
+    // physical — a shipped item: carries `quantity` (the default type)
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
     // a product with buyer choices — see "Options, variants and sale prices" below
     { name: "The Understudy", description: "…", price: 245, quantity: 8, imageUrl: imageUrls[1],
       options: [{ name: "Color", type: "color", choices: [{ name: "Ink", colorCode: "#1B1B2F" }, { name: "Bone", colorCode: "#EDE6D6" }] }] },
     // a product on sale — compareAtPrice drives the strikethrough + the tile's percent-off badge
     { name: "Encore Jacket", description: "…", price: 68, compareAtPrice: 129, quantity: 5, imageUrl: imageUrls[2] },
-    // a digital download — `digitalFileUrl` is the switch into DIGITAL
+    // digital — a file the buyer downloads & keeps (ebook, PDF, video): `digitalFileUrl`, NO `quantity`
     { name: "Backstage Guide", description: "…", price: 12, digitalFileUrl: "https://…/guide.pdf" },
   ],
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none


### PR DESCRIPTION
Follow-up to #1205 / #1207.

**1. Less prose, more code.** The product-type decision was carried by a multi-line prose block; this trims it and lets the seed **example** carry it:
- **wix-vibe-headless** `SEED.md` — example now comments the physical product (`shipped → quantity`) and the digital one (`a file the buyer keeps → digitalFileUrl, no quantity`); callout cut to one line.
- **wix-headless-fast** `SEED.md` — the `plan.json` example already shows both; callout trimmed and the duplicate decision bullet removed.
- **wix-headless** `setup-online-store.md` — one line pointing at the existing PHYSICAL/DIGITAL JSON blocks.

**2. Mitigate routing (the part I'd reverted).** base44.md `pricing-plans` picker row now names **paid course/program enrollment**, but **with a disclaimer** — *"an 'online store selling courses' is still `storefront`"* — so it catches access/enrollment intent without mis-routing an explicit store request. v1340 → v1341.

Net −12 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)