### PR TITLE
docs: streamline storefront guidance and documentation fallbacks

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -169,7 +169,7 @@ installed, not what the business is about. Never default to store/bookings on si
 4. **Build the presentation and wire the integration** following the vertical's `INSTRUCTIONS.md`.
    Reuse its supplied pieces through their documented interfaces, build the presentation it leaves
    to you, and connect routes/providers as specified. Do not reimplement shipped logic. Style new
-   presentation using the existing platform theme; on Base44, use the established `src/index.css` theme.
+   presentation using the existing platform theme.
 5. **Complete the applicable platform and vertical guidance**, including any required checks and
    handoff instructions they provide.
 

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -93,27 +93,28 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
 
 ## How this skill is structured
 
-`<SKILL_ROOT>` is this file's directory (strip `/SKILL.md`). Each vertical ships a **complete UI
-client as files** under `references/<vertical>/app/` — `components/`, `pages/`,
-`hooks/`/`context/`, and its REST helpers in `app/rest/` — plus the **shared transport** in
+`<SKILL_ROOT>` is this file's directory (strip `/SKILL.md`). Each vertical supplies integration
+code under `references/<vertical>/app/`: REST helpers in `app/rest/`, and, depending on the
+vertical, utilities, hooks, context, components, or pages. All use the **shared transport** in
 `references/shared/app/` (`app/rest/wix-client.js` + `wix-config.js`, identical for every vertical).
 Set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) in `wix-config.js`. Deploying `references/<vertical>/app/`
-and `references/shared/app/` into the app's `src/` puts every file in place — the helpers all land in
+and `references/shared/app/` into the app's `src/` puts every file in place — the REST helpers land in
 `src/rest/`, so their relative imports resolve.
 
 **Where these files live in the app, and how they get there** (pre-installed at setup, or copied
 in) **is your platform's call — follow your platform instructions for that.**
 
-Each vertical's `INSTRUCTIONS.md` is the full playbook for that solution: when to use it,
-prerequisites, the exported API, how to wire it, the hard rules, and a verification checklist.
-**Open the relevant `INSTRUCTIONS.md` before wiring** — the shapes and gotchas live there.
+Each vertical's `INSTRUCTIONS.md` specifies its prerequisites, supplied pieces, exported interfaces,
+and the presentation you must build. **Read it before implementation**: reuse the supplied pieces
+and build the missing presentation without reimplementing shipped logic. Follow the platform's
+and vertical's completion guidance where provided.
 
 ## Routing — pick the vertical(s) from the request
 
 Load the vertical(s) the user's app needs; a project may combine several (e.g. a restaurant
 with a blog, or a store with pricing plans).
 
-Each vertical's UI + helpers ship in `references/<vertical>/app/`; copy that dir plus
+Each vertical's integration files ship in `references/<vertical>/app/`; copy that dir plus
 `references/shared/app/` into the app's `src/` (base44 does this at install via `deploy.cjs`).
 
 | The user wants… | Vertical | Read |
@@ -165,14 +166,12 @@ installed, not what the business is about. Never default to store/bookings on si
    `references/shared/app/` into the app's `src/`, and set `WIX_CLIENT_ID` in `wix-config.js`. (Where
    and how they get there is your platform's call — see its instructions. On base44 the install step
    writes and verifies `wix-config.js` for you, so there's nothing to set by hand.)
-4. **Wire the shipped client** following the vertical's INSTRUCTIONS: the components are themed by
-   base44's design tokens (`src/index.css` — shadcn palette, already set by the design phase), so
-   there's no re-skin step; just wire routes + header/footer through the Layout. The UI ships as
-   files — you compose the home page and wire it, you don't rebuild the client. Style what you add
-   from the same tokens: every background paired with its own foreground (`bg-primary` with
-   `text-primary-foreground`), `border-input` on form controls, `border-border` on cards and dividers.
-5. **Verify** against the vertical's checklist before declaring done: token persists across
-   reload, live data renders (or a real empty state), and purchases go through the Wix redirect.
+4. **Build the presentation and wire the integration** following the vertical's `INSTRUCTIONS.md`.
+   Reuse its supplied pieces through their documented interfaces, build the presentation it leaves
+   to you, and connect routes/providers as specified. Do not reimplement shipped logic. Style new
+   presentation using the existing platform theme; on Base44, use the established `src/index.css` theme.
+5. **Complete the applicable platform and vertical guidance**, including any required checks and
+   handoff instructions they provide.
 
 > Some flows need Wix-side setup the user completes later (payments connected, the deployed
 > domain allow-listed on the OAuth client for hosted-checkout return, collection permissions).

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -86,8 +86,8 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   genuine gap (a field, an endpoint, or an error the snippets don't cover), extend the client with
   `wixApiRequest` — confirming the exact endpoint, method, and body first. **For that iteration and
   troubleshooting** — finding the right endpoint, reading a method's request/response schema, or
-  diagnosing an API error — fall back to the **`wix-base44-connector`** skill (`../wix-base44-connector/SKILL.md` when
-  co-installed): use its documentation discovery to search methods, read pages, and inspect API schemas.
+  diagnosing an API error — consult the official Wix API documentation using the documentation
+  skill available in your environment to search methods, read pages, and inspect API schemas.
   Reference index: https://dev.wix.com/docs/api-reference.md
 - **Provide the user with deep links to the Wix dashboard**: In many cases, the user will need to modify the default vertical data in the Wix dashboard. Always provide the user with these links. The relevant information for each vertical's links is in its `INSTRUCTIONS.md` file.
 

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -86,8 +86,8 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   genuine gap (a field, an endpoint, or an error the snippets don't cover), extend the client with
   `wixApiRequest` — confirming the exact endpoint, method, and body first. **For that iteration and
   troubleshooting** — finding the right endpoint, reading a method's request/response schema, or
-  diagnosing an API error — fall back to the **`wix-docs`** skill (`../wix-docs/SKILL.md` when
-  co-installed): it covers `curl` doc-search, reading pages, and structured API-spec queries.
+  diagnosing an API error — fall back to the **`wix-base44-connector`** skill (`../wix-base44-connector/SKILL.md` when
+  co-installed): use its documentation discovery to search methods, read pages, and inspect API schemas.
   Reference index: https://dev.wix.com/docs/api-reference.md
 - **Provide the user with deep links to the Wix dashboard**: In many cases, the user will need to modify the default vertical data in the Wix dashboard. Always provide the user with these links. The relevant information for each vertical's links is in its `INSTRUCTIONS.md` file.
 

--- a/skills/wix-vibe-headless/install/pin-agents-md.cjs
+++ b/skills/wix-vibe-headless/install/pin-agents-md.cjs
@@ -25,7 +25,7 @@ The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from th
   - **events** — publish events and handle RSVPs or ticket sales.
   - **members** — let visitors create an account and sign in — this is **auth**.
   - **restaurants** — publish a menu, take online orders, and manage table reservations.
-- \`wix-docs\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
+- \`wix-base44-connector\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
 `;
 
 const amd = '/app/AGENTS.md';

--- a/skills/wix-vibe-headless/install/pin-agents-md.cjs
+++ b/skills/wix-vibe-headless/install/pin-agents-md.cjs
@@ -25,7 +25,7 @@ The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from th
   - **events** — publish events and handle RSVPs or ticket sales.
   - **members** — let visitors create an account and sign in — this is **auth**.
   - **restaurants** — publish a menu, take online orders, and manage table reservations.
-- \`wix-base44-connector\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
+- **Documentation fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: consult the official Wix API documentation using the documentation skill available in your environment.
 `;
 
 const amd = '/app/AGENTS.md';

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -8,6 +8,9 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **The Wix skills installed below are the complete build and seed path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
+**Banner disabled for this entry flow:** do not add `<WixManageBanner/>`; skip the shared
+storefront instructions' optional banner integration.
+
 Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
@@ -87,7 +90,7 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
+**Never paste a Wix dashboard link or path.**
 
 **Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -20,8 +20,7 @@ Install three skills — they land under `.agents/skills/`:
 - **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
   catalogs, business setup).
 - **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
-  contracts, and the docs **fallback** — find + read the Wix API docs for anything
-  `wix-vibe-headless` doesn't cover.
+  contracts, and Wix API documentation discovery.
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
 
@@ -64,7 +63,7 @@ cleanup truly seems needed, ask the user first.
 Seed by calling the storefront's ready-made seed module — read
 `.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
 its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
-shape → the **`wix-base44-connector`** skill's doc discovery.
+shape → the documentation skill available in your environment.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its
 access token and send it as a bearer token:
@@ -79,8 +78,8 @@ Inline via exec_tool, `base44` is already declared — use it directly; do **not
 inline it throws *"Identifier 'base44' has already been declared."*).
 
 **Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step — `wix-base44-connector` doc discovery if the module
-doesn't cover it.
+storefront seed module's image-attach step — consult official Wix API documentation using the documentation skill
+available in your environment if the module doesn't cover it.
 
 **Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
 from the **completed** `generate_image` result and pass it straight into your single `setupStore`
@@ -110,4 +109,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the `wix-base44-connector` skill's doc discovery.
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the documentation skill available in your environment.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -20,8 +20,7 @@ Install three skills — they land under `.agents/skills/`:
 - **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
   catalogs, business setup).
 - **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
-  contracts, and the docs **fallback** — find + read the Wix API docs for anything
-  `wix-vibe-headless` doesn't cover.
+  contracts, and Wix API documentation discovery.
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
 
@@ -79,4 +78,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the `wix-base44-connector` skill's doc discovery.
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the documentation skill available in your environment.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -8,6 +8,9 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **The Wix skills installed below are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
 
+**Banner disabled for this entry flow:** do not add `<WixManageBanner/>`; skip the shared
+storefront instructions' optional banner integration.
+
 Follow STEPs 1–3 below exactly.
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
@@ -56,7 +59,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Do NOT add the `<WixManageBanner/>` component** and never paste a Wix dashboard link or path.
+**Never paste a Wix dashboard link or path.**
 
 **Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say.
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,6 +8,9 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **The Wix skills installed below are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
+**Banner enabled for this entry flow:** mount `<WixManageBanner/>` once in the Layout, above
+the header in the fixed top region, per the vertical instructions. It is preview-only.
+
 Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **except `forms`**, see STEP 3).
 
 ## STEP 1 — Install the Wix skills locally
@@ -104,8 +107,7 @@ Seeding is **admin-only** — not part of the client, which is built solely per 
 
 ## STEP 5 — Wrap up
 
-1. **Mount `<WixManageBanner/>`** (required) in your Layout's fixed top region, above the header, per your vertical's INSTRUCTIONS — it links the app to its Wix back office, self-gates to the preview, and never shows on the published site.
-2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (your metasite id) to complete setup in Wix.
+**Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (your metasite id) to complete setup in Wix.
 
 **Don't chase images.** A `/__generating__/…` placeholder is swapped for the final url automatically at turn end — do **not** edit, re-seed, or debug image urls.
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -15,7 +15,7 @@ Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **excep
 
 ## STEP 1 — Install the Wix skills locally
 
-Install three skills under `.agents/skills/`: **`wix-vibe-headless`** (the client build + seed guide — your main source of truth), **`wix-manage`** (REST recipes to manage/configure the site), and **`wix-base44-connector`** (site context + API-doc discovery, the fallback for anything the others don't cover).
+Install three skills under `.agents/skills/`: **`wix-vibe-headless`** (the client build + seed guide — your main source of truth), **`wix-manage`** (REST recipes to manage/configure the site), and **`wix-base44-connector`** (site context + API-doc discovery).
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
 
@@ -99,7 +99,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 Seed by calling your vertical's ready-made seed module — read
 `.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and follow it (the loader
 snippet, admin connector token, entity images with the final `media.base44.com` url, and every field
-shape are there). Gaps or an unexpected shape → the **`wix-base44-connector`** skill's doc discovery.
+shape are there). Gaps or an unexpected shape → the documentation skill available in your environment.
 Seeding is **admin-only** — not part of the client, which is built solely per the `wix-vibe-headless` skill.
 
 - **Additive only:** never delete or overwrite the user's content, even apparent sample data; ask first if a cleanup truly seems needed.
