### PR TITLE
create-from-template returned MetaSite.Create permission denied

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -390,7 +390,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Sites
 
 ### [Create Site from Template](references/sites/create-site-from-template.md)
-**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, and publishing. Not for headless sites.
+**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, publishing, and permission-denied recovery. Not for headless sites.
 
 ### [Create Headless Site](references/sites/create-headless-site.md)
 **Technical:** Creates a Wix Headless site (headless business) with one account-level API call — site, Wix Business Solution apps, and a configured OAuth client.

--- a/skills/wix-manage/references/sites/create-site-from-template.md
+++ b/skills/wix-manage/references/sites/create-site-from-template.md
@@ -1,6 +1,6 @@
 ---
 name: "Create Site from Template"
-description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, and publishing. Not for headless sites.
+description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, publishing, and permission-denied recovery. Not for headless sites.
 ---
 # Create Site from Template
 
@@ -8,8 +8,27 @@ This recipe guides you through creating a new Wix site from a template, includin
 
 ## Prerequisites
 
-- Wix account with site creation permissions
-- Account-level API access
+- Account-level API access for the account that will own the new site
+- An authenticated account owner or account-level team member whose role allows creating sites in
+  that account
+
+A site collaborator role is scoped to an existing site and is not sufficient for this
+account-level creation call, even when that role can edit or manage the existing site.
+
+### Authorization preflight
+
+Before creating the site:
+
+1. Identify the Wix account that should own the new site.
+2. Confirm that the authenticated identity is the owner of that account or a team member in that
+   account with permission to create sites. Do not infer account-level access from collaborator
+   access to an existing site.
+3. If the identity is only a site collaborator or has a restricted account role, stop before the
+   mutation. Ask the account owner or an Account Admin (Co-Owner) to create the site, or to grant
+   an account-level role that includes site creation.
+
+`MetaSite.Create` in a permission-denied response is the authorization check that failed; it is
+not the name of a role or a permission the user can assign directly in Roles & Permissions.
 
 ## Required APIs
 
@@ -112,6 +131,21 @@ If `siteName` is not provided, one is generated automatically.
 
 ### IMPORTANT NOTES:
 - This API creates regular Wix sites. Do NOT use it for headless sites (even with a `namespace` field) — use [Create Headless Site](create-headless-site.md) instead
+
+### Permission-denied recovery
+
+If the create call returns permission denied for `MetaSite.Create`:
+
+1. Do not retry the same request or change its payload; this error is about the authenticated
+   identity, not the template ID or site name.
+2. Report which account is expected to own the new site and whether the current identity is an
+   account owner, account-level team member, or site-only collaborator.
+3. For a collaborator or restricted team member, ask the account owner or an Account Admin
+   (Co-Owner) to run the creation, or grant an account-level role that includes creating sites,
+   then retry once.
+4. If the authenticated account owner receives the same error, stop. Preserve the error and the
+   resolved account/identity context and escalate for authentication or identity-forwarding
+   investigation; do not tell the owner to grant themselves a role or keep retrying.
 
 ---
 

--- a/yaml/wix-manage-evals/sites/create-site-from-template-permission-denied.yml
+++ b/yaml/wix-manage-evals/sites/create-site-from-template-permission-denied.yml
@@ -1,0 +1,48 @@
+name: sites/create-site-from-template-permission-denied
+description: >-
+  Verifies the agent reads the create-site-from-template skill and handles a MetaSite.Create
+  permission denial as an account-role problem, without retrying or presenting the error token as
+  a user-assignable permission.
+triggerPrompt: >-
+  I tried to create a new Wix site from a template for an account I help manage, but the call
+  returned "permission denied: MetaSite.Create". I am a collaborator on one of the account's
+  existing sites. Should I retry with a different site name, or what needs to happen next?
+tags: [sites]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/sites/skills/create-site-from-template
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user received "permission denied: MetaSite.Create" while creating a site from a
+      template and says they are only a collaborator on an existing site in the account.
+
+      Pass if the response:
+      - explains that site-collaborator access is scoped to an existing site and does not establish
+        authority for this account-level site creation, AND
+      - says changing the site name or retrying the same request will not fix this authorization
+        error, AND
+      - asks the account owner or an Account Admin (Co-Owner) to perform the creation or grant an
+        account-level role that includes creating sites, AND
+      - says that if an authenticated account owner also receives the error, the agent should stop
+        and escalate with the account/identity context for authentication or identity-forwarding
+        investigation, AND
+      - does not claim that "MetaSite.Create" is a role or a permission that can be assigned by
+        that exact name in the Wix Roles & Permissions UI.
+
+      Fail if the response retries the mutation, changes the payload or template to recover,
+      treats a site-management collaborator role as sufficient, tells the user to grant a role
+      named MetaSite.Create, or assumes the Wix MCP authentication is broken without an owner-role
+      reproduction.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Judge the tool-call path for this permission-denied diagnosis. A clean path reads the Create
+      Site from Template recipe, recognizes the account-vs-site role mismatch, and gives recovery
+      guidance without making another site-creation call. Penalize redundant docs searches,
+      speculative API calls, retries of the failed mutation, payload changes, or claims that the
+      MCP is broken before the same failure is reproduced for an authenticated account owner.
+      Return ONLY {"score":<0-10>,"reason":"<terse frictions and suspected docs/MCP gap, or clean path>"}.


### PR DESCRIPTION
## Summary

Prepared a skills-only fix preview. No commit, push, or PR was created.

- Routing: `wix/skills` owns the served recipe. Current evidence supports an account-role guidance gap, not broken MCP identity forwarding.
- Changed: the recipe, its index description, and a regression eval covering preflight and recovery.
- Verified: official Wix sources, YAML parsing, unique scenario name, coverage URL, description length, clean diff, and exact `origin/main` base.
- Remaining uncertainty: owner/collaborator/restricted live reproduction was not possible with the single authenticated identity. The full paired EvalForge gate requires a PR and was therefore not run. `MetaSite.Create` is documented only a

## Evidence

Slack classified the report under Wix MCP, but the current evidence does not prove that MCP authentication or identity forwarding is broken. The verified gap is in wix/skills: the recipe lists only generic account-level access and gives no exact permission, preflight, or recovery guidance.

## Verification

Reproduce under owner, collaborator, and restricted roles. If an authorized owner also fails, inspect MCP identity forwarding; otherwise keep the fix in wix/skills.