### PR TITLE
revert(ci): stop enforcing check-truncation.mjs on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
     outputs:
       wix_app: ${{ steps.changes.outputs.wix_app }}
       evalforge: ${{ steps.changes.outputs.evalforge }}
-      changed_refs: ${{ steps.changes.outputs.changed_refs }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -47,7 +46,6 @@ jobs:
         id: changes
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
           echo "Changed files:"
@@ -62,20 +60,6 @@ jobs:
           else
             echo "wix_app=false" >> "$GITHUB_OUTPUT"
           fi
-
-          # Reference files this PR touches, for the fetch-limit gate below. Deliberately
-          # NOT derived from $changed: that diffs against the base commit recorded when the
-          # PR opened, so once a branch merges the base back into itself, every file the
-          # base changed since looks like part of this PR. Diffing against the base branch's
-          # current tip keeps the set to what this branch actually authored. Only files that
-          # still exist are listed, so a deletion doesn't fail the gate on a missing path.
-          git fetch --no-tags --quiet origin "$BASE_REF"
-          refs=$(git diff --name-only "origin/$BASE_REF...HEAD" \
-            | grep -E '^skills/[^/]+/references/.*\.md$' || true)
-          present=""
-          for f in $refs; do [ -f "$f" ] && present="${present:+$present,}$f"; done
-          echo "changed_refs=$present" >> "$GITHUB_OUTPUT"
-          echo "Changed reference files: ${present:-none}"
 
           # evalforge-core plus both actions that bundle it. A change to core affects both
           # actions' committed bundles, so any of these paths exercises the whole set.
@@ -100,7 +84,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-        if: ${{ needs.detect.outputs.wix_app == 'true' || needs.detect.outputs.evalforge == 'true' || needs.detect.outputs.changed_refs != '' }}
+        if: ${{ needs.detect.outputs.wix_app == 'true' || needs.detect.outputs.evalforge == 'true' }}
         with:
           node-version: '24'
 
@@ -128,14 +112,6 @@ jobs:
         if: ${{ needs.detect.outputs.wix_app == 'true' }}
         working-directory: .github/wix-app-typecheck
         run: node extract.mjs
-
-      # Some agents truncate a fetched file at ~10k chars, so anything past that is
-      # silently lost — usually the checklist or conclusion the file is linked for.
-      # Scoped to the files this PR touches: the repo has a pre-existing tail of
-      # over-limit files, and a whole-repo gate could only ever be red.
-      - name: skills — changed reference files fit the fetch limit
-        if: ${{ needs.detect.outputs.changed_refs != '' }}
-        run: node scripts/check-truncation.mjs --fail --files='${{ needs.detect.outputs.changed_refs }}'
 
       # ── evalforge: typecheck the shared package and both actions ────────────────────
       # `working-directory` rather than `yarn --cwd`: each package vendors yarn 4.12.0 via


### PR DESCRIPTION
Reverts the CI enforcement of `scripts/check-truncation.mjs` that #1100 introduced.

Removed from `.github/workflows/ci.yml`:
- the `skills — changed reference files fit the fetch limit` step in `typecheck`, which ran `check-truncation.mjs --fail --files=…`
- the `changed_refs` output on the `detect` job, its `BASE_REF` env var, and the block that diffed against the base branch tip to collect changed `skills/*/references/*.md` files
- `changed_refs != ''` from the `setup-node` step condition (back to wix_app / evalforge only)

The workflow file is now byte-identical to its pre-#1100 content (blob `ed1079de`), so nothing else in it drifted.

`scripts/check-truncation.mjs` is deliberately left untouched: its `--files=` and `--fail` flags are inert with nothing invoking them, and the plain `node scripts/check-truncation.mjs` report still runs and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)