### PR TITLE
fix(wix-app): check the project, not a file list

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -443,7 +443,7 @@ Open every path returned in `newFiles` and replace stubbed handler bodies / UI /
 After all implementation is complete, you MUST run validation. See [APP_VALIDATION.md](references/APP_VALIDATION.md) for the complete validation workflow:
 
 1. Package installation (detect package manager, run install)
-2. TypeScript compilation check (`npx tsc --noEmit`)
+2. TypeScript compilation check (`npx tsc --noEmit -p .`)
 3. Build validation (`npx wix build`)
 4. Preview deployment (`npx wix preview`)
 
@@ -506,7 +506,7 @@ The following actions need to be done manually by you:
 Execute these steps sequentially after all implementation is complete. See [APP_VALIDATION.md](references/APP_VALIDATION.md) for the complete guide.
 
 1. **Package Installation** — Detect package manager, run install
-2. **TypeScript Compilation** — `npx tsc --noEmit`
+2. **TypeScript Compilation** — `npx tsc --noEmit -p .`
 3. **Build** — `npx wix build`
 4. **Preview** — `npx wix preview`
 

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -66,9 +66,8 @@ And the config cannot be handed back on the side: `tsc -p tsconfig.json <file>` 
 **Checking only what you generated does not work even when the config is right.** A type error caused
 by generated code usually surfaces where that code is *consumed* — the page compiles and `App.tsx`
 does not. Measured: a scoped check over the generated directory reported nothing, while the project
-check reported `TS2322` in the consuming file. Scope hides the wiring errors, which are the ones an
-agent actually makes. It is also not worth much — the whole project takes about 1.3s on a real app,
-where 3,169 of the files in the program come from `node_modules` and 13 are yours.
+check reported `TS2322` in the consuming file. Scoping is only sound if you already know the error is
+confined to those files, which is what the check exists to find out.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -47,16 +47,22 @@ pnpm install
 Run TypeScript compiler to check for type errors.
 
 ```bash
-npx tsc --noEmit
+npx tsc --noEmit -p .
 ```
 
-**This is the only form to use.** Passing filenames or globs on the command line makes TypeScript
-ignore `tsconfig.json` altogether — no `strict`, no `noImplicitAny`, no `jsx`, no `paths`. A targeted
-run therefore checks the code against *no* configuration: it misses the errors that matter and
-floods the output with errors that do not. Measured on a real app — a file with an untyped parameter
-reports `TS7006` under `tsc --noEmit`, and under `tsc --noEmit <file>` reports no `TS7006` at all,
-just dozens of `Cannot find name 'Set'` from `node_modules/@types` (no `lib`, no `skipLibCheck`).
-Always check the project, never a file list.
+**This is the only form to use, and there is no targeted variant.** Passing filenames or globs makes
+TypeScript ignore `tsconfig.json` altogether — no `strict`, no `noImplicitAny`, no `jsx`, no `paths`,
+no `lib`, no `skipLibCheck` — so the run checks the code against *no* configuration: it misses the
+errors that matter and floods the output with errors that do not. Measured on a real app, on a file
+with one untyped parameter:
+
+- `npx tsc --noEmit -p .` → `TS7006: Parameter 'x' implicitly has an 'any' type`
+- `npx tsc --noEmit <that file>` → no `TS7006` at all, and instead dozens of
+  `Cannot find name 'Set'` from `node_modules/@types`
+
+And the config cannot be handed back on the side: `tsc -p tsconfig.json <file>` fails outright with
+`TS5042: Option 'project' cannot be mixed with source files on a command line`. Checking a subset of
+files under the project's own settings is not something the compiler offers, so check the project.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -46,41 +46,17 @@ pnpm install
 
 Run TypeScript compiler to check for type errors.
 
-**Full project check:**
 ```bash
 npx tsc --noEmit
 ```
 
