### PR TITLE
Skip repeated setup in the Base44 commerce seed guide

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -6,29 +6,55 @@ initial prompt, and the Wix connector is already configured.
 The shipped client is already configured. Use its documented hooks and components; no ID lookup
 or configuration changes are needed.
 
-> **The installed Wix skills are the complete build and seed path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
+> **The Wix skills installed below are the complete build and seed path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
 **Banner disabled for this entry flow:** do not add `<WixManageBanner/>`; skip the shared
 storefront instructions' optional banner integration.
 
-Base44 setup has already installed the Wix skills, deployed the storefront files, and added the
-AGENTS.md note. Proceed with the build and seed steps below.
+Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
 
-Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
+## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
+
+Install three skills — they land under `.agents/skills/`:
+- **`wix-vibe-headless`** — the storefront build + seed guide (STEPs 2–3): your main source of truth.
+- **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
+  catalogs, business setup).
+- **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
+  contracts, and Wix API documentation discovery.
+
+Run this through exec_tool, exactly as written — installs all three skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
+
+```js
+const { execSync } = require('child_process');
+const { existsSync, readdirSync } = require('fs');
+const results = {};
+for (const skill of ['wix-vibe-headless', 'wix-manage', 'wix-base44-connector']) {
+  if (existsSync(`/app/.agents/skills/${skill}/SKILL.md`)) { results[skill] = 'already_installed'; continue; }
+  try {
+    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`,
+      { cwd: '/app', timeout: 60000, shell: '/bin/bash' }).toString().replace(/\x1b\[[0-9;]*m/g, '');
+    results[skill] = /installed 1 skill|found 1 skill/i.test(out) ? 'success'
+      : out.includes('No valid skills') ? 'not_found' : 'unknown';
+  } catch (e) { results[skill] = 'error: ' + e.message; }
+}
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront`, { cwd: '/app' }).toString();
+const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
+return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
+```
 
 Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
 
-## STEP 1 — Build the client
+## STEP 2 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
+**Successful STEP 1 verifies installation of the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
 rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
 
-## STEP 2 — Seed the storefront
+## STEP 3 — Seed the storefront
 
 **Never delete or clean up anything on the user's site — seeding is additive only.** It's a live
 user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
@@ -61,7 +87,7 @@ call (images included). A still-generating `/__generating__/<id>.png` placeholde
 — Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
 urls are ready by the time you seed.
 
-## STEP 3 — Wrap up
+## STEP 4 — Wrap up
 
 **Never paste a Wix dashboard link or path.**
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -77,8 +77,9 @@ urls are ready by the time you seed.
 
 **Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
 
-## Later admin requests
+## Follow-up changes and additional Wix features
 
-For all follow-up Wix admin requests, read and follow the already-installed
-`wix-base44-connector` skill at `.agents/skills/wix-base44-connector/SKILL.md`.
-Route all Wix site management and configuration changes through that skill.
+For follow-up Wix requests or features not covered by the shipped storefront, read and follow the
+already-installed `wix-base44-connector` skill at `.agents/skills/wix-base44-connector/SKILL.md`.
+Use its documentation discovery to look up the Wix APIs needed before implementing the change —
+including frontend or backend code, site management, and configuration.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -67,11 +67,13 @@ urls are ready by the time you seed.
 
 ## STEP 3 — Wrap up
 
+**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+
+### Final text response
+
 **Never paste a Wix dashboard link or path.**
 
-**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
-
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+**Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
 
 ## Later admin requests
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -32,7 +32,10 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Only read or change shipped files to diagnose or fix an error you encounter; limit this to the files involved.
+Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
+The shipped files are already deployed and configured; you do not need to read their source or
+rebuild them. If you encounter an error after building the client, read or change whatever you
+need to diagnose and fix it.
 
 ## STEP 2 — Seed the storefront
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -32,11 +32,7 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
-
-**`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
-(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
-rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
+**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Only read a shipped file if you can name a specific interface detail missing from the guide or need to diagnose an observed runtime error. Limit the read to the file relevant to that issue.
 
 ## STEP 2 — Seed the storefront
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -67,6 +67,8 @@ urls are ready by the time you seed.
 
 ## STEP 3 — Wrap up
 
+### Preview
+
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 
 ### Final text response

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -79,16 +79,6 @@ urls are ready by the time you seed.
 
 ## Later admin requests
 
-When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
-
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const res = await fetch("https://www.wixapis.com/<api-path>", {
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ /* request body */ }),
-});
-return await res.json();
-```
-
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the documentation skill available in your environment.
+For all follow-up Wix admin requests, read and follow the already-installed
+`wix-base44-connector` skill at `.agents/skills/wix-base44-connector/SKILL.md`.
+Route all Wix site management and configuration changes through that skill.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -20,7 +20,9 @@ These skills are already installed under `.agents/skills/`:
 
 Base44 has also deployed the storefront hooks, cart components/context, image helpers, and REST
 scaffolds into `src/`, configured the Wix connector/client, and added the Wix note to `AGENTS.md`.
