### PR TITLE
fix(wix-app): type the fetchData example and rule out register for field binding

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -117,7 +117,7 @@ Patterns owns the page shell and everything collection-shaped. These concepts ar
 | Filters, search, sorting, view presets/tabs | the collection's filter and view APIs |
 | Row actions, bulk actions, drag-and-drop | the collection's feature APIs |
 | Multiple pages inside one extension | `PatternsReactRouter`, `PatternsReactRoute`, `usePatternsNavigate` |
-| **Add / edit / view one item from a collection** | `EntityPage` + `useEntityPage` (fetch + save + validation), reached with `usePatternsNavigate().navigateToEntityPage`. Form state via `useForm` / `useController` from `@wix/patterns/form`. **Not** a dashboard modal — see [Entity create and edit](#entity-create-and-edit) |
+| **Add / edit / view one item from a collection** | `EntityPage` + `useEntityPage` (fetch + save + validation), reached with `usePatternsNavigate().navigateToEntityPage`. Form state via `useForm` / `useController` from `@wix/patterns/form` (`useController`, never `register`). **Not** a dashboard modal — see [Entity create and edit](#entity-create-and-edit) |
 | Overlays tied to a collection (item picker, bulk-action confirm) | `PickerModal` / `usePickerModal`, `bulkActionModal` |
 
 **Looking a component up is two direct file reads** — no script, never `node_modules` browsed by hand. Resolve the installed package root once per session ([Prerequisites](references/WIX_PATTERNS_DOCS.md#prerequisites)), then reuse it. Start with what exists:

--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -41,7 +41,7 @@ Then confirm the installed version actually ships the bundle index:
 ls <pkgRoot>/dist/dts-bundle/index.json
 ```
 
-**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index; it ships from **1.458.0** onward, so upgrade to at least that and re-run the check. Prefer **1.460.0** or newer: from there the docs stop repeating props the bundle already describes, which is what the lookup below assumes. A missing *file* is not the same as a name not being covered (see below): the mechanism itself isn't available yet.
+**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index; it ships from **1.458.0** onward, so upgrade to at least that and re-run the check. Prefer **1.462.0** or newer — the lookups below assume it: 1.460.0 stopped the docs repeating props the bundle describes, and 1.462.0 added `OffsetQuery` to the index and ended unreadable `@wix/bex-core` imports. A missing *file* is not the same as a name not being covered (see below): the mechanism itself isn't available yet.
 
 **Never inspect `node_modules` by hand** — no `ls`, no `find`, no `cat` of an arbitrary path, and that includes the sanctioned directories: never browse `dist/dts-bundle/` or `dist/docs/` looking around. Every lookup below names the exact file to `Read` — go straight to it.
 
@@ -102,7 +102,7 @@ function App() {
 }
 
 // MyCollectionPage.tsx
-import { Table, useTableCollection } from '@wix/patterns';
+import { Table, useTableCollection, OffsetQuery } from '@wix/patterns';
 import { CollectionPage } from '@wix/patterns/page';
 
 function MyCollectionPage() {
@@ -111,7 +111,8 @@ function MyCollectionPage() {
     queryName: 'my-items',
     itemKey: (item) => item.id,
     itemName: (item) => item.name,
-    fetchData: async () => ({ items: [], total: 0 }),
+    // annotate the param: it carries limit/offset/search/filters
+    fetchData: async (query: OffsetQuery) => ({ items: [], total: 0 }),
     filters: {},
   });
   return (
@@ -150,24 +151,20 @@ The mechanics of the file an index names — types the docs don't cover, which o
 
 ## The Collection → Entity Flow
 
-A collection page and its item form are **two patterns pages**, not a page plus a modal. Getting the table right and then hand-building the "add item" form as a dashboard modal is the most common way this goes wrong.
+A collection page and its item form are **two patterns pages**, not a page plus a modal — hand-building the "add item" form as a dashboard modal is the most common way this goes wrong. Reserve modals for dialogs that neither write nor display a listed record: a delete or discard confirmation, an unsaved-changes prompt. **A create / "add new" form is not one of them** — it writes the record, so it is an `EntityPage` even with nothing to edit yet, at any size or field count. A page that lists no records is outside this rule.
 
 | Step | What owns it |
 | --- | --- |
 | Navigate from a row / primary action to the item | `usePatternsNavigate()` → `navigateToEntityPage({ path, entity })` |
 | Register the route | `PatternsReactRoute` inside `PatternsReactRouter` |
 | Fetch, save, validation, dirty state, skeletons, errors | `useEntityPage({ fetch, onSave })` |
-| Form state and field binding | `useForm` / `useController` from `@wix/patterns/form` |
+| Form state and field binding | `useForm` / `useController` from `@wix/patterns/form` — `useController`, never `register` |
 | Body layout | `EntityPage.Header`, `.MainContent`, `.AdditionalContent`, `.Card` |
 | The individual fields inside those cards | `@wix/design-system` (`FormField`, `Input`, `Text`) |
 
-Prefer `navigateToEntityPage` over a plain route change: the entity header (title, subtitle, breadcrumbs) renders immediately, without waiting for the fetch.
+Prefer `navigateToEntityPage` over a plain route change — the entity header renders before the fetch resolves.
 
-Read `EntityPage.md`, `useEntityPage.md`, and `usePatternsNavigate.md` before implementing — and note `useCreateCollection` is **not** about creating items; it returns a function that initializes collection state.
-
-Three things about the `useEntityPage` call are worth getting right first time — both generics, what `onSave` receives, which params exist: [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
-
-Reserve dashboard modals for dialogs that neither write nor display a listed record — a delete or discard confirmation, an unsaved-changes prompt. **A create / "add new" form is not one of them**: it writes the record, so it is an `EntityPage` even though nothing is being edited yet. Size and field count are not exceptions — a one-field create form is still an `EntityPage`. A page that lists no records is outside this rule.
+Read `EntityPage.md`, `useEntityPage.md` and `usePatternsNavigate.md` before implementing, plus [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the `useEntityPage` call itself — both generics, what `onSave` receives, which params exist. Note `useCreateCollection` is **not** about creating items: it returns a function that initializes collection state.
 
 ## When Patterns Has No Equivalent
 

--- a/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
@@ -64,10 +64,43 @@ Confirm the shape rather than guessing — the hook's doc has an empty API secti
 | --- | --- |
 | Getting here from the collection page | `usePatternsNavigate()` → `navigateToEntityPage({ path, entity })` |
 | Registering the route | `PatternsReactRoute` inside `PatternsReactRouter` |
-| Form state and field binding | `useForm` / `useController` from `@wix/patterns/form` |
+| Form state and field binding | `useForm` / `useController` from `@wix/patterns/form` — `useController`, never `register` |
 | Body layout | `EntityPage.Header`, `.MainContent`, `.AdditionalContent`, `.Card` |
 | The fields inside those cards | `@wix/design-system` (`FormField`, `Input`, `Text`) |
 
 `@wix/patterns/form` re-exports `@wix/bex-core/form`, which wraps `react-hook-form` — so `form.getValues()`, `form.reset()` and the rest are react-hook-form's API, documented there rather than in the patterns docs.
+
+## Binding a field: `useController`, never `register`
+
+`register` returns props for a plain `<input>`, and WDS components are not one. Two ways it fails:
+
+`<Input {...register('qty')} />` does not compile — `register` always returns `min`/`max` as `string | number`, whatever options you passed, and WDS types them `number | undefined`. The error names `InputProps`, which reads like a WDS bug and isn't.
+
+`<Input ref={register('qty').ref} />` **does** compile and is wrong. `Input`'s `ref` is its imperative handle (`Ref<InputImperativeActions>`); `register`'s ref is `(instance: any) => void`, so it accepts that and binds the handle rather than the `<input>`. The field never registers, validation never sees it, and nothing reports it.
+
+Bind through value/onChange instead:
+
+```tsx
+import { useController, useForm } from '@wix/patterns/form';
+import { FormField, Input } from '@wix/design-system';
+
+type ProductForm = { name: string; qty: number };
+
+function NameField({ form }: { form: ReturnType<typeof useForm<ProductForm>> }) {
+  const { field, fieldState } = useController({
+    name: 'name',
+    control: form.control,
+    rules: { required: 'Name is required' },
+  });
+
+  return (
+    <FormField label="Name" required status={fieldState.error ? 'error' : undefined} statusMessage={fieldState.error?.message}>
+      <Input value={field.value} onChange={field.onChange} onBlur={field.onBlur} />
+    </FormField>
+  );
+}
+```
+
+Rules live in `rules`, not on the WDS component. If you need `register` for a DOM concern such as input masking, `Input` takes `inputRef?: React.Ref<HTMLInputElement>` — pass the ref there, never to `ref`.
 
 A dialog that creates, updates or displays one listed record is **not** a dashboard modal — a create / "add new" form included, since it writes the record. See [DASHBOARD_MODAL.md](../DASHBOARD_MODAL.md).


### PR DESCRIPTION
Audit item **P7**, unblocked by `@wix/patterns@1.462.0` — the first release whose index actually contains `OffsetQuery` (verified against the published tarball, not assumed).

## The `fetchData` example taught the wrong shape

The only `fetchData` the skill showed was `async () => ({ items: [], total: 0 })`. A zero-arg lambda teaches the callback as taking nothing, which is how generated apps end up ignoring `limit`/`offset`/`search`/`filters`. Now annotated with `OffsetQuery`, imported in the same snippet.

**Version floor moves to 1.462.0**, and it has to: the lookups tell an agent to resolve names through `dist/dts-bundle/index.json`, and `OffsetQuery` is not in it before 1.462.0. That release is also where `@wix/bex-core` stops appearing as unreadable imports.

## `register` appeared in zero skill files

So nothing warned against the binding an agent reaches for first. Both failure modes verified by compiling against WDS and react-hook-form **in a generated app** (`strict: true`, `strictNullChecks: false`):

| | |
|---|---|
| `<Input {...register('qty')} />` | **does not compile.** `register` always returns `min`/`max` as `string \| number`, whatever options were passed; WDS types them `number \| undefined`. The error names `InputProps`, so it reads like a WDS bug. |
| `<Input ref={register('qty').ref} />` | **compiles, and is wrong.** `Input`'s ref is `Ref<InputImperativeActions>`; `register`'s is `(instance: any) => void`, so it accepts that and binds the imperative handle instead of the `<input>`. Nothing reports it. |

The loud one is caught by the compiler; **the silent one isn't**, and that's the case worth documenting.

`ENTITY_PAGE_TOOLKIT.md` now carries both, plus a worked `useController` binding — `value`/`onChange`, `fieldState.error` driving `FormField`'s `status`, rules in `rules` — and names `Input`'s `inputRef?: React.Ref<HTMLInputElement>` as the escape hatch when `register` is genuinely needed for a DOM concern such as input masking. The four field-binding cells now read "`useController`, never `register`".

**Note on P4:** the audit said the WDS `min`/`max` widening must ship *with* `inputRef` documentation, never alone. `inputRef` already exists and is documented in the installed WDS, so that precondition is met.

## The worked example is compiled, not written from memory

My first draft used `status={fieldState.error && 'error'}`. That yields `'"" | "error"'` and doesn't assign to `StatusType`. It's a ternary in the committed version because the compiler said so — which is the same defect class this whole audit item is about.

## One pre-existing problem surfaced

`WIX_PATTERNS_DOCS.md` was **already 30 chars over the 10,000-char fetch limit on `main`** — invisible because CI only checks changed files. My additions would have put it 335 over, so two duplications inside the same section are merged:

- the modal-vs-`EntityPage` rule was stated at both the top and the bottom of "The Collection → Entity Flow"
- the "read these before implementing" pointer appeared twice

**10,030 → 9,976 chars.** The gate passes on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)