### PR TITLE
Read storefront seed site ID from deployed config

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -3,8 +3,8 @@
 You are building a **Wix Managed** headless storefront inside Base44 — the business is described in your
 initial prompt, and the Wix connector is already configured.
 
-Your Wix client id is in your prompt — a public, buyer-facing credential (anonymous visitor tokens
-only), safe in the frontend; use it directly for the Wix client setup.
+The shipped client is already configured. Use its documented hooks and components; no ID lookup
+or configuration changes are needed.
 
 > **The Wix skills installed below are the complete build and seed path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -3,8 +3,8 @@
 You are building a **Wix Managed** headless storefront inside Base44 — the business is described in your
 initial prompt, and the Wix connector is already configured.
 
-Your Wix client id is in your prompt — a public, buyer-facing credential (anonymous visitor tokens
-only), safe in the frontend; use it directly for the Wix client setup.
+The shipped client is already configured. Use its documented hooks and components; no ID lookup
+or configuration changes are needed.
 
 > **The Wix skills installed below are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
 

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -4,12 +4,12 @@ The storefront ships the commerce hooks, server cart, REST transport, image help
 You build the presentation: Shop page, product grid and cards, variant controls, product detail
 (PDP) page, Home, header, and footer. Use the interfaces below and proceed directly to implementation.
 
-The client talks to Wix over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock
-products or hand-build a `/checkout` URL; the shipped cart uses the eCom redirect session.
+The shipped client handles visitor authentication using its deployed configuration. No ID lookup
+or configuration changes are needed to build the UI. Never mock products or hand-build a
+`/checkout` URL; the shipped cart uses the eCom redirect session.
 
 ## Prerequisites
 - The site's **Wix Stores** catalog is the read/cart target. It's installed and seeded separately, in parallel with this build — so it may be empty at build time; render the empty state until products land.
-- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
 ## Already installed in `src/`
 Successful deployment verified these files are in place; use this map without needing to read their source (`@/` → `src/`).
@@ -25,7 +25,7 @@ Successful deployment verified these files are in place; use this map without ne
 | `components/CartButton.jsx` | Cart icon button with a live-count badge |
 | `components/CartDrawer.jsx` | Cart drawer; mount once, opens through `useCart` |
 | `components/WixManageBanner.jsx` | Preview-only manage banner; include only when the entry guide enables it |
-| `rest/wix-config.js` | Wix client and site ids |
+| `rest/wix-config.js` | Deployed configuration; consumed internally by the shipped client |
 | `rest/wix-client.js` | REST transport and visitor authentication |
 | `rest/wix-store-catalog.js` | Product and category queries |
 | `rest/wix-store-cart.js` | Cart mutations and hosted checkout |