@@ -114,7 +114,8 @@ Seeding is **admin-only** — not part of the client, which is built solely per 
 ## Later admin requests
 
 For any later admin/management request, work as in STEP 4: your vertical's seed module first, else
-`wix-base44-connector` doc discovery — all over the connector.
+consult official Wix API documentation using the documentation skill available in your environment.
+Keep admin calls on the connected Wix connector.
 
 **A change to what the business data COLLECTS is one of these, however UI it sounds** — a new form
 field, product option or service setting. Change it on Wix first per the vertical's `seed/SEED.md`,

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -57,18 +57,12 @@ within each. **One exception — `forms` must be seeded before its UI is built; 
 ### 1 · Install the skills
 
 Two skills, into `.agents/skills/`: **`wix-vibe-headless`** (this build guide + the seed modules —
-self-contained) and **`wix-base44-connector`** (fallback to search/read the Wix API reference).
+self-contained) and **`wix-docs`** (search/read the Wix API reference).
 
 ```bash
 CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
-CI=1 npx skills@latest add wix/skills/skills/wix-base44-connector --yes
+CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 ```
-
-Outside Base44, use the connector skill's **documentation-discovery helpers only**: search/browse,
-read pages, and inspect method schemas. Its `scripts/utils.js` runs in a build-time Node.js
-environment with `fetch` and filesystem access; those helpers do not require a Base44 connection.
-Adapt its exec/file-reading examples to your local tools. Its Base44 site-context and connector-token
-instructions do not apply here; keep the visitor authentication and seeding credentials in this guide.
 
 ### 2 · Build the client
 
@@ -116,8 +110,9 @@ V=<vertical>
 find .agents/skills/wix-vibe-headless/references/$V/seed -name '*.js' -exec tail -n +1 {} +
 ```
 
-They encode the Wix API sequences (incl. app-install + provisioning-race handling); use `wix-base44-connector`
-for anything they don't cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is
+They encode the Wix API sequences (incl. app-install + provisioning-race handling). For anything
+they don't cover, consult the official Wix API documentation using the documentation skill available
+in your environment. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is
 installed + seeded (expected; the seed modules install it first). Image seeding = two Wix Media calls
 (`generate-upload-url` → `PUT` the bytes) before attaching.
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -57,12 +57,18 @@ within each. **One exception — `forms` must be seeded before its UI is built; 
 ### 1 · Install the skills
 
 Two skills, into `.agents/skills/`: **`wix-vibe-headless`** (this build guide + the seed modules —
-self-contained) and **`wix-docs`** (fallback to search/read the Wix API reference).
+self-contained) and **`wix-base44-connector`** (fallback to search/read the Wix API reference).
 
 ```bash
 CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
-CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
+CI=1 npx skills@latest add wix/skills/skills/wix-base44-connector --yes
 ```
+
+Outside Base44, use the connector skill's **documentation-discovery helpers only**: search/browse,
+read pages, and inspect method schemas. Its `scripts/utils.js` runs in a build-time Node.js
+environment with `fetch` and filesystem access; those helpers do not require a Base44 connection.
+Adapt its exec/file-reading examples to your local tools. Its Base44 site-context and connector-token
+instructions do not apply here; keep the visitor authentication and seeding credentials in this guide.
 
 ### 2 · Build the client
 
@@ -110,7 +116,7 @@ V=<vertical>
 find .agents/skills/wix-vibe-headless/references/$V/seed -name '*.js' -exec tail -n +1 {} +
 ```
 
-They encode the Wix API sequences (incl. app-install + provisioning-race handling); use `wix-docs`
+They encode the Wix API sequences (incl. app-install + provisioning-race handling); use `wix-base44-connector`
 for anything they don't cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is
 installed + seeded (expected; the seed modules install it first). Image seeding = two Wix Media calls
 (`generate-upload-url` → `PUT` the bytes) before attaching.

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -206,7 +206,7 @@ reference page inline.
   included; add them as an authenticated `wixApiRequest` call).
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
-under `src/`, or look it up via the **`wix-base44-connector`** skill.
+under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -206,7 +206,7 @@ reference page inline.
   included; add them as an authenticated `wixApiRequest` call).
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
-under `src/`, or look it up via the **`wix-docs`** skill.
+under `src/`, or look it up via the **`wix-base44-connector`** skill.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -5,7 +5,7 @@ a build-time module (run via `exec_tool`, not shipped in the app) that abstracts
 seed operation. `require` it and call the functions with plain data.
 
 > **NOT yet live-verified — transcribed from `setup-blog.md`.** Endpoints/fields mirror the recipe
-> exactly; if a call returns an unexpected shape, use the **`wix-base44-connector`** skill (never guess).
+> exactly; if a call returns an unexpected shape, use the documentation skill available in your environment (never guess).
 
 **DEFAULT — one call.** `setupBlog(ctx, plan)` runs the whole flow (memberId → categories/tags →
 posts → covers), keeping every id in memory. Pass category/tag **names** and it resolves them to
@@ -88,7 +88,7 @@ first** (`installBlogApp`, idempotent), so seeding works even if the site doesn'
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix Blog API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix Blog API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -5,7 +5,7 @@ a build-time module (run via `exec_tool`, not shipped in the app) that abstracts
 seed operation. `require` it and call the functions with plain data.
 
 > **NOT yet live-verified — transcribed from `setup-blog.md`.** Endpoints/fields mirror the recipe
-> exactly; if a call returns an unexpected shape, use the **`wix-docs`** skill (never guess).
+> exactly; if a call returns an unexpected shape, use the **`wix-base44-connector`** skill (never guess).
 
 **DEFAULT — one call.** `setupBlog(ctx, plan)` runs the whole flow (memberId → categories/tags →
 posts → covers), keeping every id in memory. Pass category/tag **names** and it resolves them to
@@ -88,7 +88,7 @@ first** (`installBlogApp`, idempotent), so seeding works even if the site doesn'
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix Blog API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix Blog API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -22,8 +22,7 @@
 //   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: files[i].id })));
 //
 // Live-verified end-to-end (members author, categories, posts single+bulk, tags, covers, idempotent
-// re-runs). If any call ever fails with a shape the caller didn't expect, fall back to the wix-base44-connector
-// skill (search + read the live Wix Blog API reference) — never guess. Source recipe:
+// re-runs). If any call ever fails with a shape the caller didn't expect, fall back to the documentation skill available in your environment (search + read the live Wix Blog API reference) — never guess. Source recipe:
 // wix-headless/references/inline-recipes/setup-blog.md.
 
 const API = "https://www.wixapis.com";

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -22,7 +22,7 @@
 //   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: files[i].id })));
 //
 // Live-verified end-to-end (members author, categories, posts single+bulk, tags, covers, idempotent
-// re-runs). If any call ever fails with a shape the caller didn't expect, fall back to the wix-docs
+// re-runs). If any call ever fails with a shape the caller didn't expect, fall back to the wix-base44-connector
 // skill (search + read the live Wix Blog API reference) — never guess. Source recipe:
 // wix-headless/references/inline-recipes/setup-blog.md.
 

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -207,7 +207,7 @@ window.location.href = checkoutUrl;   // hosted checkout; on return the booking 
 ## Extending the client
 The shipped flow covers **APPOINTMENT and CLASS** services (`listSlotsForService` routes by
 `service.type`). For anything beyond that, add a helper on `wixApiRequest`, looking the endpoint up
-in the **`wix-docs`** skill first (never guess):
+in the **`wix-base44-connector`** skill first (never guess):
 - **COURSE** enrollment — a course is enrolled as a *whole*, not per session; `listEventTimeSlots`
   returns no slots for it, so the slot-picker flow doesn't apply (course-specific flow).
 - **Service variants / participants** (duration- or person-based pricing), **add-ons**, and
@@ -217,7 +217,7 @@ in the **`wix-docs`** skill first (never guess):
   them see their own appointments.
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-docs`** skill. Each helper in
+file under `src/`, or look it up via the **`wix-base44-connector`** skill. Each helper in
 `wix-bookings-services.js` / `wix-bookings-checkout.js` links its own reference page inline; these are
 the areas they sit in:
 - Bookings (services, categories, bookings): https://dev.wix.com/docs/api-reference/business-solutions/bookings.md

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -207,7 +207,7 @@ window.location.href = checkoutUrl;   // hosted checkout; on return the booking 
 ## Extending the client
 The shipped flow covers **APPOINTMENT and CLASS** services (`listSlotsForService` routes by
 `service.type`). For anything beyond that, add a helper on `wixApiRequest`, looking the endpoint up
-in the **`wix-base44-connector`** skill first (never guess):
+using the documentation skill available in your environment first (never guess):
 - **COURSE** enrollment — a course is enrolled as a *whole*, not per session; `listEventTimeSlots`
   returns no slots for it, so the slot-picker flow doesn't apply (course-specific flow).
 - **Service variants / participants** (duration- or person-based pricing), **add-ons**, and
@@ -217,7 +217,7 @@ in the **`wix-base44-connector`** skill first (never guess):
   them see their own appointments.
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-base44-connector`** skill. Each helper in
+file under `src/`, or look it up via the documentation skill available in your environment. Each helper in
 `wix-bookings-services.js` / `wix-bookings-checkout.js` links its own reference page inline; these are
 the areas they sit in:
 - Bookings (services, categories, bookings): https://dev.wix.com/docs/api-reference/business-solutions/bookings.md

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -144,7 +144,7 @@ than a multi-service group. Pass `workingHours` only when the brief names openin
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-bookings.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -144,7 +144,7 @@ than a multi-service group. Pass `workingHours` only when the brief names openin
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-bookings.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -32,7 +32,7 @@
 //   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
 //
 // If any call fails with a shape the caller didn't expect, or you need an operation this module
-// doesn't cover, fall back to the wix-base44-connector skill (search + read the live Wix API reference) —
+// doesn't cover, fall back to the documentation skill available in your environment (search + read the live Wix API reference) —
 // never guess. Source recipe (authoritative): wix-headless/references/inline-recipes/setup-bookings.md.
 
 const API = "https://www.wixapis.com";

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -32,7 +32,7 @@
 //   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
 //
 // If any call fails with a shape the caller didn't expect, or you need an operation this module
-// doesn't cover, fall back to the wix-docs skill (search + read the live Wix API reference) —
+// doesn't cover, fall back to the wix-base44-connector skill (search + read the live Wix API reference) —
 // never guess. Source recipe (authoritative): wix-headless/references/inline-recipes/setup-bookings.md.
 
 const API = "https://www.wixapis.com";

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -148,7 +148,7 @@ Validate the mime type and the size there as well.
 
 ## Fallback — beyond the helpers
 Need something the helpers don't cover? Call it yourself with `wixApiRequest`, but look up the exact
-endpoint/method/body in the official Wix reference first (or use the `wix-docs` skill) — never guess.
+endpoint/method/body in the official Wix reference first (or use the `wix-base44-connector` skill) — never guess.
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Partial update (Patch): https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
 - Upsert by id (Save): https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/save-data-item.md

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -148,7 +148,7 @@ Validate the mime type and the size there as well.
 
 ## Fallback — beyond the helpers
 Need something the helpers don't cover? Call it yourself with `wixApiRequest`, but look up the exact
