### PR TITLE
fix(wix-app): make the compiler bar the project's own tsconfig

### DIFF
--- a/skills/wix-app/references/CODE_QUALITY.md
+++ b/skills/wix-app/references/CODE_QUALITY.md
@@ -4,7 +4,9 @@ Applies to all generated code across every Wix CLI app extension type. Each per-
 
 ## TypeScript Quality Guidelines
 
-- Generated code MUST compile with zero TypeScript errors under strict settings: `strict`, `noImplicitAny`, `strictNullChecks`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`.
+- Generated code MUST compile with zero TypeScript errors **under the project's own `tsconfig.json`** — run `npx tsc --noEmit -p .`. That file, and the base it `extends`, are the bar. Read them before writing code; do not assume a flag is on.
+- **Expect `strictNullChecks` to be off.** The Wix CLI app template sets `strictNullChecks: false` and `exactOptionalPropertyTypes: false` explicitly, on top of a base that sets only `strict: true`. So of the flags this file used to demand, `strict` and `noImplicitAny` are on, two are deliberately disabled, and `noUncheckedIndexedAccess` is never set. Writing code that only type-checks under flags the project disables — or citing those flags to justify a line — makes the reasoning wrong even when the code is right.
+- Because the compiler is *not* checking null and undefined for you, handling them is a discipline rather than something you will be told about. That makes the next three rules more important here, not less.
 - Prefer type-narrowing and exhaustive logic over assertions; avoid non-null assertions (`!`) and unsafe casts (`as any`).
 - Treat optional values, refs, and array indexing results as possibly undefined and handle them explicitly.
 - Use exhaustive checks for unions (e.g., `switch` with a `never` check) and return total values (no implicit `undefined`).

--- a/skills/wix-app/references/stores/GET_PRODUCT.md
+++ b/skills/wix-app/references/stores/GET_PRODUCT.md
@@ -37,7 +37,8 @@ if (v === 'V3_CATALOG') {
   }
 } else {
   const res = await products.getProduct(id);
-  const product = res.product!;  // product is optional in the raw type; ! matches SDK's strict-mode guarantee
+  const product = res.product;
+  if (!product) throw new Error(`Product ${id} not found`);
   for (const option of product.productOptions ?? []) {
     for (const choice of option.choices ?? []) {           // ✅ direct in V1
       render(option.name, choice.value);                   // value = label or hex string
@@ -90,7 +91,8 @@ if (v === 'V3_CATALOG') {
   }
 } else {
   const res = await products.getProduct(id);
-  const product = res.product!;  // product is optional in the raw type; ! matches SDK's strict-mode guarantee
+  const product = res.product;
+  if (!product) throw new Error(`Product ${id} not found`);
   for (const variant of product.variants ?? []) {
     // V1: choices is { [optionName]: value }
     render(Object.entries(variant.choices ?? {}).map(([k, v]) => `${k}:${v}`).join(', '));

--- a/skills/wix-app/references/stores/WRITE.md
+++ b/skills/wix-app/references/stores/WRITE.md
@@ -36,7 +36,7 @@ if (v === 'V3_CATALOG') {
   const current = await productsV3.getProduct(id);
   if (current.revision == null) throw new Error(`Product ${id} has no revision`);
   return await productsV3.updateProduct(id, {
-    revision: current.revision,  // narrowed — required under exactOptionalPropertyTypes
+    revision: current.revision,  // narrowed above: the SDK types revision as optional
     name: 'New name',
   });
 }


### PR DESCRIPTION
Audit **P5** from `DOCS-AUDIT-c646996e`.

*(Split out of an earlier version of this PR that also carried audit S6 — that is now [its own PR](https://github.com/wix/skills/pulls), since the two share nothing but the audit that found them.)*

## The bar was 3-of-5 wrong

`CODE_QUALITY.md` required five flags. Checked against a real app's *effective* config (`tsc --showConfig`):

| flag | actual |
|---|---|
| `strict` | `true` |
| `noImplicitAny` | `true` |
| `strictNullChecks` | **`false`** — disabled by the app template |
| `exactOptionalPropertyTypes` | **`false`** — disabled by the app template |
| `noUncheckedIndexedAccess` | *(never set)* |

Two aren't merely absent: the Wix CLI template turns them off explicitly, on top of a base that sets only `strict: true`.

The irony is exact — the audit's second shipped error was caused by `strictNullChecks` being off, while this file demanded it.

## The change

The bar becomes *"compiles under the project's own `tsconfig.json`"*, with an instruction to read that file and its `extends` base before writing code, and a plain statement that `strictNullChecks` should be expected off.

The five-flag list is **removed** rather than demoted to aspirational — a list of flags nobody sets is precisely what licensed the two problems below.

It also notes that since the compiler is *not* checking null and undefined here, handling them is a discipline it won't remind you about, which makes the surviving rules more important rather than less.

## The text those flags had licensed

- **`stores/WRITE.md`** justified narrowing a value with *"required under `exactOptionalPropertyTypes`"*. The narrowing is correct; the reason isn't. Reworded to the real one — the SDK types `revision` as optional.
- **`stores/GET_PRODUCT.md`** used `res.product!` **twice**, which `CODE_QUALITY.md` forbids in the very next bullet, justified as matching a *"strict-mode guarantee"* the project doesn't have. With `strictNullChecks` off the assertion is a no-op anyway. Replaced with an explicit guard, correct under either configuration:

  ```ts
  const product = res.product;
  if (!product) throw new Error(`Product ${id} not found`);
  ```

  That also stops the skill contradicting itself across two files.

3 files. No dependency on an unreleased `@wix/patterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)