### PR TITLE
Preserve storefront add results before checkout

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -117,8 +117,8 @@ export default function ProductCard({ product }) {
 For quick-add, call `addToCart(product.id)` only when `isQuickAddable` and no mandatory
 modifier needs input (`product.modifiers` entries have a `mandatory` boolean). Otherwise link to `/product/${product.slug}` for selection, including
 pre-orders. Listing results have no full variants; the PDP hook loads and resolves them.
-Use cart-context `loading` to disable repeated adds and display `error` on failure (see **Cart**);
-failure does not open the drawer.
+Use cart-context `loading` to disable repeated adds. Failures open the shipped drawer with
+`error`; you can also display it beside the card/PDP controls (see **Cart**).
 
 ### Catalog hook reference
 `useShop` and `SORTS` are named exports from `@/hooks/useShop`; the Shop skeleton above uses them.
@@ -207,6 +207,7 @@ export default function ProductDetail() {
   // quantity, setQuantity(n): number (may be "" mid-edit)
   // inStock, canAdd, adding: booleans
   // submit: async () => adds product + resolved variant + quantity + modifiers
+  // resolves undefined on success, null on failure (not a cart object or a boolean)
   // Replace these placeholders with your error, not-found, and loading UI.
   if (d.error) return null; // show d.error and offer d.retry()
   if (d.notFound) return null;
@@ -222,7 +223,22 @@ export default function ProductDetail() {
 - Render the option/modifier controls below; show a selection hint when `options.length && !variant`.
 - Keep quantity at least 1. Disable adding when `!canAdd || adding`; call `submit()` only with a loaded product and `canAdd`. `submit()` coerces quantity to at least 1 but does not itself enforce `canAdd`.
 - `canAdd` checks variant resolution, variant stock, and mandatory modifier values. `inStock` defaults to true without a resolved variant; use `canAdd` for the full gate.
-- `submit()` resets `adding` after completion and resolves without a cart result. Add failures live in `useCart().error`, not the PDP load `error`; show them even when the drawer is closed.
+- `submit()` resets `adding` after completion and preserves the cart result: `undefined` on success, `null` on failure. Add failures live in `useCart().error`, not the PDP load `error`; the shipped drawer opens to display them.
+
+For an optional **Buy Now** button, check the add result before checkout:
+```jsx
+// Inside ProductDetail, with the other hooks above any conditional returns:
+const { checkout, loading: cartLoading } = useCart(); // named import from @/context/CartContext
+async function buyNow() {
+  if (!d.product || !d.canAdd || d.adding || cartLoading) return;
+  const result = await d.submit();
+  if (result === null) return; // add failed; preserve its error and do not check out the old cart
+  await checkout();
+}
+// <button disabled={!d.canAdd || d.adding || cartLoading} onClick={buyNow}>Buy now</button>
+```
+For direct `addToCart(...)` calls, use the same `result === null` check before checkout.
+A resolved promise alone does not mean success; a truthiness check also rejects successful `undefined`.
 
 ### Variant and modifier controls
 The product-detail example above provides both groups:
@@ -273,8 +289,8 @@ const { addToCart, isOpen, setIsOpen, loading, error, clearError } = useCart();
 The context's add/remove/update/checkout methods return promises resolving to `undefined` on
 success or `null` on failure, storing the failure in `error`. They clear the previous error and
 set `loading` during the operation. Successful add updates the server-cart snapshot and opens the
-drawer; failed add does not open it. The drawer displays errors only while open, so your card/PDP
-must surface `error` too. These context methods do not return the updated cart or checkout URL.
+drawer; mutation failures also open it to display the error. Your card/PDP can additionally
+surface `error` inline. These context methods do not return the updated cart or checkout URL.
 The lower-level REST helpers can reject; don't apply their rejection contract to `useCart()`.
 
 #### Custom cart UI — optional

--- a/skills/wix-vibe-headless/references/storefront/app/context/CartContext.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/context/CartContext.jsx
@@ -40,6 +40,7 @@ export function CartProvider({ children }) {
       return await fn();
     } catch (e) {
       setError(e?.message || "Something went wrong. Please try again.");
+      setIsOpen(true); // Surface refusals even when adding from a card or PDP with the drawer closed.
       if (reread) await refreshCart().catch(() => {});
       return null;
     } finally {

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -95,10 +95,10 @@ export function useProductDetail(slug) {
     setAdding(true);
     try {
       // addToCart reports its own failures through the cart context (it opens the drawer with the
-      // reason), so nothing is swallowed by leaving this unguarded beyond resetting the button.
+      // reason). Preserve its undefined-on-success / null-on-failure result for chained actions.
       // Coerce the quantity: the shipped stepper lets the field sit empty mid-edit, and a keyboard
       // submit from that state would otherwise post "" as the quantity.
-      await addToCart(product.id, variant?.id, Math.max(1, Number(quantity) || 1), {
+      return await addToCart(product.id, variant?.id, Math.max(1, Number(quantity) || 1), {
         modifierChoices: Object.keys(modifierChoices).length ? modifierChoices : undefined,
         customTextFields: Object.keys(customTextFields).length ? customTextFields : undefined,
       });


### PR DESCRIPTION
Buy Now handlers could continue to checkout after a failed add because the product-detail hook discarded the cart mutation result. Return that result (`undefined` on success, `null` on failure), and document an optional handler that checks it before checkout. Cart mutation failures now open the shipped drawer so their errors are visible even when it was closed.

Validation: exercised the real React hooks with mocked API responses, including successful/failed adds, loading reset, quantity coercion, the documented Buy Now handler, and checkout/remove/update failures. `git diff --check` passed. No test files added to the PR.

The generic skill validator reports an existing 1,984-character description exceeding its 1,024-character limit; the skill header is unchanged. These focused behavior checks ran locally, not in repository CI.