-endpoint/method/body in the official Wix reference first (or use the `wix-base44-connector` skill) — never guess.
+endpoint/method/body in the official Wix reference first (or use the documentation skill available in your environment) — never guess.
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Partial update (Patch): https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
 - Upsert by id (Save): https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/save-data-item.md

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -141,5 +141,5 @@ permission scope, and the response envelope.
 - Bulk Insert Data Item References: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-item-references.md
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Collections: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections.md
-- Anything not covered → use the `wix-docs` skill (search + read the live reference); never guess.
-- Anything not covered → use the `wix-docs` skill (search + read the live reference); never guess.
+- Anything not covered → use the `wix-base44-connector` skill (search + read the live reference); never guess.
+- Anything not covered → use the `wix-base44-connector` skill (search + read the live reference); never guess.

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -141,5 +141,5 @@ permission scope, and the response envelope.
 - Bulk Insert Data Item References: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-item-references.md
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Collections: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections.md
-- Anything not covered → use the `wix-base44-connector` skill (search + read the live reference); never guess.
-- Anything not covered → use the `wix-base44-connector` skill (search + read the live reference); never guess.
+- Anything not covered → use the documentation skill available in your environment (search + read the live reference); never guess.
+- Anything not covered → use the documentation skill available in your environment (search + read the live reference); never guess.

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -206,7 +206,7 @@ official Wix Events API reference first, never guess:
 - Member login + "my registrations" → the **members** vertical (`references/members/INSTRUCTIONS.md`).
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
-under `src/`, or look it up via the **`wix-docs`** skill.
+under `src/`, or look it up via the **`wix-base44-connector`** skill.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -206,7 +206,7 @@ official Wix Events API reference first, never guess:
 - Member login + "my registrations" → the **members** vertical (`references/members/INSTRUCTIONS.md`).
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
-under `src/`, or look it up via the **`wix-base44-connector`** skill.
+under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -94,7 +94,7 @@ Free/RSVP events need neither.
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -94,7 +94,7 @@ Free/RSVP events need neither.
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -31,7 +31,7 @@
 //   const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
 //   await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-events.md.
 

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -31,7 +31,7 @@
 //   const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
 //   await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
+// If any call fails with a shape the caller didn't expect, fall back to the documentation skill available in your environment
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-events.md.
 

--- a/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
@@ -422,7 +422,7 @@ Don't reach for `role="form"`, an `aria-label` on an input that already has a `<
 Three sources answer what this file doesn't: the **JSDoc** in `hooks/useWixForm.js` and
 `lib/wix-form-schema-utils.js`; the **Wix reference** below; and `seed/SEED.md` for how a field was
 authored, and REVISE for changing one. Calling an endpoint the helpers don't wrap is fine via
-`wixApiRequest` — look up the exact method and body first (or the `wix-docs` skill), never guess.
+`wixApiRequest` — look up the exact method and body first (or the `wix-base44-connector` skill), never guess.
 
 - Form object (the shape `form` and its fields arrive in): https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md
 - Form Schemas API: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md

--- a/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/forms/INSTRUCTIONS.md
@@ -422,7 +422,8 @@ Don't reach for `role="form"`, an `aria-label` on an input that already has a `<
 Three sources answer what this file doesn't: the **JSDoc** in `hooks/useWixForm.js` and
 `lib/wix-form-schema-utils.js`; the **Wix reference** below; and `seed/SEED.md` for how a field was
 authored, and REVISE for changing one. Calling an endpoint the helpers don't wrap is fine via
-`wixApiRequest` — look up the exact method and body first (or the `wix-base44-connector` skill), never guess.
+`wixApiRequest` — first look up the exact method and body in official Wix API documentation using
+the documentation skill available in your environment; never guess.
 
 - Form object (the shape `form` and its fields arrive in): https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/form-object.md
 - Form Schemas API: https://dev.wix.com/docs/api-reference/crm/forms/form-schemas.md

--- a/skills/wix-vibe-headless/references/forms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/forms/seed/SEED.md
@@ -25,7 +25,7 @@ The six steps, each with a section below:
 
 Wix Forms is a **CRM** API, not Business Solutions. Read the page before writing a call you don't
 find here — never guess a shape. For anything these pages don't settle — a response shape you didn't
-expect, or an operation this doc doesn't cover — use the **`wix-base44-connector`** skill to search + read the
+expect, or an operation this doc doesn't cover — use the documentation skill available in your environment to search + read the
 live Wix API reference.
 
 | step | title | page | what it settles |

--- a/skills/wix-vibe-headless/references/forms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/forms/seed/SEED.md
@@ -25,7 +25,7 @@ The six steps, each with a section below:
 
 Wix Forms is a **CRM** API, not Business Solutions. Read the page before writing a call you don't
 find here — never guess a shape. For anything these pages don't settle — a response shape you didn't