-**Targeted check (specific files/directories):**
-
-When validating after implementing a specific extension, you can run TypeScript checks on just those files:
-
-```bash
-# Check specific directory
-npx tsc --noEmit src/extensions/dashboard/pages/survey/**/*.ts src/extensions/dashboard/pages/survey/**/*.tsx
-
-# Check dashboard pages only
-npx tsc --noEmit src/extensions/dashboard/pages/**/*.ts src/extensions/dashboard/pages/**/*.tsx
-
-# Check custom element widgets only
-npx tsc --noEmit src/extensions/site/widgets/**/*.ts src/extensions/site/widgets/**/*.tsx
-
-# Check dashboard modals only
-npx tsc --noEmit src/extensions/dashboard/modals/**/*.ts src/extensions/dashboard/modals/**/*.tsx
-
-# Check backend only
-npx tsc --noEmit src/extensions/backend/**/*.ts
-```
-
-**When to use targeted checks:**
-- After implementing a single extension (faster feedback)
-- When debugging type errors in a specific area
-- During iterative development
-
-**When to use full project check:**
-- Before final validation
-- When changes affect shared types
-- Before building/deploying
+**This is the only form to use.** Passing filenames or globs on the command line makes TypeScript
+ignore `tsconfig.json` altogether — no `strict`, no `noImplicitAny`, no `jsx`, no `paths`. A targeted
+run therefore checks the code against *no* configuration: it misses the errors that matter and
+floods the output with errors that do not. Measured on a real app — a file with an untyped parameter
+reports `TS7006` under `tsc --noEmit`, and under `tsc --noEmit <file>` reports no `TS7006` at all,
+just dozens of `Cannot find name 'Set'` from `node_modules/@types` (no `lib`, no `skipLibCheck`).
+Always check the project, never a file list.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -61,8 +61,14 @@ with one untyped parameter:
   `Cannot find name 'Set'` from `node_modules/@types`
 
 And the config cannot be handed back on the side: `tsc -p tsconfig.json <file>` fails outright with
-`TS5042: Option 'project' cannot be mixed with source files on a command line`. Checking a subset of
-files under the project's own settings is not something the compiler offers, so check the project.
+`TS5042: Option 'project' cannot be mixed with source files on a command line`.
+
+**Checking only what you generated does not work even when the config is right.** A type error caused
+by generated code usually surfaces where that code is *consumed* — the page compiles and `App.tsx`
+does not. Measured: a scoped check over the generated directory reported nothing, while the project
+check reported `TS2322` in the consuming file. Scope hides the wiring errors, which are the ones an
+agent actually makes. It is also not worth much — the whole project takes about 1.3s on a real app,
+where 3,169 of the files in the program come from `node_modules` and 13 are yours.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -144,7 +144,7 @@ Read: .wix/debug.log (with offset to the end)
 | Issue | Cause | Solution |
 |-------|-------|----------|
 | Package installation fails | Missing lock file, network issues, or corrupted node_modules | Delete `node_modules` and lock file, then reinstall |
-| TypeScript compilation fails | Type mismatches, missing declarations, or incorrect types | Fix TypeScript errors shown in `npx tsc --noEmit` output |
+| TypeScript compilation fails | Type mismatches, missing declarations, or incorrect types | Fix TypeScript errors shown in `npx tsc --noEmit -p .` output |
 | Build fails | TypeScript errors, missing dependencies, or internal CLI error | Fix TypeScript errors in source; for non-obvious failures, check `.wix/debug.log` |
 | Preview fails to start | Port conflict, config issue, or internal CLI error | Check `wix.config.json`; if unclear, check `.wix/debug.log` for details |
 | Console errors in preview | Runtime exceptions | Check browser console output |

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -50,12 +50,11 @@ Run TypeScript compiler to check for type errors.
 npx tsc --noEmit -p .
 ```
 
-Check the whole project, not just the files you generated — a type error in generated
-code usually surfaces in the file that consumes it. `-p .` is what holds that line:
-adding a file path to it is an error, whereas adding one to a bare `npx tsc --noEmit`
-silently discards `tsconfig.json` (`strict`, `paths`, `jsx`) and checks against
-compiler defaults instead. Run it from the app root: there `-p .` fails outright if no
-`tsconfig.json` is present, where bare `tsc` would walk up and check the parent project.
+Run it from the app root, and check the whole project rather than just the files you
+generated — a type error in generated code usually surfaces in the file that consumes
+it. `-p .` is what holds that line: adding a file path to it is an error, whereas adding
+one to a bare `npx tsc --noEmit` silently discards `tsconfig.json` (`strict`, `paths`,
+`jsx`) and checks against compiler defaults instead.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -50,24 +50,12 @@ Run TypeScript compiler to check for type errors.
 npx tsc --noEmit -p .
 ```
 
