### PR TITLE
fix(evalforge-yaml-gate): attach the production MCP to merge-tag sweep runs

### DIFF
--- a/.github/actions/evalforge-yaml-gate/action.yml
+++ b/.github/actions/evalforge-yaml-gate/action.yml
@@ -19,7 +19,11 @@ inputs:
     description: 'EvalForge agent ID for eval runs (required for eval, run-all, and merge-tag-sweep modes)'
     required: false
   evalforge-mcp-id:
-    description: 'EvalForge MCP capability ID (required for eval, promote, cleanup modes)'
+    description: 'EvalForge MCP capability ID for per-PR MCP versions (required for eval, promote, cleanup modes)'
+    required: false
+    default: ''
+  evalforge-prod-mcp-id:
+    description: 'EvalForge MCP capability ID for the production MCP (required for merge-tag-sweep mode)'
     required: false
     default: ''
   evalforge-app-id:

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -66722,6 +66722,7 @@ function getMergeSweepConfig() {
         evalforgeUrl: (0, evalforge_core_1.ensureHttps)(core, core.getInput('evalforge-url', { required: true })),
         projectId: core.getInput('evalforge-project-id', { required: true }),
         agentId: core.getInput('evalforge-agent-id', { required: true }),
+        prodMcpId: core.getInput('evalforge-prod-mcp-id', { required: true }),
         appId: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-id'),
         appSecret: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-secret'),
         githubToken: (0, evalforge_core_1.safeGetSecret)(core, 'github-token'),
@@ -67805,6 +67806,7 @@ exports.MAX_SWEEP_SCENARIOS = void 0;
 exports.tagsOfDirectlyAffected = tagsOfDirectlyAffected;
 exports.resolveSweepSet = resolveSweepSet;
 exports.rowsToOutcomes = rowsToOutcomes;
+exports.buildEvalRunInput = buildEvalRunInput;
 exports.runMergeTagSweep = runMergeTagSweep;
 const evalforge_core_1 = __nccwpck_require__(7495);
 const gate_1 = __nccwpck_require__(2302);
@@ -67866,6 +67868,21 @@ function rowsToOutcomes(rows) {
     }));
 }
 /**
+ * Builds one sweep attempt's eval run. `capabilityIds` is what attaches the MCP — it is not
+ * inherited from the agent, so omitting it evaluates a tool-less agent and fails every docs
+ * assertion. No version is pinned: the sweep checks `main` against the production MCP.
+ */
+function buildEvalRunInput(config, name, description, scenarioIds) {
+    return {
+        name,
+        description,
+        projectId: config.projectId,
+        agentId: config.agentId,
+        scenarioIds,
+        capabilityIds: [config.prodMcpId],
+    };
+}
+/**
  * Wraps the sweep so that anything thrown before the run's own error handling — bad config, a
  * malformed workspace, an octokit constructor failure — still reaches the `infra-error` output.
  * Without this the job would only go red, and a red check on a `main` commit is not a signal
@@ -67909,13 +67926,7 @@ async function sweep() {
     core.setOutput('matched-tags', sortedTags.join(', '));
     const runName = `merge-sweep-${github.context.sha.slice(0, 7)}`;
     const runOnce = async (name, scenarioIds) => {
-        const created = await evalforge.createAndRunEvalRun(config.projectId, {
-            name,
-            description: `Merge-tag sweep for tags: ${sortedTags.join(', ')}`,
-            projectId: config.projectId,
-            agentId: config.agentId,
-            scenarioIds,
-        });
+        const created = await evalforge.createAndRunEvalRun(config.projectId, buildEvalRunInput(config, name, `Merge-tag sweep for tags: ${sortedTags.join(', ')}`, scenarioIds));
         await evalforge.triggerEvalRun(config.projectId, created.id);
         const status = await (0, evalforge_core_2.pollUntilDone)(evalforge, config.projectId, created.id, { log: core.info, warn: core.warning });
         return { id: created.id, status };

--- a/.github/actions/evalforge-yaml-gate/src/utils/config.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/config.ts
@@ -76,6 +76,7 @@ export type MergeSweepConfig = {
   evalforgeUrl: string;
   projectId: string;
   agentId: string;
+  prodMcpId: string;
   appId: string;
   appSecret: string;
   githubToken: string;
@@ -89,6 +90,7 @@ export function getMergeSweepConfig(): MergeSweepConfig {
     evalforgeUrl: coreEnsureHttps(core, core.getInput('evalforge-url', { required: true })),
     projectId: core.getInput('evalforge-project-id', { required: true }),
     agentId: core.getInput('evalforge-agent-id', { required: true }),
+    prodMcpId: core.getInput('evalforge-prod-mcp-id', { required: true }),
     appId: coreSafeGetSecret(core, 'evalforge-app-id'),
     appSecret: coreSafeGetSecret(core, 'evalforge-app-secret'),
     githubToken: coreSafeGetSecret(core, 'github-token'),

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -4,8 +4,8 @@ import { scenariosToRun } from './gate';
 import type { AttemptOutcome } from './confirm';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { EvalForgeClient, pollUntilDone, EvalRunTimeoutError, evalRunUrl } from '@wix/evalforge-core';
-import { getMergeSweepConfig } from './config';
+import { EvalForgeClient, pollUntilDone, EvalRunTimeoutError, evalRunUrl, type EvalRunInput } from '@wix/evalforge-core';
+import { getMergeSweepConfig, type MergeSweepConfig } from './config';
 import { loadEvals } from './evals';
 import { canonicalDocUrl } from './doc-url';
 import { computeCoverage } from './coverage';
@@ -76,6 +76,27 @@ export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
 }
 
 /**
+ * Builds one sweep attempt's eval run. `capabilityIds` is what attaches the MCP — it is not
+ * inherited from the agent, so omitting it evaluates a tool-less agent and fails every docs
+ * assertion. No version is pinned: the sweep checks `main` against the production MCP.
+ */
+export function buildEvalRunInput(
+  config: Pick<MergeSweepConfig, 'projectId' | 'agentId' | 'prodMcpId'>,
+  name: string,
+  description: string,
+  scenarioIds: string[],
+): EvalRunInput {
+  return {
+    name,
+    description,
+    projectId: config.projectId,
+    agentId: config.agentId,
+    scenarioIds,
+    capabilityIds: [config.prodMcpId],
+  };
+}
+
+/**
  * Wraps the sweep so that anything thrown before the run's own error handling — bad config, a
  * malformed workspace, an octokit constructor failure — still reaches the `infra-error` output.
  * Without this the job would only go red, and a red check on a `main` commit is not a signal
@@ -122,13 +143,10 @@ async function sweep(): Promise<void> {
 
   const runName = `merge-sweep-${github.context.sha.slice(0, 7)}`;
   const runOnce = async (name: string, scenarioIds: string[]) => {
-    const created = await evalforge.createAndRunEvalRun(config.projectId, {
-      name,
-      description: `Merge-tag sweep for tags: ${sortedTags.join(', ')}`,
-      projectId: config.projectId,
-      agentId: config.agentId,
-      scenarioIds,
-    });
+    const created = await evalforge.createAndRunEvalRun(
+      config.projectId,
+      buildEvalRunInput(config, name, `Merge-tag sweep for tags: ${sortedTags.join(', ')}`, scenarioIds),
+    );
     await evalforge.triggerEvalRun(config.projectId, created.id);
     const status = await pollUntilDone(evalforge, config.projectId, created.id, { log: core.info, warn: core.warning });
     return { id: created.id, status };

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -45,6 +45,15 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).toContain('changed-files:');
   });
 
+  // Without this the action attaches no MCP and evaluates a tool-less agent.
+  it('passes the production MCP capability id so the eval runs are not agent-only', () => {
+    expect(workflowContent).toContain('evalforge-prod-mcp-id: ${{ vars.AUTO_SKILLS_PIPELINE_PROD_MCP_ID }}');
+  });
+
+  it('does not attach the per-PR MCP capability', () => {
+    expect(workflowContent).not.toContain('evalforge-mcp-id:');
+  });
+
   it('guards the confirmed-failure Slack step on a confirmed failure', () => {
     expect(workflowContent).toContain('confirmed-failed-count');
   });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import {
-  MAX_SWEEP_SCENARIOS, tagsOfDirectlyAffected, resolveSweepSet, rowsToOutcomes,
+  MAX_SWEEP_SCENARIOS, tagsOfDirectlyAffected, resolveSweepSet, rowsToOutcomes, buildEvalRunInput,
 } from '../src/utils/merge-tag-sweep';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '@wix/evalforge-core';
@@ -110,5 +112,37 @@ describe('rowsToOutcomes', () => {
       ],
     }]);
     expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: true, reasons: ['actual_fail'] }]);
+  });
+});
+
+describe('buildEvalRunInput', () => {
+  const config = { projectId: 'proj-1', agentId: 'agent-1', prodMcpId: 'mcp-1' };
+
+  it('attaches the MCP capability, without which the agent runs with no tools', () => {
+    const input = buildEvalRunInput(config, 'merge-sweep-abc1234', 'for tags: blog', ['s-1', 's-2']);
+    expect(input.capabilityIds).toEqual(['mcp-1']);
+  });
+
+  it('pins no capability version, so the sweep evaluates what the capability resolves to now', () => {
+    const input = buildEvalRunInput(config, 'merge-sweep-abc1234', 'for tags: blog', ['s-1']);
+    expect(input.capabilityVersions).toBeUndefined();
+  });
+
+  // An inline payload at the call site would leave the other tests passing over the bug.
+  it('is what the sweep builds its eval runs with', () => {
+    const src = readFileSync(join(__dirname, '../src/utils/merge-tag-sweep.ts'), 'utf-8');
+    expect(src).toContain('buildEvalRunInput(config,');
+    expect(src).not.toMatch(/createAndRunEvalRun\([^)]*\{\s*\n\s*name,/);
+  });
+
+  it('carries the run name, description, agent and scenarios through', () => {
+    const input = buildEvalRunInput(config, 'merge-sweep-abc1234', 'for tags: blog', ['s-1', 's-2']);
+    expect(input).toMatchObject({
+      name: 'merge-sweep-abc1234',
+      description: 'for tags: blog',
+      projectId: 'proj-1',
+      agentId: 'agent-1',
+      scenarioIds: ['s-1', 's-2'],
+    });
   });
 });

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -62,6 +62,7 @@ jobs:
           evalforge-url: ${{ vars.EVALFORGE_URL }}
           evalforge-project-id: ${{ vars.AUTO_SKILLS_PIPELINE_PROJECT_ID }}
           evalforge-agent-id: ${{ vars.AUTO_SKILLS_PIPELINE_AGENT_ID }}
+          evalforge-prod-mcp-id: ${{ vars.AUTO_SKILLS_PIPELINE_PROD_MCP_ID }}
           evalforge-app-id: ${{ secrets.AUTO_SKILLS_PIPELINE_APP_ID }}
           evalforge-app-secret: ${{ secrets.AUTO_SKILLS_PIPELINE_APP_SECRET }}
           changed-files: ${{ steps.diff.outputs.files }}


### PR DESCRIPTION
## The bug

The merge-tag sweep has never used the Wix MCP. Its eval runs were created with
neither `capabilityIds` nor `capabilityVersions`:

```ts
await evalforge.createAndRunEvalRun(config.projectId, {
  name, description, projectId, agentId, scenarioIds,   // <- no capabilities
});
```

`capabilityIds` is what attaches a capability to a run at all; `capabilityVersions`
only pins which version. Capabilities are **not** inherited from the agent —
`fetch-evaluation-data.ts` builds the MCP list solely from `evalRun.capabilityIds`,
and the agent this project uses declares none.

Run `0a99feab-90d9-4c75-acc6-2887ae618553` shows the result:

```
capability_ids: []
capability_versions: {}
aggregate_metrics: { total_assertions: 10, passed: 1, failed: 9 }
```

Every scenario ran as a single LLM completion, one turn, zero tool calls, with
73-152 prompt tokens — no tool definitions in context. For comparison, a run with
the MCP attached uses 210k-497k. The agent said so in its own output: *"I can't
make API calls or perform actions on social media platforms."*

The one assertion that passed is the tell: a `llm_judge` on quota semantics that
needs no tools. Everything requiring the MCP failed.

So every regression the sweep has reported is an artifact, and each one was posted
to Slack naming whoever merged.

## The fix

Attach the capability serving the production MCP — the same one the PR-time gate's
baseline arm evaluates against, which is what makes "did `main` regress?" a
meaningful question.

Deliberately **not** `AUTO_SKILLS_PIPELINE_MCP_ID`. That capability is where
`ensureMcpVersion` mints a `pr-<number>-<sha>` version per gated PR — 120 of them
so far — and resolving it unpinned would rely on no PR label ever parsing as a
semver. It is also a separate maintenance line that has already drifted: both
capabilities sit on `1.0.4` with the same URL today, but one was published
2026-06-11 and the other 2026-08-18. Nothing keeps them in step.

`capabilityVersions` stays unset so the run resolves the capability's newest
version rather than freezing to whatever is current today.

Requires the `AUTO_SKILLS_PIPELINE_PROD_MCP_ID` repo variable, which is set.

## Tests

The run payload had no coverage at all, which is how this shipped. Added tests for
the built input and, separately, for the call site — an inline payload at the call
site would otherwise leave the builder as dead exported code with every test green.
Both halves were mutation-checked: reverting either fails exactly one test.

144 tests, typecheck clean, `dist` rebuilt.

## Two things this does not fix

**Cost.** With the MCP attached a scenario goes from ~15s to ~52s and from ~100 to
~200k+ prompt tokens. At `MAX_SWEEP_SCENARIOS = 20` a sweep becomes ~17 minutes,
up to ~50 with confirm-on-fail retries, on every merge to `main` touching the
watched paths. That limit was chosen when runs were tool-less and cheap, and is
worth revisiting.

**The sweep skips the scenarios the merge changed.** `wix-manage` scenarios carry
only their draft tag while a PR is open; `evalforge-yaml-promote.yml` restores the
semantic tags at merge. Both workflows fire on the same merge and race. On one
recent merge the sweep resolved its tag set at 07:24:50 and promote wrote the tags
at 07:24:58 — so the sweep ran every other scenario on the tag and none of the
three the merge added. Folding the sweep into the promote workflow, after the
promote step, would remove the race and also supply `merged_by` directly from the
`pull_request` payload.

## Same defect elsewhere

`src/utils/schedule.ts` creates its run with no `capabilityIds` either, and
`evalforge-scheduled-run.yml` does not pass an MCP id at all, so the scheduled run
is evaluating a tool-less agent too. Left out of this PR to keep it reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