-expect, or an operation this doc doesn't cover — use the **`wix-docs`** skill to search + read the
+expect, or an operation this doc doesn't cover — use the **`wix-base44-connector`** skill to search + read the
 live Wix API reference.
 
 | step | title | page | what it settles |

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -254,7 +254,7 @@ Members Area app:
 
 Fallback only — when you hit an error or need something not shown here (password reset, custom SSO
 connection ids, a profile field these snippets don't have): read the relevant shipped file under
-`src/rest/`, or look it up via the **`wix-base44-connector`** skill.
+`src/rest/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -254,7 +254,7 @@ Members Area app:
 
 Fallback only — when you hit an error or need something not shown here (password reset, custom SSO
 connection ids, a profile field these snippets don't have): read the relevant shipped file under
-`src/rest/`, or look it up via the **`wix-docs`** skill.
+`src/rest/`, or look it up via the **`wix-base44-connector`** skill.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/members/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/members/seed/SEED.md
@@ -9,8 +9,7 @@ see this vertical's `INSTRUCTIONS.md` and the reference components.
 
 _Optional, off by default:_ only if a run's prompt explicitly asks to exercise the pricing-plans
 purchase path end-to-end, one test member may be created — keep this off so headless runs stay
-deterministic and don't stall on an interactive login. If you need that, use the **`wix-base44-connector`**
-skill for the current member-create shape (source: `wix-headless/references/SEED.md` § members).
+deterministic and don't stall on an interactive login. If you need that, use the documentation skill available in your environment for the current member-create shape (source: `wix-headless/references/SEED.md` § members).
 
 ## Reference
 Members self-register, so this vertical seeds nothing. These are the methods to read if you do reach

--- a/skills/wix-vibe-headless/references/members/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/members/seed/SEED.md
@@ -9,7 +9,7 @@ see this vertical's `INSTRUCTIONS.md` and the reference components.
 
 _Optional, off by default:_ only if a run's prompt explicitly asks to exercise the pricing-plans
 purchase path end-to-end, one test member may be created — keep this off so headless runs stay
-deterministic and don't stall on an interactive login. If you need that, use the **`wix-docs`**
+deterministic and don't stall on an interactive login. If you need that, use the **`wix-base44-connector`**
 skill for the current member-create shape (source: `wix-headless/references/SEED.md` § members).
 
 ## Reference

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -196,7 +196,7 @@ Cover images live at `collection.coverImage.imageInfo.url` and `project.coverIma
 
 Fallback only — when you hit an error or need something not shown here (collection SEO, portfolio
 settings, a field these snippets don't have): read the relevant shipped file under `src/`, or look
-it up via the **`wix-base44-connector`** skill / the Portfolio API reference. Each helper in `wix-portfolio.js`
+it up via the documentation skill available in your environment / the Portfolio API reference. Each helper in `wix-portfolio.js`
 links its own reference page inline; the whole area is here:
 - Portfolio (collections, projects, project items): https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
 

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -196,7 +196,7 @@ Cover images live at `collection.coverImage.imageInfo.url` and `project.coverIma
 
 Fallback only — when you hit an error or need something not shown here (collection SEO, portfolio
 settings, a field these snippets don't have): read the relevant shipped file under `src/`, or look
-it up via the **`wix-docs`** skill / the Portfolio API reference. Each helper in `wix-portfolio.js`
+it up via the **`wix-base44-connector`** skill / the Portfolio API reference. Each helper in `wix-portfolio.js`
 links its own reference page inline; the whole area is here:
 - Portfolio (collections, projects, project items): https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
 

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
@@ -16,7 +16,7 @@ export default function ProjectMedia({ item }) {
   }
   if (item.type === "VIDEO") {
     // resolutions[].url is the confirmed field; posters[0] is the poster (sub-shape not in the
-    // helper JSDoc — posters[0].url used here; confirm in wix-docs if a brand needs more).
+    // helper JSDoc — posters[0].url used here; confirm in wix-base44-connector if a brand needs more).
     const vi = item.video?.videoInfo;
     const src = https(vi?.resolutions?.[0]?.url);
     const poster = https(vi?.posters?.[0]?.url);

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
@@ -16,7 +16,7 @@ export default function ProjectMedia({ item }) {
   }
   if (item.type === "VIDEO") {
     // resolutions[].url is the confirmed field; posters[0] is the poster (sub-shape not in the
-    // helper JSDoc — posters[0].url used here; confirm in wix-base44-connector if a brand needs more).
+    // helper JSDoc — posters[0].url used here; confirm in documentation skill available in your environment if a brand needs more).
     const vi = item.video?.videoInfo;
     const src = https(vi?.resolutions?.[0]?.url);
     const poster = https(vi?.posters?.[0]?.url);

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -79,7 +79,7 @@ hide. `setupPortfolio` **installs the Wix Portfolio app first** (`installPortfol
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-portfolio.md`.
 
 **Transcribed from the recipe — NOT yet live-verified.** The endpoints/fields mirror

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -79,7 +79,7 @@ hide. `setupPortfolio` **installs the Wix Portfolio app first** (`installPortfol
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-portfolio.md`.
 
 **Transcribed from the recipe — NOT yet live-verified.** The endpoints/fields mirror

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -19,7 +19,7 @@
 //   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId: files[0].id, height:1024, width:1024 }]);
 //
 // **NOT yet live-verified — transcribed from setup-portfolio.md.** If any call fails with a
-// shape the caller didn't expect, fall back to the wix-docs skill (search + read the live Wix
+// shape the caller didn't expect, fall back to the wix-base44-connector skill (search + read the live Wix
 // API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-portfolio.md.
 

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -19,7 +19,7 @@
 //   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId: files[0].id, height:1024, width:1024 }]);
 //
 // **NOT yet live-verified — transcribed from setup-portfolio.md.** If any call fails with a
-// shape the caller didn't expect, fall back to the wix-base44-connector skill (search + read the live Wix
+// shape the caller didn't expect, fall back to the documentation skill available in your environment (search + read the live Wix
 // API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-portfolio.md.
 

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -192,7 +192,7 @@ window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.loca
 const orders = await getMyPlanOrders({ orderStatuses: ["ACTIVE"] });   // omit orderStatuses for all
 
 // Plan image: plan.image is a WixMedia object { id, width, height, altText } with NO .url. The shipped
-// cards render text only to avoid this. To show it, resolve the WixMedia `id` to a URL (wix-docs),
+// cards render text only to avoid this. To show it, resolve the WixMedia `id` to a URL (wix-base44-connector),
 // or omit — never <img src={plan.image}> / <img src={plan.image.url}> (undefined / [object Object]).
 ```
 
@@ -208,7 +208,7 @@ method, and body first (never guess):
 - Headless redirect session: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-docs`** skill.
+file under `src/`, or look it up via the **`wix-base44-connector`** skill.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -192,7 +192,7 @@ window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.loca
 const orders = await getMyPlanOrders({ orderStatuses: ["ACTIVE"] });   // omit orderStatuses for all
 
 // Plan image: plan.image is a WixMedia object { id, width, height, altText } with NO .url. The shipped
-// cards render text only to avoid this. To show it, resolve the WixMedia `id` to a URL (wix-base44-connector),
+// cards render text only to avoid this. To show it, resolve the WixMedia `id` to a URL (documentation skill available in your environment),
 // or omit — never <img src={plan.image}> / <img src={plan.image.url}> (undefined / [object Object]).
 ```
 
@@ -208,7 +208,7 @@ method, and body first (never guess):
 - Headless redirect session: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-base44-connector`** skill.
+file under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
@@ -1,6 +1,6 @@
 // Member plan-order row — pure UI for the "My plans" screen. Renders only fields the Order object
 // actually returns (planName, status, start/end dates); for anything else (amount paid, next-billing)
-// look it up in the Orders API reference (wix-docs) — never invent it. Styled with base44 design
+// look it up in the Orders API reference (wix-base44-connector) — never invent it. Styled with base44 design
 // tokens (shadcn Tailwind classes).
 
 // Each status carries its OWN text colour: a shared `text-primary-foreground` over a varying

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
@@ -1,6 +1,6 @@
 // Member plan-order row — pure UI for the "My plans" screen. Renders only fields the Order object
 // actually returns (planName, status, start/end dates); for anything else (amount paid, next-billing)
-// look it up in the Orders API reference (wix-base44-connector) — never invent it. Styled with base44 design
+// look it up in the Orders API reference (documentation skill available in your environment) — never invent it. Styled with base44 design
 // tokens (shadcn Tailwind classes).
 
 // Each status carries its OWN text colour: a shared `text-primary-foreground` over a varying

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -74,7 +74,7 @@ is NOT a plan field or a perk). Those ids come from the **bookings seed**
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -74,7 +74,7 @@ is NOT a plan field or a perk). Those ids come from the **bookings seed**
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
@@ -20,7 +20,7 @@
 //   // Then, per plan that covers bookings services (STEP 2; skip entirely with no bookings):
 //   await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
+// If any call fails with a shape the caller didn't expect, fall back to the documentation skill available in your environment
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-pricing-plans.md.
 

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
@@ -20,7 +20,7 @@
 //   // Then, per plan that covers bookings services (STEP 2; skip entirely with no bookings):
 //   await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-pricing-plans.md.
 

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -217,7 +217,7 @@ Building something beyond the shipped pages, or need a path these snippets don't
 Modifier up-charges / price-variant selection / special requests on the **cart line** are **not**
 wired into `addItemToCart` — the restaurants `catalogReference.options` shape for these isn't
 documented for client add-to-cart, so `ItemDialog` displays modifier groups for the diner but sends
-only quantity. To wire them, confirm the shape via the **`wix-base44-connector`** skill / the reference first,
+only quantity. To wire them, confirm the shape via the documentation skill available in your environment / the reference first,
 never guess:
 - Restaurants API reference: https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md
 - Sample flows (cart options): https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
@@ -226,7 +226,7 @@ never guess:
   in lets them see their own order/reservation history.
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-base44-connector`** skill.
+file under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -217,7 +217,7 @@ Building something beyond the shipped pages, or need a path these snippets don't
 Modifier up-charges / price-variant selection / special requests on the **cart line** are **not**
 wired into `addItemToCart` — the restaurants `catalogReference.options` shape for these isn't
 documented for client add-to-cart, so `ItemDialog` displays modifier groups for the diner but sends
-only quantity. To wire them, confirm the shape via the **`wix-docs`** skill / the reference first,
+only quantity. To wire them, confirm the shape via the **`wix-base44-connector`** skill / the reference first,
 never guess:
 - Restaurants API reference: https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md
 - Sample flows (cart options): https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
@@ -226,7 +226,7 @@ never guess:
   in lets them see their own order/reservation history.
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-docs`** skill.
+file under `src/`, or look it up via the **`wix-base44-connector`** skill.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -155,7 +155,7 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover, use the
-**`wix-docs`** skill to search + read the live Wix API reference — never guess. The **Experiences** create
+**`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The **Experiences** create
 payload especially lives in the docs (fields evolve). The authoritative source recipes are
 `wix-headless/references/inline-recipes/setup-restaurants.md`, `setup-restaurant-orders.md`,
 `setup-restaurant-reservations.md`, and `setup-restaurant-experiences.md`.

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -155,7 +155,7 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover, use the
-**`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The **Experiences** create
+documentation skill available in your environment to search + read the live Wix API reference — never guess. The **Experiences** create
 payload especially lives in the docs (fields evolve). The authoritative source recipes are
 `wix-headless/references/inline-recipes/setup-restaurants.md`, `setup-restaurant-orders.md`,
 `setup-restaurant-reservations.md`, and `setup-restaurant-experiences.md`.

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -38,7 +38,7 @@
 //
 // **NOT yet live-verified — transcribed from setup-restaurants.md / setup-restaurant-orders.md /
 // setup-restaurant-reservations.md / setup-restaurant-experiences.md.** If any call fails with a
-// shape the caller didn't expect, fall back to the wix-base44-connector skill (search + read the live Wix API
+// shape the caller didn't expect, fall back to the documentation skill available in your environment (search + read the live Wix API
 // reference) — never guess.
 //
 // ── PRECONDITIONS the recipes flag (record in the handoff, do NOT fail the seed) ─────────────────

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -38,7 +38,7 @@
 //
 // **NOT yet live-verified — transcribed from setup-restaurants.md / setup-restaurant-orders.md /
 // setup-restaurant-reservations.md / setup-restaurant-experiences.md.** If any call fails with a
-// shape the caller didn't expect, fall back to the wix-docs skill (search + read the live Wix API
+// shape the caller didn't expect, fall back to the wix-base44-connector skill (search + read the live Wix API
 // reference) — never guess.
 //
 // ── PRECONDITIONS the recipes flag (record in the handoff, do NOT fail the seed) ─────────────────

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -329,8 +329,8 @@ function Layout() {
 ```
 
 ## Missing capabilities
-For a capability these interfaces do not cover, follow the **`wix-base44-connector`** skill's
-documentation discovery.
+For anything these interfaces do not cover, consult the official Wix API documentation using
+the documentation skill available in your environment.
 For a specifically missing field/interface or an observed runtime error, read only the relevant
 shipped file; catalog and cart helpers link their API references inline.
 

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -45,12 +45,15 @@ from these contracts. `Shop` needs your grid; `/product/:slug` needs your PDP. H
 footer are yours to design; their integration is in **Routes and provider** below.
 
 ### Product card
+Pass a catalog product to `ProductCard`: use `product.id` for identity/quick-add, `product.name`
+for the title, and `product.slug` for the PDP link. Pass the full object to `useProductCard`.
+
 ```jsx
 import { useProductCard } from "@/hooks/useProductCard";
 import { useCart } from "@/context/CartContext";
 
 export default function ProductCard({ product }) {
-  const { addToCart, error } = useCart();
+  const { addToCart, loading, error } = useCart();
   const {
     isSoldOut, isPreorder, isPartiallyOutOfStock, // booleans
     leftBadges,       // [{ type: 'pre-order'|'sold-out'|'limited-stock', label }]
@@ -68,9 +71,10 @@ export default function ProductCard({ product }) {
 For quick-add, call `addToCart(product.id)` only when `isQuickAddable` and no mandatory
 modifier needs input (`product.modifiers` entries have a `mandatory` boolean). Otherwise link to `/product/${product.slug}` for selection, including
 pre-orders. Listing results have no full variants; the PDP hook loads and resolves them.
-Display cart-context `error` for a failed quick-add (see **Cart**); failure does not open the drawer.
+Use cart-context `loading` to disable repeated adds and display `error` on failure (see **Cart**);
+failure does not open the drawer.
 
-### Product grid and catalog data
+### Product grid
 ```jsx
 export default function ProductGrid({ products, loading, empty, emptyHint }) {
   // products: array | null (null while loading); loading: boolean
@@ -78,13 +82,53 @@ export default function ProductGrid({ products, loading, empty, emptyHint }) {
   // Render loading, empty, or the list of <ProductCard product={product} /> items.
 }
 ```
-For catalog data in your own pages, import `queryProducts` from `@/rest/wix-store-catalog`:
+
+### Catalog views and queries
+For a custom catalog view, use the named `useShop` and `SORTS` exports from `@/hooks/useShop`.
+The shipped `Shop` already uses this hook; your `ProductGrid` receives its products and loading state.
+
 ```js
-const { products, nextCursor } = await queryProducts({ limit: 8 });
-// Returns { products: object[], nextCursor: string | null }, never a bare array.
-// Pass nextCursor as cursor for another page; default limit is 100.
+const {
+  categories, activeCategory, setActiveCategory,
+  products, loading, error, retry,
+  hasMore, loadMore, loadingMore, sort, setSort,
+} = useShop({ pageSize: 24 }); // optional argument; default pageSize 24
+// categories: category[]; activeCategory: category | null (null = all products)
+// setActiveCategory(categoryOrNull): starts a fresh product query
+// products: product[] | null; loading: boolean (first page/category load)
+// error: string | null; retry(): reloads the active category's first page
+// hasMore, loadingMore: booleans; loadMore(): appends another page when available
+// sort: 'featured' | 'priceAsc' | 'priceHigh' | 'name'; setSort(key)
+// SORTS: { [key]: { label } } for those keys
 ```
-Handle query failure separately from loading; don't leave a failed request on a spinner.
+Sorting applies only to loaded products. Initial product failure sets `error` and an empty array;
+a later page failure preserves loaded products and sets `error`. Render the error separately from
+an empty catalog. Category loading fetches only the first 100 categories, excludes `visible: false`
+and `slug: "all-products"`, and falls back to `[]` on failure without setting `error`.
+
+For a standalone product selection or category menu, import these named functions from
+`@/rest/wix-store-catalog`. All three return promises and reject on request failure.
+
+| Function | Result |
+|---|---|
+| `queryProducts({ limit = 100, cursor } = {})` | `{ products: product[], nextCursor: string or null }` — visible catalog products |
+| `queryCategories({ limit = 100, cursor } = {})` | `{ categories: category[], nextCursor: string or null }` — one category page |
+| `queryProductsByCategory(categoryId, { limit = 100, cursor } = {})` | `{ products: product[], nextCursor: string or null }` — visible products in the category identified by `id` |
+
+Products are the full listing objects consumed by `useProductCard`. Category menu fields are
+`id`, `name`, `slug`, and `visible`. Filter out `visible === false` and the system category
+`slug === "all-products"`; an empty category list is valid.
+
+```js
+const { categories, nextCursor: categoryCursor } = await queryCategories({ limit: 100 });
+const menu = categories.filter((c) => c.visible !== false && c.slug !== "all-products");
+// Once a category has been selected:
+const { products, nextCursor } = await queryProductsByCategory(selectedCategory.id, { limit: 24 });
+```
+Destructure the arrays; these calls never return bare arrays. Pass a result's `nextCursor` back
+as `cursor` to the same query for the next page, stopping at null. Keep category and product
+cursors separate; changing category starts without a cursor. Handle failure separately from
+loading so a failed request does not leave a spinner.
 
 ### Product detail
 ```jsx
@@ -139,19 +183,18 @@ Retired option choices are filtered out. Respect each choice's `inStock` and mod
 `mandatory` flag; the hook supplies colour values and selection state without prescribing layout.
 
 ### Images
-Import from `@/lib/storeImage`; URLs may be null, so handle missing images.
+`useProductCard` returns normalized `image`/`hoverImage`, and `useProductDetail` returns normalized
+`focusMediaUrl`; use them directly. For a gallery or images outside those hooks, import from
+`@/lib/storeImage`:
 
 | Helper | Contract |
 |---|---|
+| `productGallery(product)` | `[{ url, altText }]`, main image first, de-duplicated; skips entries without an image URL; empty array when no images |
+| `productImage(product)` | Normalized primary image URL or null, for a standalone catalog image |
 | `storeImage(value)` | Accepts a URL string, `{ image: { url } }`, or `{ url }`; prefixes `//` with `https:`, returns other URLs unchanged or null when absent |
-| `productImage(product)` | Normalised `product.media.main.image.url`, or null |
-| `productGallery(product)` | `[{ url, altText }]` from the main image and `media.itemsInfo.items`, main first, de-duplicated; skips items without an image URL |
-| `choiceImage(choice)` | First `choice.media.items[].mediaId` as a URL, or null; storefront reads use this field, not `linkedMedia` |
-| `variantImage(variant)` | Uses `media.image.url`, then `media.id`, then `media.thumbnail.url`; never `media.uploadId` |
-| `wixMediaUrl(mediaId)` | Converts a Wix media id to a static CDN URL; normalises existing URLs; null for missing/non-string input |
-| `wixMediaId(url)` | Extracts the id after `/media/` for comparison across sizing URLs; returns input unchanged if unmatched |
 
-Cart line images are at `lineItems[].attributes.image.url`; normalise them with `storeImage`.
+Gallery URLs are normalized too. Handle missing images; don't reconstruct media URLs or resolve
+choice/variant media yourself. Custom cart images use `storeImage(line.attributes?.image?.url)`.
 
 ### Cart
 Use the named `useCart` export from `@/context/CartContext` within `CartProvider`.
@@ -171,7 +214,11 @@ const {
 `addToCart` uses `product.id` and the resolved `variant.id` when needed. Extras are string maps:
 `modifierChoices: { [modifier.key]: choiceKey }` and
 `customTextFields: { [modifier.freeTextSettings.key]: userInput }`; include mandatory values.
-Update/remove use `cart.lineItems[].id`, not a catalog product id.
+For custom cart presentation, `cart?.lineItems ?? []` is the list. Each line has `id`,
+`name.original`, and optional `attributes.image.url`. Option/modifier labels are in
+`attributes.descriptionLines`: `[{ name: { original }, plainText?: { original },
+colorInfo?: { original, code } }]`; use `plainText.original` or `colorInfo.original` for the value.
+Update/remove use the line's `id`, not a catalog product id.
 
 The context's add/remove/update/checkout methods return promises resolving to `undefined` on
 success or `null` on failure, storing the failure in `error`. They clear the previous error and
@@ -199,7 +246,9 @@ when finite. `status` can be `IN_STOCK`, `PARTIALLY_IN_STOCK`, `OUT_OF_STOCK`, o
 `REMOVED_FROM_CATALOG`; surface unavailable lines and prevent checkout until resolved.
 
 ## Routes and provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
-**No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
+**No file reads needed to wire this.** `Shop`, `CartDrawer`, `CartButton`, and `WixManageBanner`
+are default exports that take **no props**. `CartProvider` is a named export accepting `children`;
+wire these exactly as shown below.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it.
 - Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
@@ -262,28 +311,10 @@ function Layout() {
 </CartProvider>
 ```
 
-## Extending the client
-Building something beyond the shipped pages? Copy these:
-
-```jsx
-// Catalog list helpers return { <plural>, nextCursor } — destructure the array:
-const { products, nextCursor } = await queryProducts({ limit: 24 });
-const { categories } = await queryCategories();
-const menu = categories.filter((c) => c.slug !== "all-products");   // drop Wix's system category
-const { products: inCategory } = await queryProductsByCategory(menu[0].id, { limit: 24 });
-
-// product.plainDescription is HTML → render as HTML (the PDP does this):
-<div dangerouslySetInnerHTML={{ __html: product.plainDescription }} />
-// image urls live at: product.media.main.image.url  ·  cart lineItems[].attributes.image.url
-```
-
-Fallback only — when you hit an error or need something not shown here (coupons, members, a field
-these snippets don't have): read the relevant shipped file under `src/`, or look it up via the
-**`wix-docs`** skill. Each helper in `wix-store-catalog.js` / `wix-store-cart.js` links its own
-reference page inline; these are the areas they sit in:
-- Stores catalog (products, categories, inventory): https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3.md
-- eCommerce (cart, checkout, orders): https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md
-- Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
+## Missing capabilities
+For a capability these interfaces do not cover, use Wix documentation via the **`wix-docs`** skill.
+For a specifically missing field/interface or an observed runtime error, read only the relevant
+shipped file; catalog and cart helpers link their API references inline.
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped pages or adding a parallel theme file. Everything you build (card, grid, PDP, variant controls, Home) draws from the same tokens.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -312,7 +312,8 @@ function Layout() {
 ```
 
 ## Missing capabilities
-For a capability these interfaces do not cover, use Wix documentation via the **`wix-docs`** skill.
+For a capability these interfaces do not cover, follow the installed docs-discovery skill:
+**`wix-base44-connector`** on Base44, or **`wix-docs`** in setups that install it.
 For a specifically missing field/interface or an observed runtime error, read only the relevant
 shipped file; catalog and cart helpers link their API references inline.
 

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -185,7 +185,7 @@ other than `IN_STOCK`, and refreshes the cart after failure. `refreshCart()` rep
 and resolves to `undefined`; its underlying read returns null for no cart or a failed request. It
 does not set mutation `loading` or `error`.
 
-Cart V2 money is `{ amount, convertedAmount }`, with no formatted string. `amount` is in site
+Cart money is `{ amount, convertedAmount }`, with no formatted string. `amount` is in site
 currency; `convertedAmount` is in display currency. Format
 `money.convertedAmount ?? money.amount` with `Intl.NumberFormat` and
 `cart.customerInfo?.currencyCode ?? cart.businessInfo?.currencyCode` (the shipped drawer falls
@@ -197,9 +197,6 @@ not fetch. Tax and shipping resolve at checkout.
 Line `quantityInfo.confirmedQuantity` is the current quantity; `availableQuantity` caps increases
 when finite. `status` can be `IN_STOCK`, `PARTIALLY_IN_STOCK`, `OUT_OF_STOCK`, or
 `REMOVED_FROM_CATALOG`; surface unavailable lines and prevent checkout until resolved.
-
-Migrating from Cart V1 / Checkout V1? These helpers are V2-only; see the
-[migration guide](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/migration-guide).
 
 ## Routes and provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -329,8 +329,8 @@ function Layout() {
 ```
 
 ## Missing capabilities
-For a capability these interfaces do not cover, follow the installed docs-discovery skill:
-**`wix-base44-connector`** on Base44, or **`wix-docs`** in setups that install it.
+For a capability these interfaces do not cover, follow the **`wix-base44-connector`** skill's
+documentation discovery.
 For a specifically missing field/interface or an observed runtime error, read only the relevant
 shipped file; catalog and cart helpers link their API references inline.
 

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -24,7 +24,7 @@ Successful deployment verified these files are in place; use this map without ne
 | `lib/storeImage.js` | Wix image URL and gallery helpers |
 | `components/CartButton.jsx` | Cart icon button with a live-count badge |
 | `components/CartDrawer.jsx` | Cart drawer; mount once, opens through `useCart` |
-| `components/WixManageBanner.jsx` | Preview-only manage banner for the Layout |
+| `components/WixManageBanner.jsx` | Preview-only manage banner; include only when the entry guide enables it |
 | `pages/Shop.jsx` | `/shop` page; imports your `ProductGrid` |
 | `rest/wix-config.js` | Wix client and site ids |
 | `rest/wix-client.js` | REST transport and visitor authentication |
@@ -246,7 +246,7 @@ when finite. `status` can be `IN_STOCK`, `PARTIALLY_IN_STOCK`, `OUT_OF_STOCK`, o
 `REMOVED_FROM_CATALOG`; surface unavailable lines and prevent checkout until resolved.
 
 ## Routes and provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
-**No file reads needed to wire this.** `Shop`, `CartDrawer`, `CartButton`, and `WixManageBanner`
+**No file reads needed to wire this.** `Shop`, `CartDrawer`, and `CartButton`
 are default exports that take **no props**. `CartProvider` is a named export accepting `children`;
 wire these exactly as shown below.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
@@ -256,11 +256,6 @@ replace it.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Shop` and your own pages — so you **never edit the shipped `Shop` to add a
   header/footer** (it renders inside `<Outlet/>` as-is). Mount `<CartDrawer/>` once in the Layout.
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
-  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
-  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
-  the content by the region's measured height so it clears the chrome and self-corrects when the
-  banner is dismissed.
 - Routes under the Layout: `/shop` → `Shop` (shipped, renders your grid); `/product/:slug` → **your
   `ProductDetail`**; `/` → **your `Home`**.
 
@@ -268,35 +263,21 @@ Mount the default export `CartButton` from `@/components/CartButton` once in you
 the drawer and shows the live count, inheriting `currentColor`; use it as-is, without a nested button.
 
 ```jsx
-import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { CartProvider } from "@/context/CartContext";
 import CartDrawer from "@/components/CartDrawer";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Shop from "@/pages/Shop";                       // shipped · default export, no props
 import ProductDetail from "@/pages/ProductDetail";     // YOU build
 import Home from "@/pages/Home";       // YOU build
-import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Header from "@/components/Header";   // YOU build
 import Footer from "@/components/Footer";   // YOU build
 
 function Layout() {
-  const topRef = useRef(null);
-  const [offset, setOffset] = useState(0);
-  useEffect(() => {                                  // measure the fixed region → pad content below it
-    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
-    if (topRef.current) ro.observe(topRef.current);
-    return () => ro.disconnect();
-  }, []);
   return (<>
-    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null on the published site / when dismissed */}
-      <Header />                             {/* your brand header, in-flow inside this fixed block */}
-    </div>
-    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
-      <Outlet />                             {/* shipped Shop + your pages render here */}
-      <Footer />
-    </div>
-    <CartDrawer />                           {/* overlays every page */}
+    <Header />
+    <Outlet />
+    <Footer />
+    <CartDrawer />
   </>);
 }
 
@@ -311,6 +292,42 @@ function Layout() {
 </CartProvider>
 ```
 
+### Optional banner integration — enabled entry flows only
+Follow the entry guide's banner choice. If it disables the banner, use the common wiring above
+without a banner import, mount, or banner-specific fixed region.
+
+When enabled, `WixManageBanner` is a default export with no props. It uses `WIX_METASITE_ID` from
+`@/rest/wix-config`, links to that site's dashboard, and renders only in preview; it returns null
+when dismissed or while the site id is a placeholder. Mount it once above the header in one fixed
+region; keep the header in flow within that region and offset the content by its measured height
+so dismissal or resizing leaves no gap or overlap. Replace only the example's `Layout` with:
+
+```jsx
+import { useRef, useState, useEffect } from "react";
+import WixManageBanner from "@/components/WixManageBanner";
+
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />
+      <Header />
+    </div>
+    <div style={{ paddingTop: offset }}>
+      <Outlet />
+      <Footer />
+    </div>
+    <CartDrawer />
+  </>);
+}
+```
+
 ## Missing capabilities
 For a capability these interfaces do not cover, follow the installed docs-discovery skill:
 **`wix-base44-connector`** on Base44, or **`wix-docs`** in setups that install it.
@@ -320,6 +337,5 @@ shipped file; catalog and cart helpers link their API references inline.
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped pages or adding a parallel theme file. Everything you build (card, grid, PDP, variant controls, Home) draws from the same tokens.
 - Header/footer live in a `Layout` around `<Outlet/>` (see **Routes and provider**) — never edit the shipped `Shop` to add chrome.
-- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
 - Render live Wix data or the shipped empty state — never mock products.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -194,38 +194,49 @@ Retired option choices are filtered out. Respect each choice's `inStock` and mod
 | `storeImage(value)` | Accepts a URL string, `{ image: { url } }`, or `{ url }`; prefixes `//` with `https:`, returns other URLs unchanged or null when absent |
 
 Gallery URLs are normalized too. Handle missing images; don't reconstruct media URLs or resolve
-choice/variant media yourself. Custom cart images use `storeImage(line.attributes?.image?.url)`.
+choice/variant media yourself.
 
 ### Cart
-Use the named `useCart` export from `@/context/CartContext` within `CartProvider`.
+Use the shipped `CartDrawer` and `CartButton` with `CartProvider`, as wired below. The drawer
+already renders cart lines, quantities, subtotal, and checkout; you do not need to build a cart UI.
+Your card/PDP adds products through the named `useCart` export from `@/context/CartContext`
+within `CartProvider` (the PDP hook calls it for you).
 
 ```js
-const {
-  cart, itemCount, isOpen, setIsOpen, loading, error, clearError,
-  addToCart, removeItem, updateQuantity, checkout, refreshCart,
-} = useCart();
-// cart: server cart | null; itemCount: sum of confirmed line quantities
-// isOpen: boolean; setIsOpen(boolean); loading: mutation-in-progress boolean
-// error: string | null; clearError(): clears it
+const { addToCart, isOpen, setIsOpen, loading, error, clearError } = useCart();
 // addToCart(productId, variantId?, qty = 1, { modifierChoices?, customTextFields? }?)
-// removeItem(lineItemId); updateQuantity(lineItemId, qty)
-// checkout(); refreshCart()
+// isOpen: boolean; setIsOpen(true): open the drawer; setIsOpen(false): close it
+// loading: mutation-in-progress boolean; disable repeated adds while true
+// error: string | null; clearError(): clears it
 ```
 `addToCart` uses `product.id` and the resolved `variant.id` when needed. Extras are string maps:
 `modifierChoices: { [modifier.key]: choiceKey }` and
 `customTextFields: { [modifier.freeTextSettings.key]: userInput }`; include mandatory values.
+
+The context's add/remove/update/checkout methods return promises resolving to `undefined` on
+success or `null` on failure, storing the failure in `error`. They clear the previous error and
+set `loading` during the operation. Successful add updates the server-cart snapshot and opens the
+drawer; failed add does not open it. The drawer displays errors only while open, so your card/PDP
+must surface `error` too. These context methods do not return the updated cart or checkout URL.
+The lower-level REST helpers can reject; don't apply their rejection contract to `useCart()`.
+
+#### Custom cart UI — optional
+Only use these additional contracts if you choose to render your own cart surface. They come
+from the same `useCart()` context; mutation results and error handling are described above.
+
+```js
+const { cart, itemCount, removeItem, updateQuantity, checkout, refreshCart } = useCart();
+// cart: server cart | null; itemCount: sum of confirmed line quantities
+// removeItem(lineItemId); updateQuantity(lineItemId, qty)
+// checkout(); refreshCart()
+```
 For custom cart presentation, `cart?.lineItems ?? []` is the list. Each line has `id`,
 `name.original`, and optional `attributes.image.url`. Option/modifier labels are in
 `attributes.descriptionLines`: `[{ name: { original }, plainText?: { original },
 colorInfo?: { original, code } }]`; use `plainText.original` or `colorInfo.original` for the value.
 Update/remove use the line's `id`, not a catalog product id.
 
-The context's add/remove/update/checkout methods return promises resolving to `undefined` on
-success or `null` on failure, storing the failure in `error`. They clear the previous error and
-set `loading` during the operation. Successful add updates the server-cart snapshot and opens the
-drawer; failed add does not open it. The drawer displays errors only while open, so custom add UI
-must surface `error` too. These context methods do not return the updated cart or checkout URL.
-The lower-level REST helpers can reject; don't apply their rejection contract to `useCart()`.
+Normalize custom cart images with `storeImage(line.attributes?.image?.url)` (see **Images**).
 
 `checkout()` navigates to the hosted checkout URL; it refuses empty carts and lines with a status
 other than `IN_STOCK`, and refreshes the cart after failure. `refreshCart()` replaces the snapshot

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -1,68 +1,207 @@
 # Wix Storefront — ready-made client
 
-The storefront **commerce engine ships as real files** — the hooks, the server cart, the REST
-transport, the image helpers, and the `Shop` listing page, all correct (variant resolution,
-modifiers, stock gating, checkout). It reads from your app's design tokens (base44's `src/index.css`
-— the shadcn palette the design phase already set).
+The storefront ships the commerce hooks, server cart, REST transport, image helpers, and `Shop`
+listing page. You build the presentation: product card, grid, variant controls, product detail
+(PDP) page, Home, header, and footer. Use the interfaces below and proceed directly to implementation.
 
-**The presentation doesn't ship — you build it** (STEP 3): the product **card**, **grid**, **variant
-controls**, and the whole **product (PDP) page**, plus **Home** and the **header/footer**. Each is
-built on a shipped hook whose return type + field shapes are documented in the outline right next to
-it — the data is handed to you done, the layout and look are yours. `Shop` renders once your
-`ProductGrid` exists; the PDP renders once you build its page — that's the point.
-
-Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock
-products; never hand-build a `/checkout` URL — the shipped cart goes through the eCom
-redirect-session.
+The client talks to Wix over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock
+products or hand-build a `/checkout` URL; the shipped cart uses the eCom redirect session.
 
 ## Prerequisites
-- The site's **Wix Stores** catalog is the read/cart target. It's installed and seeded separately (see **Seeding** below), in parallel with this build — so it may be empty at build time; the client renders the shipped empty state until products land.
+- The site's **Wix Stores** catalog is the read/cart target. It's installed and seeded separately, in parallel with this build — so it may be empty at build time; render the empty state until products land.
 - The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
-## STEP 1 — The client is already in `src/`
-The install step (base44.md STEP 1) deployed the whole storefront UI client + REST scaffolds into
-`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
-so you don't need to open them:**
+## Already installed in `src/`
+Successful deployment verified these files are in place; use this map without needing to read their source (`@/` → `src/`).
 
 | file | what it is |
 |---|---|
-| `context/CartContext.jsx` | `useCart()` provider: server cart, add/update/remove, checkout |
-| `hooks/useProductDetail.js` | PDP data — product + variant resolution for a slug, plus load/add state; **your product page (STEP 3) is built on it** |
-| `hooks/useShop.js` | catalog listing — category menu, cursor paging, sort, failure state |
-| `hooks/useProductCard.js` | headless data layer for a grid tile — returns `leftBadges`, `promoBadge`, `priceDisplay`, `compareAtDisplay`, `colors`, `optionLabel`, `isQuickAddable`, `image`, `hoverImage`; **your `ProductCard` (STEP 3) is built on it** |
-| `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` / `choiceImage()` — normalise Wix image urls; `productGallery(product)` → `[{ url, altText }]` (your PDP gallery); `choiceImage(choice)` resolves an option choice's photo (V3 read shape: `media.items[].mediaId`, not `linkedMedia`) |
-| `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
-| `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
-| `hooks/useVariantOptions.js` | headless data layer for options/modifiers — returns `optionGroups` + `modifierGroups` (normalised, render-agnostic); **your PDP's variant controls (STEP 3) render from it** |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
-| `pages/Shop.jsx` | the shipped `/shop` listing page — renders your `ProductGrid` (you build `/product/:slug` and `/`) |
-| `rest/wix-config.js` | the two ids, written by the install step |
-| `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
+| `context/CartContext.jsx` | `CartProvider` and `useCart()`: server cart, add/update/remove, checkout |
+| `hooks/useProductDetail.js` | PDP product, variant resolution, selection, load/add state |
+| `hooks/useShop.js` | Catalog listing, categories, cursor paging, sort, failure state; used by `Shop` |
+| `hooks/useProductCard.js` | Card badges, prices, options summary, quick-add flag, images |
+| `hooks/useVariantOptions.js` | Render-agnostic option and modifier groups for PDP controls |
+| `lib/storeImage.js` | Wix image URL and gallery helpers |
+| `components/CartButton.jsx` | Cart icon button with a live-count badge |
+| `components/CartDrawer.jsx` | Cart drawer; mount once, opens through `useCart` |
+| `components/WixManageBanner.jsx` | Preview-only manage banner for the Layout |
+| `pages/Shop.jsx` | `/shop` page; imports your `ProductGrid` |
+| `rest/wix-config.js` | Wix client and site ids |
+| `rest/wix-client.js` | REST transport and visitor authentication |
+| `rest/wix-store-catalog.js` | Product and category queries |
+| `rest/wix-store-cart.js` | Cart mutations and hosted checkout |
 
-A successful install/deploy step is your verification that the listed storefront files are in
-place. **Use the component outlines and interfaces below, then go straight to building your
-presentation and wiring it** (card, grid, variant controls, the product page, Home — STEP 3).
-There is no separate source-inspection or verification phase before implementation; don't read
-shipped page/hook source just to confirm its structure. Read a shipped file **only** to resolve a
-specifically identified field or interface missing from the outlines, or an observed runtime
-error, and scope the read to the relevant file (see "Fallback only" at the end).
-(Shipped files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
-`references/storefront/app/` → `src/`.)
+**DO NOT READ SHIPPED SOURCE** except to resolve a specifically identified field/interface missing
+below or an observed runtime error; read only the relevant file.
+If deployment failed or files are missing, re-run the install/deploy step.
 
+## Theme
+Use the existing Base44 theme in `src/index.css` for new components. The shipped client already
+uses it; don't add a parallel theme or restyle shipped pages.
 
-## STEP 2 — Theme
-The shipped pages carry **no palette of their own** — they render from base44's design tokens
-in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
-`--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
-`text-foreground`, `bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`,
-`font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
-pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
-`.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped pages.** Style the components you build (STEP 3) and the Home/Header you add from the
-**same** base44 tokens/classes so everything matches automatically. A dark brand is just base44's
-dark palette in `index.css` — no per-component work.
+## Presentation interfaces
+Build `components/ProductCard.jsx`, `components/ProductGrid.jsx`, and `pages/ProductDetail.jsx`
+from these contracts. `Shop` needs your grid; `/product/:slug` needs your PDP. Home, header, and
+footer are yours to design; their integration is in **Routes and provider** below.
 
-## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+### Product card
+```jsx
+import { useProductCard } from "@/hooks/useProductCard";
+import { useCart } from "@/context/CartContext";
+
+export default function ProductCard({ product }) {
+  const { addToCart, error } = useCart();
+  const {
+    isSoldOut, isPreorder, isPartiallyOutOfStock, // booleans
+    leftBadges,       // [{ type: 'pre-order'|'sold-out'|'limited-stock', label }]
+    promoBadge,       // { type: 'discount'|'ribbon', label } | null
+    priceDisplay,     // formatted price or min–max range; may be undefined if absent
+    compareAtDisplay, // formatted compare-at price | null
+    colors,           // hex colour strings
+    optionLabel,      // e.g. "3 sizes · 2 materials", or ""
+    isQuickAddable,   // no product options and not sold out; does NOT check modifiers
+    image, hoverImage,// normalised primary / second gallery URL | null
+  } = useProductCard(product);
+  // Render your card.
+}
+```
+For quick-add, call `addToCart(product.id)` only when `isQuickAddable` and no mandatory
+modifier needs input (`product.modifiers` entries have a `mandatory` boolean). Otherwise link to `/product/${product.slug}` for selection, including
+pre-orders. Listing results have no full variants; the PDP hook loads and resolves them.
+Display cart-context `error` for a failed quick-add (see **Cart**); failure does not open the drawer.
+
+### Product grid and catalog data
+```jsx
+export default function ProductGrid({ products, loading, empty, emptyHint }) {
+  // products: array | null (null while loading); loading: boolean
+  // empty: heading string; emptyHint: optional supporting string
+  // Render loading, empty, or the list of <ProductCard product={product} /> items.
+}
+```
+For catalog data in your own pages, import `queryProducts` from `@/rest/wix-store-catalog`:
+```js
+const { products, nextCursor } = await queryProducts({ limit: 8 });
+// Returns { products: object[], nextCursor: string | null }, never a bare array.
+// Pass nextCursor as cursor for another page; default limit is 100.
+```
+Handle query failure separately from loading; don't leave a failed request on a spinner.
+
+### Product detail
+```jsx
+import { useParams } from "react-router-dom";
+import { useProductDetail } from "@/hooks/useProductDetail";
+import { productGallery } from "@/lib/storeImage";
+
+export default function ProductDetail() {
+  const { slug } = useParams();
+  const d = useProductDetail(slug);
+  // d contains:
+  // product: Wix product | null; .name, .slug, .plainDescription (HTML)
+  // notFound: boolean; error: string | null (load error); retry: () => void
+  // price, compareAtPrice: formatted strings ("" if absent), follow the selected variant
+  // options, modifiers: arrays for useVariantOptions below
+  // selectedOptions: { [optionId]: choiceId }; selectOption(optionId, choiceId)
+  // modifierValues: { [key]: value }; setModifier(key, value)
+  // variant: resolved variant | null; null if required choices are missing or no match exists
+  // focusMediaUrl: selected choice image, then variant image, or null
+  // quantity, setQuantity(n): number (may be "" mid-edit)
+  // inStock, canAdd, adding: booleans
+  // submit: async () => adds product + resolved variant + quantity + modifiers
+  const images = productGallery(d.product); // [{ url, altText }], main first, de-duplicated
+  // Render your PDP.
+}
+```
+- Handle `error` with `retry()`, then `notFound`, then `!product` as loading.
+- Render `product.plainDescription` as HTML; strike `compareAtPrice` only when present and different from `price`.
+- Make the gallery follow `focusMediaUrl` when the selected option changes.
+- Render the option/modifier controls below; show a selection hint when `options.length && !variant`.
+- Keep quantity at least 1. Disable adding when `!canAdd || adding`; call `submit()` only with a loaded product and `canAdd`. `submit()` coerces quantity to at least 1 but does not itself enforce `canAdd`.
+- `canAdd` checks variant resolution, variant stock, and mandatory modifier values. `inStock` defaults to true without a resolved variant; use `canAdd` for the full gate.
+- `submit()` resets `adding` after completion and resolves without a cart result. Add failures live in `useCart().error`, not the PDP load `error`; show them even when the drawer is closed.
+
+### Variant and modifier controls
+```jsx
+import { useVariantOptions } from "@/hooks/useVariantOptions";
+
+const { optionGroups, modifierGroups } = useVariantOptions(
+  d.options, d.modifiers, d.selectedOptions, d.modifierValues
+);
+// optionGroups: [{ id, name, isColor, choices: [
+//   { choiceId, name, colorCode: string | null, isColorSwatch, inStock, selected }
+// ] }]
+// modifierGroups: [{ key, name, mandatory, type: 'choices'|'text',
+//   choices?: [{ key, name, selected }], value?: string }]
+// Select option: d.selectOption(group.id, choice.choiceId)
+// Select modifier: d.setModifier(m.key, choice.key)
+// Text modifier: d.setModifier(m.key, text)
+```
+Retired option choices are filtered out. Respect each choice's `inStock` and modifier's
+`mandatory` flag; the hook supplies colour values and selection state without prescribing layout.
+
+### Images
+Import from `@/lib/storeImage`; URLs may be null, so handle missing images.
+
+| Helper | Contract |
+|---|---|
+| `storeImage(value)` | Accepts a URL string, `{ image: { url } }`, or `{ url }`; prefixes `//` with `https:`, returns other URLs unchanged or null when absent |
+| `productImage(product)` | Normalised `product.media.main.image.url`, or null |
+| `productGallery(product)` | `[{ url, altText }]` from the main image and `media.itemsInfo.items`, main first, de-duplicated; skips items without an image URL |
+| `choiceImage(choice)` | First `choice.media.items[].mediaId` as a URL, or null; storefront reads use this field, not `linkedMedia` |
+| `variantImage(variant)` | Uses `media.image.url`, then `media.id`, then `media.thumbnail.url`; never `media.uploadId` |
+| `wixMediaUrl(mediaId)` | Converts a Wix media id to a static CDN URL; normalises existing URLs; null for missing/non-string input |
+| `wixMediaId(url)` | Extracts the id after `/media/` for comparison across sizing URLs; returns input unchanged if unmatched |
+
+Cart line images are at `lineItems[].attributes.image.url`; normalise them with `storeImage`.
+
+### Cart
+Use the named `useCart` export from `@/context/CartContext` within `CartProvider`.
+
+```js
+const {
+  cart, itemCount, isOpen, setIsOpen, loading, error, clearError,
+  addToCart, removeItem, updateQuantity, checkout, refreshCart,
+} = useCart();
+// cart: server cart | null; itemCount: sum of confirmed line quantities
+// isOpen: boolean; setIsOpen(boolean); loading: mutation-in-progress boolean
+// error: string | null; clearError(): clears it
+// addToCart(productId, variantId?, qty = 1, { modifierChoices?, customTextFields? }?)
+// removeItem(lineItemId); updateQuantity(lineItemId, qty)
+// checkout(); refreshCart()
+```
+`addToCart` uses `product.id` and the resolved `variant.id` when needed. Extras are string maps:
+`modifierChoices: { [modifier.key]: choiceKey }` and
+`customTextFields: { [modifier.freeTextSettings.key]: userInput }`; include mandatory values.
+Update/remove use `cart.lineItems[].id`, not a catalog product id.
+
+The context's add/remove/update/checkout methods return promises resolving to `undefined` on
+success or `null` on failure, storing the failure in `error`. They clear the previous error and
+set `loading` during the operation. Successful add updates the server-cart snapshot and opens the
+drawer; failed add does not open it. The drawer displays errors only while open, so custom add UI
+must surface `error` too. These context methods do not return the updated cart or checkout URL.
+The lower-level REST helpers can reject; don't apply their rejection contract to `useCart()`.
+
+`checkout()` navigates to the hosted checkout URL; it refuses empty carts and lines with a status
+other than `IN_STOCK`, and refreshes the cart after failure. `refreshCart()` replaces the snapshot
+and resolves to `undefined`; its underlying read returns null for no cart or a failed request. It
+does not set mutation `loading` or `error`.
+
+Cart V2 money is `{ amount, convertedAmount }`, with no formatted string. `amount` is in site
+currency; `convertedAmount` is in display currency. Format
+`money.convertedAmount ?? money.amount` with `Intl.NumberFormat` and
+`cart.customerInfo?.currencyCode ?? cart.businessInfo?.currencyCode` (the shipped drawer falls
+back to `USD`). Use server `cart.subtotal` and line `pricing.totalPrice`; never sum lines yourself.
+The cart has no `subtotalAfterDiscounts`, `discount`, or `appliedDiscounts`; discounted summary
+totals require a currentCartV2 estimate/calculate `summary.priceSummary`, which these helpers do
+not fetch. Tax and shipping resolve at checkout.
+
+Line `quantityInfo.confirmedQuantity` is the current quantity; `availableQuantity` caps increases
+when finite. `status` can be `IN_STOCK`, `PARTIALLY_IN_STOCK`, `OUT_OF_STOCK`, or
+`REMOVED_FROM_CATALOG`; surface unavailable lines and prevent checkout until resolved.
+
+Migrating from Cart V1 / Checkout V1? These helpers are V2-only; see the
+[migration guide](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/migration-guide).
+
+## Routes and provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it.
@@ -79,117 +218,8 @@ replace it.
 - Routes under the Layout: `/shop` → `Shop` (shipped, renders your grid); `/product/:slug` → **your
   `ProductDetail`**; `/` → **your `Home`**.
 
-**Build the presentation — it's all yours.** Each piece below is built on a shipped hook whose return
-type + field shapes are in the outline right after this list — the data is done, the render is yours.
-`Shop` won't show products until `ProductGrid` exists, and `/product/:slug` won't render until you
-build the product page, so these aren't optional:
-
-- **`components/ProductGrid.jsx`** — `Shop` and your Home render it. It receives `products`, `loading`,
-  `empty`, `emptyHint` and owns three states (loading, empty, list) plus the layout. A boutique might
-  want a 3-col editorial layout; a high-volume store a dense 4-col grid; a home strip a horizontal scroll.
-- **`components/ProductCard.jsx`** — your grid maps each product to it. Built on `useProductCard`
-  (badges, price display, colour dots, quick-add flag, images) — you decide layout, shape, hover, CTA.
-  A lifestyle brand might want full-bleed images with an overlay gradient; a tech store a compact item.
-- **`pages/ProductDetail.jsx`** — the **whole product page**, built on `useProductDetail`; route
-  `/product/:slug` to it. Gallery, price, description, the variant controls (options/modifiers via
-  `useVariantOptions`), the buy box — you arrange and style all of it (nothing PDP ships). This is the
-  surface that usually looks most generic, so make the layout the brand's: an editorial split, a sticky
-  buy column, a full-bleed gallery, large swatches vs a compact dropdown — your call.
-
-```jsx
-// components/ProductCard.jsx — your grid maps each product to it.
-import { Link } from "react-router-dom";
-import { useCart } from "@/context/CartContext";          // addToCart(product.id) for quick-add
-import { useProductCard } from "@/hooks/useProductCard";
-
-export default function ProductCard({ product }) {
-  const { addToCart } = useCart();
-  const {
-    isSoldOut, isPreorder,
-    leftBadges,       // [{ type: 'pre-order'|'sold-out'|'limited-stock', label }] — image top-left
-    promoBadge,       // { type: 'discount'|'ribbon', label } | null — image top-right
-    priceDisplay,     // "€10"  |  "€10 – €20" (range when variants differ)
-    compareAtDisplay, // original price string | null — strike-through
-    colors,           // hex strings → colour dots
-    optionLabel,      // "3 sizes · 2 materials" | ""
-    isQuickAddable,   // true → addToCart(product.id);  else <Link to={`/product/${product.slug}`}>
-    image, hoverImage,// URLs | null
-  } = useProductCard(product);
-  // …you implement the tile.
-}
-```
-
-```jsx
-// Variant controls — render the product's options/modifiers from useVariantOptions.
-// The inputs (options, modifiers, selectedOptions, modifierValues) come from useProductDetail (below).
-import { useVariantOptions } from "@/hooks/useVariantOptions";
-
-const { optionGroups, modifierGroups } = useVariantOptions(options, modifiers, selectedOptions, modifierValues);
-// optionGroups:   [{ id, name, isColor, choices: [{ choiceId, name, colorCode, isColorSwatch, inStock, selected }] }]
-// modifierGroups: [{ key, name, mandatory, type: 'choices'|'text', choices?: [{ key, name, selected }], value?: string }]
-// pick a choice:  selectOption(group.id, choice.choiceId)
-// set a modifier: setModifier(m.key, choice.key)   ·   text type: setModifier(m.key, e.target.value)
-```
-
-```jsx
-// components/ProductGrid.jsx — Shop and your Home render it.
-import ProductCard from "./ProductCard";                 // your card, above
-
-export default function ProductGrid({ products, loading, empty, emptyHint }) {
-  // products   — array | null (null while loading)
-  // loading    — boolean
-  // empty      — heading string for the no-products state
-  // emptyHint  — sub-text string for the no-products state
-  // …you implement: the loading state, the empty state (empty + emptyHint), and the layout
-  //    mapping products → <ProductCard product={p} />.
-}
-```
-
-```jsx
-// pages/ProductDetail.jsx — YOU build the whole product page. Route `/product/:slug` to it.
-// A thin view over useProductDetail: keep the data logic in the hook, render however fits the brand.
-import { useMemo } from "react";
-import { useParams, Link } from "react-router-dom";
-import { useProductDetail } from "@/hooks/useProductDetail";
-import { productGallery } from "@/lib/storeImage";
-
-export default function ProductDetail() {
-  const { slug } = useParams();
-  const d = useProductDetail(slug);
-  // useProductDetail(slug) returns:
-  //   product         Wix product | null (loading) — has .name, .plainDescription (HTML), .slug
-  //   notFound        bool — dead link (distinct from error)
-  //   error           string | null — failed load; call retry() to reload
-  //   retry           () => void
-  //   price           formatted string, follows the selection ("€24.00")
-  //   compareAtPrice  formatted string — a "was" price; strike it only when it differs from price
-  //   options, modifiers                                            → feed useVariantOptions for the variant controls (block above)
-  //   selectedOptions, selectOption, modifierValues, setModifier    → also for the variant controls
-  //   variant         resolved variant | null (null until every option is picked)
-  //   focusMediaUrl   image url for the selected choice — make the gallery show it
-  //   quantity, setQuantity(n)   number (may be "" mid-edit) — keep min 1
-  //   inStock, canAdd, adding    booleans that gate the buy button
-  //   submit          async () => adds the resolved variant + quantity + modifiers to the cart
-  const images = useMemo(() => productGallery(d.product), [d.product]);  // [{ url, altText }], main first, de-duped
-
-  // …you implement the page. Handle in order:
-  //   error     → show d.error + a retry button (onClick={d.retry})
-  //   notFound  → a "not found" message + a <Link to="/shop">
-  //   !product  → a loading placeholder
-  //   else the product view, laid out to fit the brand:
-  //     • gallery from `images` — main + thumbnails, a carousel, a full-bleed hero (your call);
-  //       make the shown image follow d.focusMediaUrl when a choice is selected
-  //     • d.product.name · d.price (strike d.compareAtPrice when it differs) ·
-  //       d.product.plainDescription (HTML → dangerouslySetInnerHTML)
-  //     • variant controls — render d.options/d.modifiers via useVariantOptions (block above);
-  //       d.selectOption / d.setModifier update the selection
-  //     • a "pick an option to continue" hint when d.options.length && !d.variant
-  //     • a quantity control (d.quantity / d.setQuantity, min 1 — a −/＋ stepper reads better than a
-  //       native number input) + the buy button:
-  //         <button disabled={!d.canAdd || d.adding} onClick={d.submit}>
-  //           {d.adding ? "Adding…" : d.inStock ? "Add to cart" : "Out of stock"}</button>
-}
-```
+Mount the default export `CartButton` from `@/components/CartButton` once in your header. It opens
+the drawer and shows the live count, inheriting `currentColor`; use it as-is, without a nested button.
 
 ```jsx
 import { useRef, useState, useEffect } from "react";
@@ -235,119 +265,11 @@ function Layout() {
 </CartProvider>
 ```
 
-## What you build (not shipped)
-The **home / landing page**, the **`Header`** (mount `<CartButton/>` in it) and a **`Footer`** — the
-two you drop into the `Layout` (STEP 3) so they wrap every route — plus the overall brand story,
-styled from the same base44 tokens/classes. **Reuse your own `ProductGrid`** (STEP 3) and the shipped
-cart pieces — a featured strip is just `queryProducts` + your `ProductGrid`; the nav is a `<CartButton/>`
-(a clean cart-**icon** button with a live-count badge — render it as-is, don't wrap it in your own
-text button) + a link to `/shop`:
-
-```jsx
-import { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
-import { queryProducts } from "@/rest/wix-store-catalog";
-import ProductGrid from "@/components/ProductGrid";        // yours (STEP 3)
-import CartButton from "@/components/CartButton";           // shipped
-
-// Responsive header: choose ONE branch with a state flag, so <CartButton/> mounts once.
-// Do NOT render a desktop nav AND a mobile nav toggled by `hidden md:flex` / `md:hidden`:
-// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden`
-// never applies — BOTH branches render and you get two cart buttons. One branch = one cart.
-export function Header() {                                  // in your nav
-  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
-  useEffect(() => {
-    const onResize = () => setMobile(window.innerWidth < 768);
-    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return (
-    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-      {/* brand/logo */}
-      {mobile
-        ? <YourMenu />                                       // your hamburger + <CartButton/> here
-        : <div style={{ display: "flex", gap: 24 }}><Link to="/shop">Shop</Link><CartButton /></div>}
-    </nav>
-  );
-}
-export function Featured() {                                // on your home page
-  const [products, setProducts] = useState(null);           // null → ProductGrid shows skeletons
-  // NB: queryProducts returns { products, nextCursor } — destructure the array.
-  useEffect(() => {
-    queryProducts({ limit: 8 })
-      .then(({ products }) => setProducts(products))
-      .catch(() => setProducts([]));                        // land on the empty state, not a spinner
-  }, []);
-  return <ProductGrid products={products} loading={products === null} empty="Products coming soon." />;
-}
-```
-Everything reads base44's design tokens (`index.css`), so your home/nav match the shipped pages
-automatically. `<CartButton/>` is an icon button (live-count badge) — drop it in as-is, it inherits `currentColor`.
-
-**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
-can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
-full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
-render.
-
-## Using the client from your own UI (cart, hand-built images)
-
-> Migrating from Cart V1 / Checkout V1? These helpers are V2-only — see the [migration guide](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/migration-guide) for the before/after.
-
-```jsx
-import { Link } from "react-router-dom";
-import { useCart } from "@/context/CartContext";
-
-// useCart() gives:
-// { cart, itemCount, isOpen, setIsOpen, loading, error, clearError(),
-//   addToCart(productId, variantId?, qty=1, { modifierChoices?, customTextFields? }?),
-//   removeItem(lineItemId), updateQuantity(lineItemId, qty), checkout(), refreshCart() }
-// Every mutation catches its own failure into `error` (the shipped CartDrawer renders it), so a
-// refusal — an empty cart, or a line item whose status left IN_STOCK — reaches the buyer instead
-// of becoming an unhandled rejection.
-//
-// Cart money: every amount is a ConvertedMoney { amount, convertedAmount } with NO formatted string —
-// `amount` is in the site currency, `convertedAmount` in the display currency; format the number
-// yourself (Intl.NumberFormat with the cart's currency —
-// `cart.customerInfo?.currencyCode ?? cart.businessInfo?.currencyCode`) so the symbol and grouping
-// match the locale. The V2 cart has no `subtotalAfterDiscounts`/`discount`/`appliedDiscounts`: it
-// carries only a raw `cart.subtotal` (ConvertedMoney). The authoritative discounted totals come from
-// a currentCartV2 estimate/calculate `summary.priceSummary`, not the cart — call that when you need
-// the after-coupon figure; otherwise show `cart.subtotal`. Never sum line items yourself — tax and
-// shipping resolve at checkout.
-// A line's `status` (IN_STOCK / PARTIALLY_IN_STOCK / OUT_OF_STOCK) tells a quantity control whether
-// another increment is still fulfillable.
-
-function CartCount() {                                   // header badge
-  const { itemCount, setIsOpen } = useCart();
-  return <button onClick={() => setIsOpen(true)}>Cart ({itemCount})</button>;
-}
-
-// Buy from a card → link to the PDP; your ProductDetail (on useProductDetail) owns options/variants + add-to-cart.
-// (Listing helpers return no variants — only getProductBySlug does — so buying happens on the PDP.)
-const CardBuy = ({ product }) => <Link to={`/product/${product.slug}`}>View</Link>;
-
-// Doing add-to-cart yourself? addToCart resolves for an option-less product; wrap it — it rejects on
-// out-of-stock / empty cart / a missing required selection, and you show that message.
-async function quickAdd(addToCart, product) {
-  try { await addToCart(product.id); } catch (e) { alert(e.message); }
-}
-
-// An image you render yourself (hero / custom card): normalise the url through lib/storeImage — Wix
-// returns these protocol-relative — and keep a token bg so a just-generated url that 404s for a
-// second reads as a surface, not a blank block.
-import { storeImage, productImage, productGallery } from "@/lib/storeImage";
-function BrandImage({ url, alt }) {
-  return <div className="bg-card"><img src={storeImage(url)} alt={alt} /></div>;
-}
-// productImage(product) → the catalog image · productGallery(product) → every image, main first,
-// de-duplicated (media.itemsInfo.items repeats the main one and video items carry no image url).
-```
-
 ## Extending the client
 Building something beyond the shipped pages? Copy these:
 
 ```jsx
-// Every catalog/cart list helper returns { <plural>, nextCursor } — destructure the array:
+// Catalog list helpers return { <plural>, nextCursor } — destructure the array:
 const { products, nextCursor } = await queryProducts({ limit: 24 });
 const { categories } = await queryCategories();
 const menu = categories.filter((c) => c.slug !== "all-products");   // drop Wix's system category
@@ -368,27 +290,7 @@ reference page inline; these are the areas they sit in:
 
 ## Hard rules
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped pages or adding a parallel theme file. Everything you build (card, grid, PDP, variant controls, Home) draws from the same tokens.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Shop` to add chrome.
+- Header/footer live in a `Layout` around `<Outlet/>` (see **Routes and provider**) — never edit the shipped `Shop` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
 - Render live Wix data or the shipped empty state — never mock products.
-
-## Point the user to their dashboard
-Provide deep links so the owner can edit content (substitute the site's `metaSiteId`):
-- **Products** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/products`
-- **Categories** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/categories/list`
-
-## Seeding
-Seed the catalog per `seed/SEED.md` (the build-time `setupStore` module) — separate from this
-client build; run in parallel.
-
-## Verify (before declaring done)
-- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] **The pieces you own exist and are wired:** `components/ProductCard.jsx`, `components/ProductGrid.jsx` (imported by `Shop` + your Home), and `pages/ProductDetail.jsx` (routed at `/product/:slug`, with working variant controls). `/shop` and a PDP compile and render (they won't until these exist).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; the shipped `Shop` page not restyled or rewritten.
-- [ ] **Opened `/shop` and a product detail page** (not just the home page) and confirmed your cards render themed (surface, text, brand color) with images; the grid shows its loading + empty states; the PDP shows the gallery, price, variant controls, and add-to-cart, and its error/not-found/loading states hold.
-- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; the shipped `Shop` untouched; content clears the fixed chrome; `<CartProvider>` wraps the tree; `<CartDrawer/>` mounted; `<CartButton/>` in the header.
-- [ ] Cart survives reload (same visitor); add / update-qty / remove work; checkout redirects; the drawer shows a **subtotal**.
-- [ ] Empty catalog shows the shipped empty state; no mock products anywhere.
-- [ ] A product with several images shows **thumbnails** on the PDP, and one with per-variant prices shows a **range** on its card.
-- [ ] Categories seeded? The `/shop` menu lists them (minus the auto-created `all-products`) and filters; a catalog past one page shows **Load more**.

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -118,7 +118,7 @@ await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: ima
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-online-store.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -118,7 +118,7 @@ await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: ima
 
 ## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
-use the **`wix-base44-connector`** skill to search + read the live Wix API reference — never guess. The
+use the documentation skill available in your environment to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-online-store.md`.
 
 Read a method's page before writing its call: it carries the exact body shape, the required

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -13,7 +13,7 @@
 //   await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
 //   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, url:imageUrls[i], altText:p.slug })));
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-online-store.md.
 

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -13,7 +13,7 @@
 //   await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
 //   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, url:imageUrls[i], altText:p.slug })));
 //
-// If any call fails with a shape the caller didn't expect, fall back to the wix-base44-connector skill
+// If any call fails with a shape the caller didn't expect, fall back to the documentation skill available in your environment
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
 // wix-headless/references/inline-recipes/setup-online-store.md.
 


### PR DESCRIPTION
Describe each vertical as integration code with optional UI; its instructions define supplied pieces and presentation to build. Remove universal complete-UI/checklist claims.

Streamline storefront contracts for catalog/category queries, cart errors, and image helpers. Remove tutorials, duplicate/legacy prose, and dashboard/seeding/verification sections. Separate common routing from optional banner wiring: full Base44 enables it; light flows disable it. Preserve seeding and handoffs.

Across guides, seed docs, source comments, and pinned instructions, documentation fallbacks use the skill available in the environment. Keep original platform installations, official documentation URLs, and standalone skills.

Validation: source/contract and banner audits; catalog/pinning mock checks; reference scan; original install code, shared rules, routing table and presentation preservation checks; diff and CLI pinning pass. Behavioral impact unmeasured. Wix-manage/wix-app eval gates do not apply.