-**This is the only form to use, and there is no targeted variant.** Passing filenames or globs makes
-TypeScript ignore `tsconfig.json` altogether — no `strict`, no `noImplicitAny`, no `jsx`, no `paths`,
-no `lib`, no `skipLibCheck` — so the run checks the code against *no* configuration: it misses the
-errors that matter and floods the output with errors that do not. Measured on a real app, on a file
-with one untyped parameter:
-
-- `npx tsc --noEmit -p .` → `TS7006: Parameter 'x' implicitly has an 'any' type`
-- `npx tsc --noEmit <that file>` → no `TS7006` at all, and instead dozens of
-  `Cannot find name 'Set'` from `node_modules/@types`
-
-And the config cannot be handed back on the side: `tsc -p tsconfig.json <file>` fails outright with
-`TS5042: Option 'project' cannot be mixed with source files on a command line`.
-
-**Checking only what you generated does not work even when the config is right.** A type error caused
-by generated code usually surfaces where that code is *consumed* — the page compiles and `App.tsx`
-does not. Measured: a scoped check over the generated directory reported nothing, while the project
-check reported `TS2322` in the consuming file. Scoping is only sound if you already know the error is
-confined to those files, which is what the check exists to find out.
+Check the whole project, not just the files you generated — a type error in generated
+code usually surfaces in the file that consumes it. `-p .` is what holds that line:
+adding a file path to it is an error, whereas adding one to a bare `npx tsc --noEmit`
+silently discards `tsconfig.json` (`strict`, `paths`, `jsx`) and checks against
+compiler defaults instead. Run it from the app root: there `-p .` fails outright if no
+`tsconfig.json` is present, where bare `tsc` would walk up and check the parent project.
 
 **Success criteria:**
 - Exit code 0

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -63,7 +63,7 @@ roles intact.
 
    ```bash
    npx wix build && npx wix generate manifest
-   npx tsc --noEmit
+   npx tsc --noEmit -p .
    ```
 
    Run relevant tests and lint when available. Inspect the regenerated manifest;

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -63,7 +63,7 @@ roles intact.
 
    ```bash
    npx wix build && npx wix generate manifest
-   npx tsc --noEmit -p .
+   npx tsc --noEmit
    ```
 
    Run relevant tests and lint when available. Inspect the regenerated manifest;

--- a/skills/wix-app/references/editor-react-component/MANIFEST-ERRORS.md
+++ b/skills/wix-app/references/editor-react-component/MANIFEST-ERRORS.md
@@ -13,8 +13,8 @@ exits with an error. Read the error name from the first token before the colon
 | `IoError` (render phase, no other pattern) | SSR crash — remove browser-only APIs (`window`, `document`, `localStorage`) used at render time; ensure props have defaults |
 | `NotFoundError: File not found` | Restore the missing source file or fix its registered/imported path; do not re-scaffold an existing component |
 | `NotFoundError: Component "X" was not found as a named export` | Confirm `component.tsx` has a default export and re-run `npx wix build` |
