### PR TITLE
fix(seo): route site title requests to the correct SEO level

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -37,7 +37,7 @@ Lists all apps installed on a site using Apps Installer API. Useful for verifyin
 ## SEO
 
 ### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
-Read and update the SEO tags of a Wix site at the right level — site-wide tags, page-type patterns, or one item's tags. Discover item IDs and pattern variables instead of inventing them, read before every full-replace write, and report resolved tags with the source each one came from.
+Read and update SEO titles and tags at the right level. For "change my site's SEO title", clarify homepage, specific page, or page-type pattern before discovery or writes; site-level tags accept meta tags only, never titles. Discover item IDs and pattern variables, read before every full-replace write, and report resolved tags with their sources.
 
 ### [Manage URL Redirects on a Wix Site](references/seo/manage-url-redirects.md)
 "Retrieve, create, and delete URL redirects on a Wix site using the public SEO Redirects API. Covers exact and group redirects, language-scoped redirects for multilingual sites, batches of up to 500, and the change flow for a redirect that already exists. This API has no query, search, or update method: List Redirects is the only read-many. Redirects do not chain, so creating one that points at a path another redirect starts from permanently deletes that other redirect; list and check before every write."

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -1,6 +1,6 @@
 ---
 name: "Manage a Wix Site's SEO Tags"
-description: Read and update the SEO tags of a Wix site at the right level — site-wide tags, page-type patterns, or one item's tags. Discover item IDs and pattern variables instead of inventing them, read before every full-replace write, and report resolved tags with the source each one came from.
+description: Read and update SEO titles and tags at the right level. For "change my site's SEO title", clarify homepage, specific page, or page-type pattern before discovery or writes; site-level tags accept meta tags only, never titles. Discover item IDs and pattern variables, read before every full-replace write, and report resolved tags with their sources.
 ---
 
 # Manage a Wix Site's SEO Tags
@@ -46,7 +46,8 @@ SEO Patterns for a page-type title convention. See the
 
 If the user says "change my site's SEO title" without identifying a page or
 page type, ask whether they mean the homepage, another specific page, or a
-page-type title convention. Do not write until scope is clear. For an explicit
+page-type title convention. Ask immediately after reading this recipe; do not make discovery or schema
+queries until scope is clear. For an explicit
 homepage request, discover its actual ID; never assume an ID such as `home`.
 Use Item SEO Tags with `STATIC_PAGE`, read its current tags, and merge the title
 into the complete set. Follow the static-page publication rules below.
@@ -98,7 +99,38 @@ No request body. Returns `itemSeoTags` with `tags`, `resolvedTags`,
 
 ### List Item SEO Tags — `GET /item-seo-tags/{itemType}?paging.limit=100`
 
-No request body. Returns `itemSeoTagsList[]` and `pagingMetadata` with cursors.
+No request body. Returns `itemSeoTags[]` and `pagingMetadata` with cursors.
+`itemSeoTagsList` is not a response field. Each array entry is an Item SEO Tags
+object directly, not a wrapper: read `entry.itemId`, `entry.tags`, and
+`entry.resolvedTags`, not `entry.itemSeoTags`. Use `itemId` as the path ID;
+`id` is a composite identifier and `hostPageId` is not the item identifier.
+
+For static-page discovery, call this with `STATIC_PAGE`. Example response:
+
+```json
+{
+  "itemSeoTags": [
+    {
+      "itemType": "STATIC_PAGE",
+      "itemId": "<page-id>",
+      "tags": [],
+      "resolvedTags": [
+        { "tag": { "type": "title", "children": "Home | Studio Shop" },
+          "source": "TAG_SOURCE_DEFAULT_PATTERN" }
+      ]
+    }
+  ],
+  "pagingMetadata": { "hasNext": false }
+}
+```
+
+Inspect the returned page identities and resolved tags to identify the requested
+page, then Get that exact `itemId` before writing. If the response does not
+unambiguously identify it, ask the user to identify the page. Do not interpret
+a missing response field as an empty page list, assume the first entry is the
+homepage, or create/update a pattern as a fallback for a missing page. A
+single-page request never authorizes changing all pages of its type.
+See [List Item SEO Tags](https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/list-item-seo-tags).
 
 ### Set Site SEO Tags — `PATCH /site-seo-tags`
 

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -38,6 +38,20 @@ Match the user's request to the level that owns the change:
 | "All my product/blog/event pages should be titled like X" — a convention for every item of a page type | Pattern | **SEO Patterns** |
 | "Change the title of this page/product/post" — one specific item | Item | **Item SEO Tags** |
 