@@ -363,8 +363,8 @@ function Layout() {
 Follow the entry guide's banner choice. If it disables the banner, use the common wiring above
 without a banner import, mount, or banner-specific fixed region.
 
-When enabled, `WixManageBanner` is a default export with no props. It uses `WIX_METASITE_ID` from
-`@/rest/wix-config`, links to that site's dashboard, and renders only in preview; it returns null
+When enabled, `WixManageBanner` is a default export with no props. It reads its own configuration,
+links to the site's dashboard, and renders only in preview; it returns null
 when dismissed or while the site id is a placeholder. Mount it once above the header in one fixed
 region; keep the header in flow within that region and offset the content by its measured height
 so dismissal or resizing leaves no gap or overlap. Replace only the example's `Layout` with:

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -3,6 +3,7 @@
 Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
+The module reads the site ID from `/app/src/rest/wix-config.js`; do not read or pass it yourself.
 
 **Match each product's type to what the buyer receives** (the example shows both). *Access* — a
 membership, or an online course/program the buyer enrolls in — isn't a store product at all; that's
@@ -16,7 +17,7 @@ const fs = require("fs");
 const seed = (() => { const m = { exports: {} };
   new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js", "utf8"))(m, m.exports, require);
   return m.exports; })();
-const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+const ctx = { token: accessToken };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -3,7 +3,8 @@
 Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
-For Stores installation only, the module reads the site ID from `/app/src/rest/wix-config.js`; do not read or pass it yourself.
+Pass only the connector token and catalog data. The module handles site configuration internally;
+do not read the config or supply site/client IDs.
 
 **Match each product's type to what the buyer receives** (the example shows both). *Access* — a
 membership, or an online course/program the buyer enrolls in — isn't a store product at all; that's

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -3,7 +3,7 @@
 Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
-The module reads the site ID from `/app/src/rest/wix-config.js`; do not read or pass it yourself.
+For Stores installation only, the module reads the site ID from `/app/src/rest/wix-config.js`; do not read or pass it yourself.
 
 **Match each product's type to what the buyer receives** (the example shows both). *Access* — a
 membership, or an online course/program the buyer enrolls in — isn't a store product at all; that's

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -6,7 +6,7 @@
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
 //   const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
-//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//   const ctx = { token: accessToken }; // Site ID is read from the deployed Wix config.
 //   await seed.installStoresApp(ctx);
 //   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);
 //   const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);
@@ -19,6 +19,28 @@
 
 const API = "https://www.wixapis.com";
 const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
+const WIX_CONFIG_PATH = "/app/src/rest/wix-config.js";
+let siteId;
+
+function getSiteId() {
+  if (siteId) return siteId;
+  let source;
+  try {
+    source = require("fs").readFileSync(WIX_CONFIG_PATH, "utf8");
+  } catch {
+    throw new Error(`Cannot read ${WIX_CONFIG_PATH}; deploy the Wix config before seeding.`);
+  }
+  // Base44/deploy writes a named export containing a JSON string literal. Do not execute config.
+  const match = source.match(/^export const WIX_METASITE_ID\s*=\s*("(?:[^"\\]|\\.)*")\s*;/m);
+  let value;
+  try { value = match && JSON.parse(match[1]); } catch { /* invalid config */ }
+  if (typeof value !== "string" || !/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new Error(`Missing or invalid WIX_METASITE_ID in ${WIX_CONFIG_PATH}; deploy the Wix config before seeding.`);
+  }
+  siteId = value;
+  return siteId;
+}
+
 
 async function req(ctx, path, { method = "POST", body } = {}) {
   // Retry while the catalog is still provisioning: right after a fresh Stores install the V3 WRITE
@@ -30,7 +52,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
       method,
       headers: {
         Authorization: `Bearer ${ctx.token}`,
-        "wix-site-id": ctx.siteId,
+        "wix-site-id": getSiteId(),
         "Content-Type": "application/json",
       },
       body: body ? JSON.stringify(body) : undefined,
@@ -69,7 +91,7 @@ async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
     const res = await fetch(`${API}/stores/v3/products/query`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${ctx.token}`, "wix-site-id": ctx.siteId, "Content-Type": "application/json" },
+      headers: { Authorization: `Bearer ${ctx.token}`, "wix-site-id": getSiteId(), "Content-Type": "application/json" },
       body: JSON.stringify({ query: { paging: { limit: 1 } } }),
     });
     if (res.ok) return;
@@ -230,9 +252,10 @@ const digitalFileName = (p) =>
 // ---- exported operations ----
 
 async function installStoresApp(ctx) {
+  const siteId = getSiteId(); // Fail before the install-error catch if config is missing.
   try {
     await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
-      tenant: { tenantType: "SITE", id: ctx.siteId },
+      tenant: { tenantType: "SITE", id: siteId },
       appInstance: { appDefId: STORES_APP_ID, enabled: true },
     } });
   } catch {

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -6,7 +6,7 @@
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
 //   const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
-//   const ctx = { token: accessToken }; // Site ID is read from the deployed Wix config.
+//   const ctx = { token: accessToken }; // Installation reads the site ID from the deployed Wix config.
 //   await seed.installStoresApp(ctx);
 //   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);
 //   const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);
@@ -42,7 +42,7 @@ function getSiteId() {
 }
 
 
-async function req(ctx, path, { method = "POST", body } = {}) {
+async function req(ctx, path, { method = "POST", body, headers = {} } = {}) {
   // Retry while the catalog is still provisioning: right after a fresh Stores install the V3 WRITE
   // path becomes usable a bit later than the V3 read path, so even once waitForCatalogV3 (a read
   // probe) returns, the first bulk-create can still 428. Wait it out (~80s budget); every other
@@ -52,7 +52,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
       method,
       headers: {
         Authorization: `Bearer ${ctx.token}`,
-        "wix-site-id": getSiteId(),
+        ...headers,
         "Content-Type": "application/json",
       },
       body: body ? JSON.stringify(body) : undefined,
@@ -91,7 +91,7 @@ async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
     const res = await fetch(`${API}/stores/v3/products/query`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${ctx.token}`, "wix-site-id": getSiteId(), "Content-Type": "application/json" },
+      headers: { Authorization: `Bearer ${ctx.token}`, "Content-Type": "application/json" },
       body: JSON.stringify({ query: { paging: { limit: 1 } } }),
     });
     if (res.ok) return;
@@ -254,7 +254,7 @@ const digitalFileName = (p) =>
 async function installStoresApp(ctx) {
   const siteId = getSiteId(); // Fail before the install-error catch if config is missing.
   try {
-    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { headers: { "wix-site-id": siteId }, body: {
       tenant: { tenantType: "SITE", id: siteId },
       appInstance: { appDefId: STORES_APP_ID, enabled: true },
     } });


### PR DESCRIPTION
The storefront seeding example referenced an undefined site-ID variable, causing a sampled build to fail before sending its first request.

Callers now supply only the token. Stores installation reads and caches the site ID from the deployed `/app/src/rest/wix-config.js`, then includes it in the installation header and required tenant body. All other seeding calls, including catalog readiness, omit the site-ID header and do not need configuration. Parse the generated string export without executing configuration; installation fails before its network request if configuration is missing or invalid. Update the recipe and usage example accordingly. Remove the client-ID prerequisite from the storefront reference and the redundant client-setup instruction from both Base44 light entry guides; clarify that shipped code and the seed helper handle configuration internally. The full deployment guide retains its required deployment inputs from the prompt.

Validation: syntax and diff checks passed. Local execution verified that only installation reads configuration and sends the site ID, with a single cached read. Earlier checks covered missing/invalid configuration. Live requests on the owner's test site exercised the seeding endpoints without the header; installation testing used an already-installed store and retained the tenant ID in its body. A separate duplicate-inventory error occurred with and without the header and is outside this change. No new network requests, retries, or test files.