-| `ParseError: Failed to parse TypeScript config` | Fix `tsconfig.json`; run `npx tsc --noEmit` to surface the error |
-| `ParseError: Failed to extract component types from "X"` | TypeScript error in the component — run `npx tsc --noEmit` and fix |
+| `ParseError: Failed to parse TypeScript config` | Fix `tsconfig.json`; run `npx tsc --noEmit -p .` to surface the error |
+| `ParseError: Failed to extract component types from "X"` | TypeScript error in the component — run `npx tsc --noEmit -p .` and fix |
 | `ParseError: Failed to compile "<file.scss>"` | SCSS syntax error — line/column is in the error message |
 | `ParseError: Failed to parse CSS file for component "X"` | CSS syntax error in `.module.css` — line/column is in the error message |
 


### PR DESCRIPTION
Audit item P0. `APP_VALIDATION.md` carried five per-file `tsc` recipes telling an agent to type-check only the files it had just generated. Both halves of that are wrong, and the skill now prescribes one form: `npx tsc --noEmit -p .`.

## What `-p .` actually buys

**Corrected after review** — an earlier version of this description claimed `-p .` was needed for correctness. It is not. At the app root, bare `tsc --noEmit` reads `tsconfig.json` exactly the same way. Reproduced on TS 5.8.3, matching @mirivoWix's 5.7.3 run:

| from | invocation | result |
|---|---|---|
| root | `tsc --noEmit` | `TS7006` |
| root | `tsc --noEmit -p .` | `TS7006` — **identical** |
| root | `tsc --noEmit a.ts` | **exit 0**, `tsconfig.json` silently discarded |
| root | `tsc --noEmit -p . a.ts` | `TS5042` |
| subdir | `tsc --noEmit` | checks `../a.ts` — walks up into the parent project |
| subdir | `tsc --noEmit -p .` | `TS5057` |

So `-p .` buys two guard rails, and those are what the skill now states:

1. **The footgun becomes a hard error instead of a silent pass.** An agent wanting to narrow the check will append a path. Appended to bare `tsc` that discards the config and checks against compiler defaults — exit 0, a false pass. Appended to `-p .` it is `TS5042`.
2. **It fails loudly from the wrong directory.** Silently checking a project you did not mean to check is the worse outcome in a monorepo.

(TS 7 adds `TS5112`, warning that the config will be ignored when files are specified — closing upstream, but silent on the 5.x these apps ship.)

## Why scoping to generated files is wrong even with the config right

A type error caused by generated code usually surfaces where that code is *consumed*. Measured on a real app: a scoped check over the generated directory reported nothing, while the project check reported `TS2322` in the consuming file. Scoping is only sound if you already know the error is confined to those files — which is what the check exists to find out.

Kept here rather than in the skill: it is the argument for the instruction, not the instruction.

## What changed

`APP_VALIDATION.md` — five per-file recipes deleted; one command, and a short statement of what it buys. The replacement text was rewritten after review: it had been arguing against globs in a file an agent loads at validation time, which reprinted the broken command, demonstrated a `TS5042` an agent following the instruction never reaches, and negated "targeted check" in a way that put the idea back in the reader's head. Now 6 lines instead of 24.

`SKILL.md`, `editor-react-component/MANIFEST-ERRORS.md` — the same bare `npx tsc --noEmit` occurrences updated.

## Not fixed here

`references/EDITOR_REACT_COMPONENT.md:66` still has a bare `npx tsc --noEmit`. An earlier version of this description listed it as fixed; it is not, and it is not fixable in this repo — the file is synced in from [wix-private/editor-react-component-creation-skills](https://github.com/wix-private/editor-react-component-creation-skills/tree/master#skill-sync--keeping-wixskills-up-to-date), so an edit here is overwritten on the next sync. It needs the components team to change it upstream. Tracking as a follow-up rather than leaving it assumed done, since that is the step where an agent actually runs the command mid-flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)