### PR TITLE
docs(wix-app): props come from the bundle, not the doc

### DIFF
--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -41,7 +41,7 @@ Then confirm the installed version actually ships the bundle index:
 ls <pkgRoot>/dist/dts-bundle/index.json
 ```
 
-**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index; it ships from **1.458.0** onward, so upgrade to at least that and re-run the check. A missing *file* is not the same as a name not being covered (see below): the mechanism itself isn't available yet.
+**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index; it ships from **1.458.0** onward, so upgrade to at least that and re-run the check. Prefer **1.460.0** or newer: from there the docs stop repeating props the bundle already describes, which is what the lookup below assumes. A missing *file* is not the same as a name not being covered (see below): the mechanism itself isn't available yet.
 
 **Never inspect `node_modules` by hand** — no `ls`, no `find`, no `cat` of an arbitrary path, and that includes the sanctioned directories: never browse `dist/dts-bundle/` or `dist/docs/` looking around. Every lookup below names the exact file to `Read` — go straight to it.
 
@@ -141,6 +141,8 @@ Not every real `@wix/patterns` export is in this index — only the names these 
 `Read <pkgRoot>/dist/docs/index.json` to resolve a name to its doc file — or a `symbols` alias, for the cases where the Storybook title doesn't match the export (`ExportTo.md` documents `ExportButton`) — then `Read <pkgRoot>/dist/docs/<file>.md` directly, the whole file, not piped through `head`. It covers more names than the bundle index above: it's produced for every documented component, not just the curated ones.
 
 **Always check the import statement inside the doc** — not everything comes from `@wix/patterns` (some use subpaths like `@wix/patterns/provider`).
+
+A doc whose index entry has a `bundle` field does **not** list its props: its `### Props` points at that bundle instead, so the props come from there. One without that field still carries its own table. Either way the doc owns the prose, the variations, the BI events and the import line.
 
 ### Reading the file the index names
 

--- a/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
+++ b/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
@@ -6,9 +6,25 @@
 > against browsing `node_modules` by hand — is in
 > [WIX_PATTERNS_DOCS.md](../WIX_PATTERNS_DOCS.md). Nothing here replaces those steps.
 
+## Where props live
+
+From `@wix/patterns` **1.460.0** onward a doc does not repeat props that the bundle already
+describes. Which one holds them is stated in the doc's own index entry:
+
+| `dist/docs/index.json` entry | where the props are |
+| --- | --- |
+| has a `bundle` field | that bundle — the doc's `### Props` is a pointer to it, on purpose |
+| no `bundle` field | the doc's own `### Props` table, as before |
+
+Roughly 74 of 167 docs point at a bundle and 62 still carry a table, so expect both. When a doc
+says `Read \`dist/dts-bundle/...\``, that **is** the props answer — read the named file rather
+than treating the doc as incomplete. The bundle is the better source anyway: it keeps the
+`extends` clause with its exclusions, so `Omit<PopoverMenuItemProps, 'text' | 'prefixIcon' | 'onClick'>` tells
+you what you do *not* inherit, which the old doc link did not.
+
 ## Types the docs don't cover
 
