### PR TITLE
docs(wix-app): name the third kind of stub, the bare import

### DIFF
--- a/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
+++ b/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
@@ -48,7 +48,20 @@ An empty body with a **"Produced by"** note means: call that hook or factory to 
 
 A stub saying **"cut here because it has its own bundle"** means the same thing for a shape you *do* write: it wasn't copied in twice, so look the name up and read its own file.
 
-Every bundle fits in a single read; the index's `bytes` field says how big before you open it. So a bundle is never partially shown — if something looks missing, it was cut on purpose and the stub names where to find it.
+Every bundle fits in a single read; the index's `bytes` field says how big before you open it. So a bundle is never partially shown — if something looks missing, it was cut on purpose. Both stubs above name where to find it.
+
+### The one that doesn't: a bare `import`
+
+A plain `import { X } from '<module>'` at the top of a bundle, with no note attached, is the third shape you will meet — and unlike the two above it does **not** tell you where to look. What to do depends on the path, not the name:
+
+**A normal entry point** — `react`, `react-hook-form`, `history`, `@wix/design-system`. Resolve it the ordinary way. For `@wix/design-system` names use the `wix-design-system` skill; don't read WDS files directly.
+
+**A deep internal path** — `@wix/design-system/dist/types/DropdownLayout`, `@wix/bex-utils/@wix/bi-logger-os-data/v2/types`. This is an upstream defect: the bundle recorded where the type is *declared* instead of where it is exported. Two things follow, and the second is the one that saves you time:
+
+- Never import that path in your own code, and don't go read the file it points at. It is not a public entry point, and the name is often not re-exported from the package root either — `DropdownLayoutOption` is not exported from `@wix/design-system`, so there is no shorter import to substitute.
+- You usually don't need the declaration at all. Where the type is a **prop you fill in** — WDS option shapes like `SingleSelectFilter`'s and `AutoCompleteFilter`'s `items` — look the *component* up in the `wix-design-system` skill and use the shape its docs show. Where it is a **pass-through you never construct** — the BI logger params behind optional fields like `biAdditionalInfo` — pass what the patterns doc shows, or omit it; it is optional.
+
+If a name you genuinely need stays unresolved after that, stop and say so, and name the bundle and the exact import path that dead-ended. Do not guess a shape and do not go spelunking in `node_modules` — a wrong guess compiles here and breaks at runtime, which is worse than the missing type.
 
 A handful of names carry `"status": "unreachable"` with a message saying not to import them (the `...BaseProps` interfaces a component's props `extends`). Read those for the props they contribute; don't write an import for them.
 


### PR DESCRIPTION
Audit item **S4**, the last one that is entirely ours and unblocked.

## The gap

`PATTERNS_BUNDLE_READING.md` described two one-line stub shapes — the "Produced by" empty class, and "cut here because it has its own bundle" — and closed with:

> if something looks missing, it was cut on purpose and **the stub names where to find it**

A third shape exists and names nothing: a plain `import { X } from '<module>'` at the top of a bundle. An agent that hits one has no route, and the skill's lookup rule then dead-ends at *"stop and say so"* — on a name the bundle is actively using in a prop the agent has to fill in.

## It is live now, not hypothetical

11 of 127 bundles in the published **1.461.0**:

| deep path | bundles |
|---|---|
| `@wix/design-system/dist/types/DropdownLayout` | `SingleSelectFilter`, `AutoCompleteFilter`, `TableFolders`, `CollectionTableBaseProps` |
| `@wix/bex-utils/@wix/bi-logger-os-data/v2/types` | `EntityPage`, `useEntityPage`, `ExportButton`, `OnSaveParams`, `UseEntityPageParams`, `EntityPageStateParams`, `useExportConfig` |

## Why the two cases need opposite handling

This is why "go read the file it points at" would be the wrong single answer:

- **`DropdownLayoutOption` is genuinely needed** — it is `items`, a prop you construct (`items: DropdownLayoutOptionWithSectionId[]`). It is *also* **not exported from the `@wix/design-system` root**, so there is no shorter import to substitute. The route is the `wix-design-system` skill, by component, for the shape its docs show.
- **`cairoPageCtaClickedParams` is not needed at all** — it sits behind an optional `biAdditionalInfo?: cairoPageCtaClickedParams['additionalInfo']`. A pass-through; omit it.

## Where I departed from the audit's proposal

The audit said to *"sanction exactly one escape hatch (`dist/types/index.d.ts`) so an agent is not stuck."* **I did not, because I measured it and it does not work:**

- `DropdownLayoutOption` — 0 hits
- `CairoProviderBaseProps` (the audit's own example) — 0 hits

It is a re-export barrel (`export * from './components/Table'`), so a name can be reachable *through* it without being findable *in* it. Sanctioning a route that dead-ends is worse than the current instruction, and it would contradict `WIX_PATTERNS_DOCS.md`'s standing rule against inspecting `node_modules` by hand.

So "stop and say so" stands — now with the requirement to name the bundle and the exact import path, so the upstream defect gets fixed rather than silently worked around.

## Also

Corrected the closing promise, which was simply false for this third shape.

Gate: `check-truncation.mjs --fail` passes — 7,699 chars, ~15% of the read limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)