### PR TITLE
feat(wix-manage): add a Generate an Image with AI recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -345,6 +345,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Upload Media to Wix](references/media/upload-media-to-wix.md)
 **Technical:** Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
 
+### [Generate an Image with AI](references/media/generate-image-with-ai.md)
+**Technical:** Generates an image from a text prompt with the Wix AI APIs (`POST /runwareschemaless/v1/request`). The response is a short-lived URL, so keeping the image means importing it — that step hands off to Upload Media to Wix. Covers choosing a model and its cost/latency/content-filter trade-off, the accepted output sizes, per-model batching limits, the UUIDv4 `taskUUID`, the AI credit each call spends, and why a content refusal arrives as a success response with no image. Use when the user wants an image they do not have; an image they supplied is uploaded, not generated.
+
 ---
 
 ## Pricing Plans

--- a/skills/wix-manage/references/media/generate-image-with-ai.md
+++ b/skills/wix-manage/references/media/generate-image-with-ai.md
@@ -1,0 +1,86 @@
+---
+name: "Generate an Image with AI"
+description: Generates an image from a text prompt with the Wix AI APIs (Runware). Returns a short-lived URL that must be imported to be kept — importing is Upload Media to Wix's job, and this recipe hands off to it. Covers choosing a model and its cost/latency/content-filter trade-off, the accepted output sizes, per-model batching limits, the AI credit each call spends, and why a content refusal arrives as a success response with no image.
+---
+# RECIPE: Generate an Image with AI
+
+For an image the user does not have. An image they supplied — an attachment or a public URL — is uploaded instead: [Upload Media to Wix](upload-media-to-wix.md).
+
+**API reference:** [About the Wix AI APIs](https://dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis), *Generating images* — endpoint, auth, and the full model table. Developer Preview, so confirm the contract there.
+
+---
+
+## AI credits
+
+Each call spends roughly **one AI credit**, billed to the site owner, or to the Wix user who installed the calling app. `numberResults: n` spends n. Importing is free.
+
+Generate one image per entity that needs one, and say how many a run will generate before starting it. Regenerate only when the user asks.
+
+---
+
+## Step 1: Generate
+
+```bash
+curl -X POST 'https://www.wixapis.com/runwareschemaless/v1/request' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-H 'wix-site-id: <METASITE_ID>' \
+-d '[{
+    "taskType": "imageInference",
+    "taskUUID": "3f8c1e42-9b7a-4d16-8a5e-2c0f7b9d4e11",
+    "outputType": "URL",
+    "outputFormat": "PNG",
+    "positivePrompt": "a ceramic pour-over coffee dripper on a walnut counter, morning light",
+    "width": 1024,
+    "height": 1024,
+    "model": "runware:400@1",
+    "numberResults": 1
+}]'
+```
+
+| Parameter | Value |
+|---|---|
+| `taskUUID` | A real UUIDv4. Anything else returns `400 invalidTaskUUID` |
+| `width` / `height` | `1024×1024` (square — products, services, menu items), `1376×768` (16:9 hero), `1200×896` (4:3 editorial). Free-form sizes return 400 |
+| `model` | See below |
+| `numberResults` | `1` |
+
+Omit `steps` and `CFGScale`: Runware accepts them, other models return `400 unsupportedParameter`.
+
+### Models
+
+| `model` | Latency | Content filter |
+|---|---|---|
+| `runware:400@1` | ~5s | Loosest — the default |
+| `google:4@2` | ~25s | Medium, best fidelity |
+| `bfl:5@1` | — | Strictest; refuses trademark-ish prompts |
+
+Any Runware-supported model works — the reference's *Suggested models* table has the current AIR IDs.
+
+### Read the response
+
+```json
+{ "data": [ { "imageURL": "https://im.runware.ai/image/ws/2/ii/<id>.png" } ] }
+```
+
+**A refusal is a success response with no `imageURL`** — test for the field, not the status. On a refusal, reword the prompt or switch model, and report the image as not created.
+
+---
+
+## Step 2: Import
+
+`imageURL` expires, so import it as it lands. [Upload Media to Wix](upload-media-to-wix.md) owns that endpoint and its `PENDING` / `READY` rules; pass the `imageURL` as `url` and `image/png` as `mimeType`.
+
+The result is the returned `file.id` / `file.url` — permanent, and what an entity field takes.
+
+---
+
+## Batches
+
+`runware:400@1` and `bfl:5@1` take several tasks in one body. `google:4@2` returns 504 at three or more, so fire parallel single-task requests for it.
+
+Failure is per image: attach the ones that succeeded, create the rest of the entities text-only, and name which entities have no image and why. A failed image stays missing rather than being swapped for another.
+
+---
+
+For JavaScript callers there is an SDK path — `generateImage()` from the Vercel AI SDK with `runware.image(...)` from `@wix/ai`: [Set up the Wix AI SDK](https://dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/set-up-the-wix-ai-sdk).

--- a/skills/wix-manage/references/stores/create-product-catalog-v3.md
+++ b/skills/wix-manage/references/stores/create-product-catalog-v3.md
@@ -180,7 +180,9 @@ With no file supplied, create the product and report it as not sellable until on
 
 ## Add images
 
-Skip this step when no image was supplied. Prefer the available dedicated Wix image-upload capability and upload all attachments and public image URLs together. Do not reconstruct that capability inside a general API-execution call. When no dedicated uploader is available, use `POST /site-media/v1/files/import` with the external URL in the body field named exactly `url`—not `importUrl`:
+Skip this step when no image was supplied — unless the user asked for one to be generated, in which case create it first with [Generate an Image with AI](../media/generate-image-with-ai.md) and continue below with the Media Manager file it returns. Do not offer generation unprompted, and never generate a substitute for a supplied image that failed to upload.
+
+Prefer the available dedicated Wix image-upload capability and upload all attachments and public image URLs together. Do not reconstruct that capability inside a general API-execution call. When no dedicated uploader is available, use `POST /site-media/v1/files/import` with the external URL in the body field named exactly `url`—not `importUrl`:
 
 ```json
 {"url":"https://example.com/product.jpg","mimeType":"image/jpeg","displayName":"Product.jpg","mediaType":"IMAGE"}

--- a/yaml/wix-manage/media/documentation.yaml
+++ b/yaml/wix-manage/media/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Upload Media to Wix
       docsEntry: https://dev.wix.com/docs/api-reference/assets/media
       tags: [media]
+
+    - file: ../../../skills/wix-manage/references/media/generate-image-with-ai.md
+      title: Generate an Image with AI
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/media
+      tags: [media]


### PR DESCRIPTION
## What

A new `wix-manage` recipe: **Generate an Image with AI** (`references/media/generate-image-with-ai.md`), plus its `SKILL.md` entry and `documentation.yaml` row.

Generating an image is two calls, and the second one is the part that gets missed:

```
POST /runwareschemaless/v1/request   -> data[0].imageURL   (short-lived)
POST /site-media/v1/files/import     -> file.id, file.url  (permanent)
```

The generated URL expires, so an agent that stores it or hands it back has produced something that breaks later.

## Why a recipe when the API is documented

[About the Wix AI APIs](https://dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis) owns the endpoint, the auth requirements and the model table, and the recipe points at it as the source of truth. What it doesn't carry is how the call behaves in a real seeding or product-creation run:

- **A content refusal returns a success status with no `imageURL`.** Checking the status code and reporting success is wrong.
- **`taskUUID` must be a real UUIDv4** — a slug returns 400.
- **Sizes are a closed set of three** (1024×1024, 1376×768, 1200×896); free-form dimensions are rejected.
- **Batching is per-model.** `google:4@2` times out at three or more tasks in one body; `runware:400@1` and `bfl:5@1` batch fine.
- **Import is mandatory and belongs to another recipe** — the step defers to [Upload Media to Wix](https://github.com/wix/skills/blob/main/skills/wix-manage/references/media/upload-media-to-wix.md) rather than restating that endpoint.
- **Failure is per-image.** A refusal on one entity's image must not block creating the others, and a failed image is never silently replaced with a different one.

It also states the cost plainly — roughly **one AI credit per call**, billed to the site owner (or to the app's installer), with `numberResults > 1` costing a credit per image — so an agent doesn't speculatively generate a batch or regenerate for a nicer variant.

The operational rules are taken from the working implementation in `wix-headless` (`references/shared/seed/images.mjs`), which uses this endpoint to give seeded products, services and menu items their images.

## Also

`create-product-catalog-v3.md` links to it from `## Add images`, for the case where the user has no image and asks for one. Two guards on that path: do not offer generation unprompted, and never generate a substitute for a supplied image that failed to upload.

## Open

**No eval scenario yet** (CONTRIBUTING steps 4–5). The assertion would target a `dev.wix.com/docs/.../skills/generate-image-with-ai` URL that only exists once this is published, and I'd rather confirm how a new recipe's docs URL is minted than guess it. Happy to add it here once that's settled.

Note the reference is marked **Developer Preview**, so the contract may move.
