### PR TITLE
Sort and filter storefront products across the full catalog

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -57,6 +57,9 @@ export default function Shop() {
   // select with s.setActiveCategory(category), or null for all products.
   // Sort controls: Object.entries(SORTS) -> [key, { label }];
   // selected value s.sort; change with s.setSort(key).
+  // Optional filters: s.setFilters({ minPrice: 20, maxPrice: 100,
+  //   inStockOnly: true, search: "linen" }); s.setFilters({}) clears them.
+  // Apply a submitted/debounced search value; the hook queries on every change.
   // Render s.error with s.retry separately from loading/empty results.
   // On a later-page error, keep already loaded products visible.
   // Pagination: when s.hasMore, call s.loadMore(); disable while s.loadingMore.
@@ -121,30 +124,45 @@ failure does not open the drawer.
 const {
   categories, activeCategory, setActiveCategory,
   products, loading, error, retry,
-  hasMore, loadMore, loadingMore, sort, setSort,
+  hasMore, loadMore, loadingMore, sort, setSort, filters, setFilters,
 } = useShop({ pageSize: 24 }); // optional argument; default pageSize 24
 // categories: category[]; activeCategory: category | null (null = all products)
-// setActiveCategory(categoryOrNull): starts a fresh product query
-// products: product[] | null; loading: boolean (first page/category load)
+// setActiveCategory(categoryOrNull): starts a fresh product query, keeping sort/filters
+// products: product[] | null; loading: boolean (fresh query, including sort/filter changes)
 // error: string | null; retry(): reloads the active category's first page
 // hasMore, loadingMore: booleans; loadMore(): appends another page when available
-// sort: 'featured' | 'priceAsc' | 'priceHigh' | 'name'; setSort(key)
+// sort: 'featured' | 'priceAsc' | 'priceHigh' | 'name' | 'newest'; setSort(key)
+// filters: { minPrice?, maxPrice?, inStockOnly?, search? }
+// setFilters(object): replaces filters; setFilters(previous => ({ ...previous, ...patch })) merges
 // SORTS: { [key]: { label } } for those keys
 ```
-Sorting applies only to loaded products. Initial product failure sets `error` and an empty array;
-a later page failure preserves loaded products and sets `error`. Render the error separately from
+Wix filters and sorts the full matching catalog before paging; the hook never sorts a loaded subset.
+Changing category, sort, or filters resets products and the cursor; stale responses are ignored.
+`featured` retains its existing key but means **Default order**, not merchant-curated placement.
+Prices use the product's minimum actual variant price in site currency, in either direction and
+for both bounds; this is not a selected-variant or checkout-discount price. Bounds are inclusive,
+non-negative numbers (numeric strings accepted); null/empty omits a bound. Min must not exceed max.
+`inStockOnly` matches `IN_STOCK` products, excluding partially stocked and preorder-only products.
+`search` searches product names (up to 100 characters). These filters can be combined.
+
+Initial product failure sets `error` and an empty array;
+a later page failure preserves products and cursor; call `loadMore()` again to retry that page.
+`retry()` starts over at page one with current selections. Render the error separately from
 an empty catalog. Category loading fetches only the first 100 categories, excludes `visible: false`
 and `slug: "all-products"`, and falls back to `[]` on failure without setting `error`.
 
 For a standalone product selection or category menu, import these named functions from
-`@/rest/wix-store-catalog`. All three return promises and reject on request failure.
+`@/rest/wix-store-catalog`. They return promises and reject on invalid query options or request failure.
 
 | Function | Result |
 |---|---|
-| `queryProducts({ limit = 100, cursor } = {})` | `{ products: product[], nextCursor: string or null }` — visible catalog products |
+| `searchProducts({ limit = 100, cursor, categoryId, sort, minPrice, maxPrice, inStockOnly, search } = {})` | `{ products: product[], nextCursor: string or null }` — same sort/filter semantics as the hook |
+| `queryProducts(options = {})` | `{ products: product[], nextCursor: string or null }` — visible catalog products |
 | `queryCategories({ limit = 100, cursor } = {})` | `{ categories: category[], nextCursor: string or null }` — one category page |
-| `queryProductsByCategory(categoryId, { limit = 100, cursor } = {})` | `{ products: product[], nextCursor: string or null }` — visible products in the category identified by `id` |
+| `queryProductsByCategory(categoryId, options = {})` | `{ products: product[], nextCursor: string or null }` — visible products in the category identified by `id` |
 
+`queryProducts` and `queryProductsByCategory` accept the same options as `searchProducts`.
+A cursor continues the original query; changed filters/sort require starting without one.
 Products are the full listing objects consumed by `useProductCard`. Category menu fields are
 `id`, `name`, `slug`, and `visible`. Filter out `visible === false` and the system category
 `slug === "all-products"`; an empty category list is valid.
@@ -157,7 +175,7 @@ const { products, nextCursor } = await queryProductsByCategory(selectedCategory.
 ```
 Destructure the arrays; these calls never return bare arrays. Pass a result's `nextCursor` back
 as `cursor` to the same query for the next page, stopping at null. Keep category and product
-cursors separate; changing category starts without a cursor. Handle failure separately from
+cursors separate; changing category, sort, or filters starts without a cursor. Handle failure separately from
 loading so a failed request does not leave a spinner.
 
 ### Product detail

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useShop.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useShop.js
@@ -1,98 +1,83 @@
-// useShop — all catalog-listing logic, no markup: load the category menu, load a page of products for
-// the active category, append the next page on demand, sort client-side, and surface a failure instead
-// of leaving the page on a spinner. The Shop page only renders what this returns.
-//
-// Load-bearing:
-// • paging is CURSOR-based. Keep the cursor from the previous response and pass it back; a cursor
-//   follow-up reuses the original filter, so the category is fixed for the life of that cursor.
-//   Changing category starts a fresh query, never a cursor continuation.
-// • queryCategories returns the auto-created "all-products" system category alongside real ones, and
-//   `visible` does not flag it — filter it by slug or the menu shows a duplicate of everything.
-// • sorting is done here on the loaded page, not by the API: with cursor paging the server would
-//   re-sort per page, so a sort applied across pages already fetched is the honest option. Say so in
-//   the UI if the catalog is larger than one page.
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { queryProducts, queryProductsByCategory, queryCategories } from "@/rest/wix-store-catalog";
+// Catalog queries run on Wix before pagination. A changed selection starts a fresh cursor chain.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { searchProducts, queryCategories, CATALOG_SORTS } from "@/rest/wix-store-catalog";
 
+export const SORTS = CATALOG_SORTS;
 const SYSTEM_CATEGORY_SLUG = "all-products";
-export const SORTS = {
-  featured: { label: "Featured" },
-  priceAsc: { label: "Price: low to high" },
-  priceHigh: { label: "Price: high to low" },
-  name: { label: "Name: A–Z" },
-};
-
-// Prices arrive formatted for display ("$12.00"), so read the numeric value for sorting from the
-// amount when it's there and fall back to digits in the formatted string.
-function priceOf(product) {
-  const min = product?.actualPriceRange?.minValue;
-  const n = Number(min?.amount ?? String(min?.formattedAmount || "").replace(/[^\d.]/g, ""));
-  return Number.isFinite(n) ? n : 0;
-}
 
 export function useShop({ pageSize = 24 } = {}) {
   const [categories, setCategories] = useState([]);
-  const [activeCategory, setActiveCategory] = useState(null); // null = everything
-  const [products, setProducts] = useState(null);             // null = first load
-  const [cursor, setCursor] = useState(null);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState(null);
+  const [activeCategory, setActiveCategory] = useState(null);
   const [sort, setSort] = useState("featured");
+  const [filters, setFilters] = useState({});
+  const [attempt, setAttempt] = useState(0);
+  const [page, setPage] = useState({ key: null, products: null, cursor: null, error: null, loadingMore: false });
+  const generation = useRef(0);
+  const pendingMore = useRef(null);
+  const key = JSON.stringify([pageSize, activeCategory?.id ?? null, sort, filters.minPrice ?? null,
+    filters.maxPrice ?? null, !!filters.inStockOnly, filters.search ?? "", attempt]);
+  const currentKey = useRef(key);
+  currentKey.current = key;
 
   useEffect(() => {
+    let alive = true;
     queryCategories({ limit: 100 })
-      .then(({ categories: list }) =>
-        setCategories((list || []).filter((c) => c.visible !== false && c.slug !== SYSTEM_CATEGORY_SLUG)))
-      .catch(() => setCategories([]));   // a store without categories is normal, not an error
+      .then(({ categories: list }) => {
+        if (alive) setCategories((list || []).filter(c => c.visible !== false && c.slug !== SYSTEM_CATEGORY_SLUG));
+      })
+      .catch(() => { if (alive) setCategories([]); });
+    return () => { alive = false; };
   }, []);
 
-  const load = useCallback(async (categoryId) => {
-    setProducts(null);
-    setCursor(null);
-    setError(null);
-    try {
-      const res = categoryId
-        ? await queryProductsByCategory(categoryId, { limit: pageSize })
-        : await queryProducts({ limit: pageSize });
-      setProducts(res.products);
-      setCursor(res.nextCursor);
-    } catch (e) {
-      setError(e?.message || "Couldn't load products.");
-      setProducts([]);
-    }
-  }, [pageSize]);
+  useEffect(() => {
+    const id = ++generation.current;
+    let alive = true;
+    pendingMore.current = null;
+    setPage({ key, products: null, cursor: null, error: null, loadingMore: false });
+    const [limit, categoryId, selectedSort, minPrice, maxPrice, inStockOnly, search] = JSON.parse(key);
+    searchProducts({ limit, categoryId, sort: selectedSort, minPrice, maxPrice, inStockOnly, search })
+      .then(res => {
+        if (alive && generation.current === id && currentKey.current === key) {
+          setPage({ key, products: res.products, cursor: res.nextCursor, error: null, loadingMore: false });
+        }
+      })
+      .catch(e => {
+        if (alive && generation.current === id && currentKey.current === key) {
+          setPage({ key, products: [], cursor: null, error: e?.message || "Couldn't load products.", loadingMore: false });
+        }
+      });
+    return () => { alive = false; generation.current++; };
+  }, [key]);
 
-  useEffect(() => { load(activeCategory?.id ?? null); }, [activeCategory, load]);
-
-  const loadMore = async () => {
-    if (!cursor || loadingMore) return;
-    setLoadingMore(true);
+  const loadMore = useCallback(async () => {
+    if (page.key !== key || !page.cursor || pendingMore.current) return;
+    const request = { generation: generation.current, key };
+    pendingMore.current = request; // blocks repeated clicks before React rerenders
+    const isCurrent = () => generation.current === request.generation && currentKey.current === key;
+    setPage(p => ({ ...p, loadingMore: true, error: null }));
     try {
-      const res = activeCategory
-        ? await queryProductsByCategory(activeCategory.id, { limit: pageSize, cursor })
-        : await queryProducts({ limit: pageSize, cursor });
-      setProducts((prev) => [...(prev || []), ...res.products]);
-      setCursor(res.nextCursor);
+      const res = await searchProducts({ limit: pageSize, cursor: page.cursor });
+      if (isCurrent()) setPage(p => {
+        const seen = new Set((p.products || []).map(product => product.id));
+        return { ...p, products: [...(p.products || []), ...res.products.filter(product => {
+          if (seen.has(product.id)) return false;
+          seen.add(product.id); return true;
+        })], cursor: res.nextCursor };
+      });
     } catch (e) {
-      setError(e?.message || "Couldn't load more products.");
+      if (isCurrent()) setPage(p => ({ ...p, error: e?.message || "Couldn't load more products." }));
     } finally {
-      setLoadingMore(false);
+      if (pendingMore.current === request) pendingMore.current = null;
+      if (isCurrent()) setPage(p => ({ ...p, loadingMore: false }));
     }
-  };
+  }, [key, page.key, page.cursor, pageSize]);
 
-  const sorted = useMemo(() => {
-    if (!products) return null;
-    const copy = [...products];
-    if (sort === "priceAsc") copy.sort((a, b) => priceOf(a) - priceOf(b));
-    else if (sort === "priceHigh") copy.sort((a, b) => priceOf(b) - priceOf(a));
-    else if (sort === "name") copy.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
-    return copy;
-  }, [products, sort]);
-
+  const retry = useCallback(() => setAttempt(n => n + 1), []);
+  const current = page.key === key;
   return {
-    categories, activeCategory, setActiveCategory,
-    products: sorted, loading: products === null, error,
-    hasMore: !!cursor, loadMore, loadingMore,
-    sort, setSort, retry: () => load(activeCategory?.id ?? null),
+    categories, activeCategory, setActiveCategory, sort, setSort, filters, setFilters,
+    products: current ? page.products : null, loading: !current || page.products === null,
+    error: current ? page.error : null, retry,
+    hasMore: current && !!page.cursor, loadMore, loadingMore: current && page.loadingMore,
   };
 }

--- a/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
+++ b/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
@@ -55,26 +55,67 @@ import { wixApiRequest } from "./wix-client.js";
  * Full model: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories
  */
 
+// Search Products supports server-side sort/filter before cursor paging:
+// https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products.md
+export const CATALOG_SORTS = {
+  featured: { label: "Default order" }, // legacy key; no promise of merchant-curated ranking
+  priceAsc: { label: "Price: low to high" },
+  priceHigh: { label: "Price: high to low" },
+  name: { label: "Name: A–Z" },
+  newest: { label: "Newest" },
+};
+const SORT_FIELDS = {
+  priceAsc: [{ fieldName: "actualPriceRange.minValue.amount", order: "ASC" }, { fieldName: "name", order: "ASC" }],
+  priceHigh: [{ fieldName: "actualPriceRange.minValue.amount", order: "DESC" }, { fieldName: "name", order: "ASC" }],
+  name: [{ fieldName: "name", order: "ASC" }],
+  newest: [{ fieldName: "createdDate", order: "DESC" }, { fieldName: "name", order: "ASC" }],
+};
+
+function priceBound(value, name) {
+  if (value == null || value === "") return undefined;
+  if (!["number", "string"].includes(typeof value) || !String(value).trim() || !Number.isFinite(Number(value)) || Number(value) < 0) {
+    throw new Error(`${name} must be a non-negative number.`);
+  }
+  return Number(value);
+}
+
 /**
- * Query visible products (one page). Pass nextCursor back as cursor to load the next page.
- * @param {{ limit?: number, cursor?: string }} [options]
+ * Search visible catalog products, sorted/filtered across the whole catalog.
+ * Price bounds and ordering use the product's minimum actual variant price in site currency.
+ * A cursor continues the original query; start without one when any selection changes.
+ * @param {{ limit?: number, cursor?: string, categoryId?: string, sort?: string,
+ *   minPrice?: number|string, maxPrice?: number|string, inStockOnly?: boolean, search?: string }} [options]
  * @returns {Promise<{ products: object[], nextCursor: string|null }>}
  */
-export async function queryProducts({ limit = 100, cursor } = {}) {
-  const res = await wixApiRequest("/stores/v3/products/query", {
+export async function searchProducts({ limit = 100, cursor, categoryId, sort = "featured", minPrice, maxPrice, inStockOnly = false, search = "" } = {}) {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) throw new Error("limit must be between 1 and 100.");
+  let query = { cursorPaging: { limit, ...(cursor ? { cursor } : {}) } };
+  if (!cursor) {
+    if (!Object.hasOwn(CATALOG_SORTS, sort)) throw new Error("Unsupported catalog sort.");
+    const min = priceBound(minPrice, "minPrice"), max = priceBound(maxPrice, "maxPrice");
+    if (min !== undefined && max !== undefined && min > max) throw new Error("minPrice must not exceed maxPrice.");
+    if (typeof search !== "string" || search.trim().length > 100) throw new Error("Search must be at most 100 characters.");
+    const conditions = [{ visible: true }];
+    if (categoryId) conditions.push({ "allCategoriesInfo.categories": { $matchItems: [{ id: categoryId }] } });
+    // Search rejects two operators in the same field object. Join separate bounds with $and.
+    if (min !== undefined) conditions.push({ "actualPriceRange.minValue.amount": { $gte: String(min) } });
+    if (max !== undefined) conditions.push({ "actualPriceRange.minValue.amount": { $lte: String(max) } });
+    if (inStockOnly) conditions.push({ "inventory.availabilityStatus": { $eq: "IN_STOCK" } });
+    query = { ...query, filter: { $and: conditions },
+      ...(SORT_FIELDS[sort] ? { sort: SORT_FIELDS[sort] } : {}),
+      ...(search.trim() ? { search: { expression: search.trim(), fields: ["name"] } } : {}),
+    };
+  }
+  const res = await wixApiRequest("/stores/v3/products/search", {
     method: "POST",
-    body: {
-      fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"],
-      query: {
-        ...(cursor ? {} : { filter: { visible: true } }),
-        cursorPaging: cursor ? { limit, cursor } : { limit },
-      },
-    },
+    body: { fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"], search: query },
   });
-  return {
-    products: res?.products ?? [],
-    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
-  };
+  return { products: res?.products ?? [], nextCursor: res?.pagingMetadata?.cursors?.next ?? null };
+}
+
+/** Visible products; accepts the same sort/filter options as searchProducts. */
+export function queryProducts(options = {}) {
+  return searchProducts(options);
 }
 
 /**
@@ -102,34 +143,9 @@ export async function getProductBySlug(slug) {
   return res?.product ?? null;
 }
 
-/**
- * Query visible products belonging to a category (one page).
- * @param {string} categoryId  Category GUID from queryCategories / getCategoryBySlug.
- * @param {{ limit?: number, cursor?: string }} [options]
- * @returns {Promise<{ products: object[], nextCursor: string|null }>}
- */
-export async function queryProductsByCategory(categoryId, { limit = 100, cursor } = {}) {
-  const res = await wixApiRequest("/stores/v3/products/search", {
-    method: "POST",
-    body: {
-      fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"],
-      search: {
-        ...(cursor
-          ? { cursorPaging: { limit, cursor } }
-          : {
-              cursorPaging: { limit },
-              filter: {
-                visible: true,
-                "allCategoriesInfo.categories": { $matchItems: [{ id: categoryId }] },
-              },
-            }),
-      },
-    },
-  });
-  return {
-    products: res?.products ?? [],
-    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
-  };
+/** Category products; accepts the same sort/filter options as searchProducts. */
+export function queryProductsByCategory(categoryId, options = {}) {
+  return searchProducts({ ...options, categoryId });
 }
 
 /**


### PR DESCRIPTION
Sorting previously reordered only loaded products. Use Wix Search Products to sort and filter the full matching catalog before cursor pagination. Add price bounds, stock and name-search filters; retain category filtering and existing helper entry points. Update the hook and builder skeleton/contracts.

Selection changes reset pagination and ignore stale responses; repeated load-more calls are guarded, and page failures retain loaded products/cursor. The legacy featured key is labeled Default order.

Validated on a new unpublished test site: 90 controlled products in 3 categories plus 12 Stores demo products. Visitor API tests covered multi-page sort/filter queries; a local React storefront passed live combinations, empty/invalid states, delayed-response races, duplicate clicks and error recovery. Production UI build, syntax and diff checks pass. Category-menu limits are unchanged. No payment/checkout tests or live builder-model evaluation.