-No installation, deployment, or AGENTS.md update is needed. Continue with STEP 1.
+No installation, deployment, or AGENTS.md update is needed.
+The deployed implementation and configuration files do not need to be read; use the build and seed
+guides below for their contracts and usage. Continue with STEP 1.
 
 Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -81,5 +81,6 @@ urls are ready by the time you seed.
 
 For follow-up Wix requests or features not covered by the shipped storefront, read and follow the
 already-installed `wix-base44-connector` skill at `.agents/skills/wix-base44-connector/SKILL.md`.
-Use its documentation discovery to look up the Wix APIs needed before implementing the change —
-including frontend or backend code, site management, and configuration.
+It covers building on the connected Wix site: gathering site context, discovering APIs and their
+contracts, choosing visitor or admin authentication, and writing frontend and backend code, as
+well as management and configuration. Use it to research and implement these changes.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -32,7 +32,7 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Only read a shipped file if you can name a specific interface detail missing from the guide or need to diagnose an observed runtime error. Limit the read to the file relevant to that issue.
+**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Only read or change shipped files to diagnose or fix an error you encounter; limit this to the files involved.
 
 ## STEP 2 — Seed the storefront
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -26,8 +26,6 @@ guides below for their contracts and usage. Continue with STEP 1.
 
 Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
 
-Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
-
 ## STEP 1 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -62,8 +62,7 @@ storefront seed module's image-attach step.
 
 **Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
 from the **completed** `generate_image` result and pass it straight into your single `setupStore`
-call (images included). A still-generating `/__generating__/<id>.png` placeholder is not a real url
-— Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
+call (images included). `generate_image` runs in the background while you build the client, so the
 urls are ready by the time you seed.
 
 ## STEP 3 — Wrap up

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -11,8 +11,16 @@ or configuration changes are needed.
 **Banner disabled for this entry flow:** do not add `<WixManageBanner/>`; skip the shared
 storefront instructions' optional banner integration.
 
-Base44 setup has already installed the Wix skills, deployed the storefront files, and added the
-AGENTS.md note. Proceed with the build and seed steps below.
+## STEP 0 — Setup already completed by Base44
+
+These skills are already installed under `.agents/skills/`:
+- **`wix-vibe-headless`** — storefront build instructions, hook/component contracts, and seeding modules.
+- **`wix-manage`** — REST recipes for managing and configuring the Wix site.
+- **`wix-base44-connector`** — Wix connector usage, API contracts, and documentation discovery.
+
+Base44 has also deployed the storefront hooks, cart components/context, image helpers, and REST
+scaffolds into `src/`, configured the Wix connector/client, and added the Wix note to `AGENTS.md`.
+No installation, deployment, or AGENTS.md update is needed. Continue with STEP 1.
 
 Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -32,7 +32,7 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
+**Base44 setup has already deployed the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** Don't read or inspect the shipped files' source to confirm structure, and don't rebuild the shipped client. After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -58,8 +58,7 @@ Inline via exec_tool, `base44` is already declared — use it directly; do **not
 inline it throws *"Identifier 'base44' has already been declared."*).
 
 **Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step — consult official Wix API documentation using the documentation skill
-available in your environment if the module doesn't cover it.
+storefront seed module's image-attach step.
 
 **Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
 from the **completed** `generate_image` result and pass it straight into your single `setupStore`

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -329,12 +329,13 @@ Line `quantityInfo.confirmedQuantity` is the current quantity; `availableQuantit
 when finite. `status` can be `IN_STOCK`, `PARTIALLY_IN_STOCK`, `OUT_OF_STOCK`, or
 `REMOVED_FROM_CATALOG`; surface unavailable lines and prevent checkout until resolved.
 
-## Routes and provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## Routes and provider
 **No shipped source reads needed to wire this.** `CartDrawer` and `CartButton`
 are default exports that take **no props**. `CartProvider` is a named export accepting `children`;
 wire these exactly as shown below.
-`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
-replace it.
+When adding storefront routes and providers to `src/App.jsx`, preserve the existing platform
+authentication setup, including `AuthProvider`, `useAuth`, and their `@/lib/AuthContext` imports.
+Do not remove or replace that authentication logic.
 - Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
 - Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -30,8 +30,8 @@ Successful deployment verified these files are in place; use this map without ne
 | `rest/wix-store-catalog.js` | Product and category queries |
 | `rest/wix-store-cart.js` | Cart mutations and hosted checkout |
 
-**DO NOT READ SHIPPED SOURCE** except to resolve a specifically identified field/interface missing
-below or an observed runtime error; read only the relevant file.
+Build using the interfaces below without reading the shipped source. If you encounter an error
+after building the client, read or change whatever you need to diagnose and fix it.
 If deployment failed or files are missing, re-run the install/deploy step.
 
 ## Theme


### PR DESCRIPTION
Base44 commerce setup already installs skills, deploys the storefront, configures the connector, and adds the AGENTS note. The entry guide now describes that completed setup instead of asking the agent to repeat it. The original guide is preserved verbatim as `base44-ecom-light-seed-with-install.md`.

Clarify building from documented interfaces before inspecting shipped source, with unrestricted diagnosis and fixes after an error. Keep auth-preservation guidance in storefront INSTRUCTIONS without prescribing an editing tool. Simplify image guidance, put preview before final-response instructions, and direct additional Wix features through the connector skill.

Validation: exact preservation of the installation guide, step-reference checks, and diff whitespace checks passed. Documentation-only; no test files added.