-The docs cover components and props, not the types those props use — `Filter<T>`, `RangeItem<T>`, `CursorQuery`, a `...Props` interface. `Read <pkgRoot>/dist/dts-bundle/index.json`, look up the type name, then `Read <pkgRoot>/dist/dts-bundle/<entry.file>` using exactly the `file` path the index gives — **never reconstruct the path from the name**; bundles are nested one directory per kind (`components/Table.d.ts`, `hooks/useForm.d.ts`, `types/RangeItem.d.ts`, …), so guessing `<Name>.d.ts` at the top level is wrong by construction.
+The same bundles also hold the types those props use — `Filter<T>`, `RangeItem<T>`, `CursorQuery`, a `...Props` interface. `Read <pkgRoot>/dist/dts-bundle/index.json`, look up the type name, then `Read <pkgRoot>/dist/dts-bundle/<entry.file>` using exactly the `file` path the index gives — **never reconstruct the path from the name**; bundles are nested one directory per kind (`components/Table.d.ts`, `hooks/useForm.d.ts`, `types/RangeItem.d.ts`, …), so guessing `<Name>.d.ts` at the top level is wrong by construction.
 
 Several of these types (`RangeItem`, `Filter`, `CursorQuery`, the filter factory functions) actually live in `@wix/bex-core` — the bundle already resolves and inlines the real declaration, so you get the full shape with no deep, undeclared `@wix/bex-core/dist/types/...` path to chase. Still always import it from `@wix/patterns`, per the index's `importPath` field, never from wherever the bundle says it's really declared.
 
@@ -49,4 +65,9 @@ Links to `https://www.docs.wixdesignsystem.com/` are external (Wix Design System
 ## Tips
 
 - **Compound components** have separate docs per sub-part: `CollectionPage.md`, `CollectionPage.Header.md`, `CollectionPage.Content.md`.
-- **Hook docs** list configuration options as props in the API table.
+- **Hook docs** list configuration options as props — in the API table when the doc has no
+  `bundle` field, otherwise in the bundle it points at.
+- **Heavy examples live beside the doc.** A variation whose code was long is written out
+  separately, and the doc keeps the heading, the description and an exact path:
+  `Example code: read \`dist/docs/ToolbarFilters/apply-changes.tsx\``. Read that path only if you
+  need that particular variation — the heading and description are usually enough to choose.


### PR DESCRIPTION
Consumes `@wix/patterns@1.460.0`, which ships cairo #5831.

## Why

The skill still teaches the old division of labour — *"the docs cover components and props, not the types those props use"*. As of 1.460.0 that is backwards for **74 of 167 docs**: their `### Props` is now a pointer at the type bundle, so an agent following the current guidance would read that pointer as a truncated doc and go looking elsewhere.

## What changed

`PATTERNS_BUNDLE_READING.md` gains a **Where props live** section, because the answer is per-doc rather than global:

| `dist/docs/index.json` entry | where the props are |
| --- | --- |
| has a `bundle` field | that bundle — the doc's `### Props` is a pointer to it, on purpose |
| no `bundle` field | the doc's own `### Props` table, as before |

Both shapes are common (74 point at a bundle, 62 still carry a table), so the doc says to expect both rather than implying a single rule. It also explains that the bundle is the *better* source: it keeps the `extends` clause with its exclusions, so `Omit<PopoverMenuItemProps, 'text' | 'prefixIcon' | 'onClick'>` states what you do **not** inherit — something the doc's old design-system link never did.

Two smaller additions:

- **Heavy example code now lives beside the doc.** A reader meets `Example code: read \`dist/docs/ToolbarFilters/apply-changes.tsx\`` and is told to follow it only for the variation they actually want, since the heading and description are usually enough to choose.
- **The hook-docs tip is qualified** — a hook's configuration options are in its bundle when it has one, and in the API table when it doesn't.

`WIX_PATTERNS_DOCS.md` keeps **1.458.0** as the hard gate (that is when the bundle index first shipped, and the check is for its presence) but now recommends **1.460.0**, since that is where the docs behave as described here.

## Verification

Every concrete claim checked against the **installed 1.460.0**, not a local build:

- the 74 / 62 / 167 split
- `dist/docs/ToolbarFilters/apply-changes.tsx` resolves, and the doc really uses the `Example code: read` wording
- the exact `Omit` clause (I had abbreviated it in a first draft and corrected it)
- a doc with a `bundle` field has no props table of its own

Also confirmed 1.460.0 ships what it should: 167 docs at 615KB, none over the ~50KB read limit (largest 18.6KB), 190 example files across 38 directories published, and all 74 index bundle pointers resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)