+**Site SEO Tags accepts meta tags only** (including site-level social image
+and robots settings). Never send `title`, `link`, or `script` tags to
+`PATCH /site-seo-tags`. Use Item SEO Tags for a specific page's title, or
+SEO Patterns for a page-type title convention. See the
+[Site SEO Tags object](https://dev.wix.com/docs/api-reference/business-management/seo/site-seo-tags-v1/site-seo-tags-object).
+
+If the user says "change my site's SEO title" without identifying a page or
+page type, ask whether they mean the homepage, another specific page, or a
+page-type title convention. Do not write until scope is clear. For an explicit
+homepage request, discover its actual ID; never assume an ID such as `home`.
+Use Item SEO Tags with `STATIC_PAGE`, read its current tags, and merge the title
+into the complete set. Follow the static-page publication rules below.
+Do not substitute `og:title` for the requested SEO title.
+
 Work at the level that matches the change. Writing the same title onto many
 items is the same outcome as one pattern and much harder to undo. If the user's
 words fit more than one level, ask one short question before writing. An
@@ -255,8 +269,9 @@ issue another Get — the write response is the confirmation.
 - **Calling List Item SEO Tags expecting product names.** List returns IDs
   and tags, not names. Use Search Products to find the ID by name first.
 - **Retrying a 400 with a different request shape without checking why.** A 400
-  means the shape was wrong. Compare against the shapes in this recipe, fix the
-  mismatch, send once. Three retries with guessed shapes is three wasted calls.
+  can mean the target level is wrong, not just the shape. Read the validation
+  message and check the level rules first. Compare against the shapes in this
+  recipe, fix the mismatch, send once. Three retries with guessed shapes is three wasted calls.
 
 Tags can currently be written only for the site's primary language: leave
 `language` unset on every write. There is no revision checking — the last write
@@ -298,12 +313,18 @@ success.
 - **`UNSUPPORTED_ITEM_TYPE`:** the error message lists the item types the API
   supports; use it to redirect the request rather than retrying blindly.
 - **`ITEM_NOT_FOUND`:** re-discover the item ID; do not guess a new one.
+- **Unsupported site-level tag / `FIELD_NOT_ALLOWED`:** a rejected `title`,
+  `link`, or `script` is a wrong-level error, not a nesting or field-mask error.
+  Do not retry it at site level or silently drop the requested tag. Clarify the
+  target if needed, then use the appropriate item or pattern API. Get that
+  target's current tags before merging and writing; never reuse the site's
+  tags as the new target's complete set. A rejected write saved no changes.
 - **Invalid tags:** tags are validated before anything is saved, so nothing
   changed; fix the tag and resend the same complete set.
 - **`400` on a request you built from this recipe:** compare the request you
   sent against the shapes in this recipe's "REST request and response shapes"
-  section. Fix the mismatch — a wrong nesting level, a missing wrapper key, or
-  `fieldMask` sent as an array instead of a string — and send again. Never
+  section and the wrong-level recovery rule above. Fix the mismatch — a wrong
+  nesting level, a missing wrapper key, or `fieldMask` sent as an array instead of a string — and send again. Never
   resend the same shape, and never walk through variations hoping one is
   accepted.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading

--- a/yaml/wix-manage-evals/seo/manage-seo-tags-ambiguous-site-title.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags-ambiguous-site-title.yml
@@ -1,0 +1,30 @@
+name: seo/manage-seo-tags-ambiguous-site-title
+description: Clarifies ambiguous site SEO titles before writing.
+triggerPrompt: >-
+  Change my site's SEO title to "Handmade Ceramics | Studio Shop".
+tags: [seo]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-site-s-seo-tags
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Require a concise clarification asking whether the user means the homepage,
+      another specific page, or a page-type title convention. Scope is missing.
+      Fail (score 0) for ANY mutating API call, a guessed target, or a claim
+      that the title was updated. A question with no write is the successful
+      outcome. Substituting og:title for the SEO title is incorrect.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Score 0-10 for a direct path from reading the recipe to a scope question.
+      Penalize unnecessary discovery/probing calls and any non-2xx error.
+      Any attempted write must score 0, even if rejected.
+      Identify each friction and its likely skill, MCP, or docs cause.
+      Return ONLY {"score":<0-10>,"reason":"<frictions and causes, or clean path>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor

--- a/yaml/wix-manage-evals/seo/manage-seo-tags-homepage-title.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags-homepage-title.yml
@@ -1,0 +1,37 @@
+name: seo/manage-seo-tags-homepage-title
+description: Updates a homepage SEO title at item level and preserves unrelated tags.
+triggerPrompt: >-
+  Change my site's SEO title to "Handmade Ceramics | Studio Shop". I mean only the homepage. Save as a draft without publishing, preserve all other SEO tags, and tell me what changed.
+tags: [seo]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-site-s-seo-tags
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Require discovery of the homepage ID from API responses, Get Item SEO Tags
+      for STATIC_PAGE and that ID, then a successful Set for the same target.
+      Require the complete tags array to preserve every unrelated tag from Get
+      and set type title with children "Handmade Ceramics | Studio Shop".
+      publish must be false or omitted. Require a truthful draft-only report
+      based on the successful write response. Fail (score 0) if no successful
+      item write occurred, an ID was guessed, a pattern was written, unrelated
+      tags were dropped, the change was published, or a live change was claimed.
+      Any title/link/script sent to Site SEO Tags must score 0 even if recovered.
+      Substituting og:title or asking for the supplied scope is not completion.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Score 0-10 for efficient homepage discovery, one target Get, one complete
+      Set, and reporting from its response. A title sent to Site SEO Tags or
+      a write without the target Get must score 0 even if later recovered.
+      Penalize non-2xx errors, duplicate writes, guessed-shape retries, redundant
+      verification reads, and unnecessary scope clarification.
+      Identify each friction and its likely skill, MCP, or docs cause.
+      Return ONLY {"score":<0-10>,"reason":"<frictions and causes, or clean path>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -12,7 +12,7 @@ tags: [seo, stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/skills/manage-a-wix-site-s-seo-tags
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-site-s-seo-tags
   - type: llm_judge
     minScore: 7
     maxTokens: 2048


### PR DESCRIPTION
## Summary

Requests such as “change my site’s SEO title” can lead agents to send a title to Site SEO Tags, which rejects it. Make the site-level restriction explicit, clarify ambiguous scope before writing, and route a confirmed homepage request to Item SEO Tags. Add wrong-level recovery guidance that requires reading the newly selected target before writing.

Adds two regression scenarios: ambiguous site title (clarification with no writes) and explicit homepage title (draft item-level update preserving unrelated tags). Both reject attempted site-level title writes even if later recovered. Corrects the existing product scenario’s coverage URL to match the documentation mapping. The first live eval exposed a pre-existing wrong list-response field: correct `itemSeoTagsList` to `itemSeoTags`, document the direct entry shape and item ID, and prohibit a pattern fallback when a page cannot be identified. Surface the routing rule in the recipe description and matching index.

Follow-up to #1075 and #1172. This concerns SEO tags, separately from content-plan PR #1216.

## Validation

- `corepack yarn install --immutable` and `corepack yarn build` in `packages/evalforge-core` passed.
- Parsed all three SEO-tag scenarios using the repository’s compiled `parseScenario` schema and verified at least three assertions each: passed.
- `git diff --check`: passed.
- Verified the routing against the official Wix docs search result for Site SEO Tags and the reported API validation error.

## Live EvalForge validation

Passed on commit `3e77e570814ab583b3e8b8be9cbaa1ccaaa88985`: all three scenarios passed all nine assertions; every PR correctness/quality judge scored 10/10. The ambiguous-title and homepage-title scenarios both beat production with high confidence; the existing product scenario tied production.

[Passing gate, attempt 3](https://github.com/wix/skills/actions/runs/34030371469/attempts/3)

The first run exposed the incorrect list-response field and pattern fallback, which were fixed. Two subsequent runs exposed variable recipe selection (the agent sometimes skipped the recipe); their startup index still displayed the production description despite the branch override. The final run passed unchanged assertions and thresholds after reruns. This is a passing live run, not proof that upstream recipe discovery is deterministic.
