### PR TITLE
docs: clarify storefront transition to presentation implementation

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -46,7 +46,7 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**REST scaffolds are already in `src/rest/`** (STEP 1 deployed them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+**Successful STEP 1 verifies installation of the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -39,11 +39,13 @@ so you don't need to open them:**
 | `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
 
-Everything in the table is already in place — go **straight to wiring + building your presentation**
-(card, grid, variant controls, the product page, Home — STEP 3), nothing to verify first.
-**Don't `read_file` the shipped page/hook source to inspect it** — the table says what each is and
-every field shape you need is in the outlines below. Read a shipped file's source **only** on a real
-fallback — a runtime error, or a field the outlines don't cover (see "Fallback only" at the end).
+A successful install/deploy step is your verification that the listed storefront files are in
+place. **Use the component outlines and interfaces below, then go straight to building your
+presentation and wiring it** (card, grid, variant controls, the product page, Home — STEP 3).
+There is no separate source-inspection or verification phase before implementation; don't read
+shipped page/hook source just to confirm its structure. Read a shipped file **only** to resolve a
+specifically identified field or interface missing from the outlines, or an observed runtime
+error, and scope the read to the relevant file (see "Fallback only" at the end).
 (Shipped files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/storefront/app/` → `src/`.)
 


### PR DESCRIPTION
Some agents inspect shipped storefront implementation to confirm structure despite the provided interfaces. Make the transition from reading those interfaces to building presentation and wiring explicit in the storefront instructions and Base44 STEP 2.

Successful setup establishes that shipped files are installed. Source reads remain available for a specifically identified field/interface missing from the outlines or an observed runtime error, scoped to the relevant file. No extra phase, tool calls, or approval gate is introduced.

Validation: reviewed the two-file diff and repository checklist; `git diff --check` and the CLI pinning check pass. The wix-manage/wix-app eval gates do not cover these paths. Behavioral impact is unmeasured; no controlled behavioral evaluation was run.
