### PR TITLE
storefront seed: default to 3 products (vibe-headless)

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -47,7 +47,7 @@ const result = await seed.setupStore(ctx, {
 ## How many, and exercising the UI
 
 **Default to 3 products** unless the brief asks for a specific catalog — the seed shows the shape,
-not a full inventory; the owner adds the rest from the Wix dashboard.
+not a full inventory; the owner adds the rest later, from the Wix dashboard or by asking you for more.
 
 The shipped storefront renders colour options as real swatches, shows a size/colour summary on each
 tile, and puts a percent-off badge on a discounted product. A catalog of plain single-price products

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -52,8 +52,7 @@ not a full inventory; the owner adds the rest later, from the Wix dashboard or b
 The shipped storefront renders colour options as real swatches, shows a size/colour summary on each
 tile, and puts a percent-off badge on a discounted product. A catalog of plain single-price products
 leaves all of that invisible, so **make those 3 exercise it**: unless the brief says otherwise, give
-at least one product a colour option and put one product on sale. Keep it truthful to the business —
-a ceramics studio has glaze colours, a bakery does not.
+at least one product a colour option and put one product on sale. Keep it truthful to the business.
 
 ```js
 options: [

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -44,13 +44,16 @@ const result = await seed.setupStore(ctx, {
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
 
-## Options, variants and sale prices
+## How many, and exercising the UI
+
+**Default to 3 products** unless the brief asks for a specific catalog — the seed shows the shape,
+not a full inventory; the owner adds the rest from the Wix dashboard.
 
 The shipped storefront renders colour options as real swatches, shows a size/colour summary on each
 tile, and puts a percent-off badge on a discounted product. A catalog of plain single-price products
-leaves all of that invisible, so **seed a catalog that exercises it**: unless the brief says
-otherwise, give at least one product a colour option and put one product on sale. Keep it truthful
-to the business — a ceramics studio has glaze colours, a bakery does not.
+leaves all of that invisible, so **make those 3 exercise it**: unless the brief says otherwise, give
+at least one product a colour option and put one product on sale. Keep it truthful to the business —
+a ceramics studio has glaze colours, a bakery does not.
 
 ```js
 options: [


### PR DESCRIPTION
The vibe-headless storefront `SEED.md` steered catalog **variety** (exercise a colour option + a sale) but gave no **count** — so builds seeded ~8 products by default. The sibling `wix-headless-fast` `SEED.md` already caps at 3 (*"the seed shows the shape, not a full inventory"*).

This brings the same **default of 3 products** to vibe-headless: a small, shape-showing catalog the owner extends later — from the Wix dashboard **or by asking the builder for more** — still exercising the shipped UI (one colour option + one product on sale). Category count left to the agent, as before.

Scope: vibe-headless only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)