### PR TITLE
fix(wix-app): stop teaching a CLI that no longer exists

### DIFF
--- a/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
@@ -34,9 +34,9 @@ Everything below is a real name in the installed `@wix/patterns`. Confirm the pr
 | A fixed in-memory option list for a filter | `useStaticListFilterCollection` |
 | Sorting | `Sortable Columns`, `MultiLevelSorting` |
 
-**Ask for several names at once.** `docs`, `types` and `exports` all take a list — `types ComputedQuery OffsetQuery RangeItem`, `exports page form router` — and each call is a full model turn, so five one-name calls cost five turns for one call's worth of answer. `exports` with no argument lists the 31 entry points; that is a one-off orientation, not something to re-run.
+**Read the index once, then go straight to files.** `dist/dts-bundle/index.json` answers every name in this table in a single read — resolve it once per session and keep it, rather than re-reading it per lookup. Each entry names the exact file to open next.
 
-**A factory or hook's doc is often empty where its signature should be** — `docs idNameArrayFilter` prints an `## API` heading with nothing under it, because the props table only exists for components. Ask `types idNameArrayFilter` instead and you get the signature: `<T extends { id: string; name: string }>(params?) => ArrayFilterState<T>`. That applies to every `use…` hook and every `…Filter` factory in the table above, and it is the difference between knowing the name and being able to call it.
+**A factory or hook's doc is often empty where its signature should be** — the props table is generated for components, so `idNameArrayFilter`'s doc shows an `## API` heading with nothing under it. Its bundle has the signature: `<T extends { id: string; name: string }>(params?) => ArrayFilterState<T>`. That holds for every `use…` hook and every `…Filter` factory in the table above, and it is the difference between knowing a name and being able to call it — so for these, read the bundle the index names, not the doc.
 
 **A filter must narrow the result.** Declare it in the collection hook's `filters` map and read it inside `fetchData`, so the value reaches the query. Filter UI that renders but never changes the rows is a defect that looks like a feature — and it is the failure mode these components exist to prevent.
 


### PR DESCRIPTION
Audit **S6** from `DOCS-AUDIT-c646996e`. Split out of #1250, which carried an unrelated audit item.

## The problem

`COLLECTION_TOOLKIT.md` still taught `patterns.cjs`'s subcommands in two paragraphs — `docs`, `types` and `exports` as commands, how to batch arguments into one call, and `exports` with no argument listing the entry points.

That script was deleted; lookups are direct file reads now. So the skill was telling an agent to run commands that don't exist.

## How it survived

Worth naming, because the same gap could hide others: the checkpoint that removed `patterns.cjs` grepped for **`patterns.cjs`**, found nothing, and called the repo clean. It never looked for the *subcommands*. Prose describing a removed tool doesn't mention the tool's filename.

## The change

Both paragraphs keep their advice and lose the tool.

- *"Ask for several names at once"* → **"read the index once, then go straight to files."** The batching advice was about turn cost in a CLI; the equivalent now is that `dist/dts-bundle/index.json` answers every name in that table in a single read, and each entry names the exact file to open next.

- The second paragraph was still true and worth more than its wrapper: a factory or hook's doc shows an empty `## API` because the props table is generated for components, so its signature lives in the bundle. Now stated as **"for these, read the bundle the index names, not the doc"** — which is also what would have kept the audit's run from guessing a hook signature.

Hard counts go with the tool. The entry-point number was correct at 1.460.0, but it is exactly the kind of fact that rots silently between releases.

1 file. No dependency on an unreleased `@wix/patterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)