### PR TITLE
Return full Wix context reports without section filtering

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -66,7 +66,7 @@ const wx = (() => { const m = { exports: {} };
 
 - `wx.post/get/patch/put/del(url, [body], token?)` — JSON transports, one per verb (`get`/`del` take no body): Bearer from `token`, non-2xx **throws** the API's own error
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
-- `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
+- `wx.context(token)` — the site's full dynamic context report; inline when small, otherwise a saved Markdown file with a heading outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
 - `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A REST search also ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
@@ -86,12 +86,15 @@ two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across ev
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-return await wx.context(accessToken, "Apps");   // no section arg → the report's outline
+return await wx.context(accessToken);
 ```
 
 One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs V3 decides its
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
 An empty report = bad token, never an empty site.
+
+Reports over 4,000 characters are saved in full to a temporary Markdown file. The result includes
+its path, byte and line counts, and a heading outline. Read that file to inspect the site context.
 
 ## Learn Wix — find the APIs, learn their contracts
 

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -13,7 +13,7 @@
 // to find, read_file(<path>) with offset/limit to window (numbered lines, 45K cap — no exec
 // round needed), pipelines for the rest (GNU grep/sed; awk is mawk; no rg).
 //
-// API responses are site data and never saved — post() projects them to facts.
+// API transports return data directly; oversized context reports are saved for reading.
 
 const fs = require("fs");
 const path = require("path");
@@ -87,19 +87,14 @@ async function resolveRef(ref) {
 
 // ── gather context ────────────────────────────────────────────────────────────
 
-// The dynamic context report — site data, never saved. No section → the whole report
-// when it fits, else its header outline; with one → that section's text. Empty
-// report = bad token, never an empty site.
-async function context(token, section) {
+// Return the full dynamic context report inline when it fits. Larger reports use the
+// same saved-file and heading-outline format as documentation pages.
+async function context(token) {
   const { markdown } = await post(
     "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {}, token);
-  if (!section) {
-    if (markdown.length <= BUDGET) return markdown;   // most sites: the whole report, one round
-    return { truncated: true, total: markdown.length, head: markdown.slice(0, BUDGET),
-             note: "site data — never saved (no path); narrow: wx.context(token, '<section name>')" };
-  }
-  const m = markdown.match(new RegExp("^#{1,3} .*" + section + "[\\s\\S]*?(?=\\n#{1,3} |$)", "im"));
-  return clip({ total: markdown.length, section: m ? m[0] : "not found — call context(token) for the outline" });
+  if (markdown.length <= BUDGET) return markdown;
+  const saved = save("site-context-" + require("crypto").randomUUID() + ".md", markdown);
+  return { ...saved, ...outlineOf(markdown.split("\n")) };
 }
 
 // The wix-manage skill, when it is installed in the sandbox, is these same recipes on disk —


### PR DESCRIPTION
The context section parser could return only a heading and discard its contents. Remove section filtering: return the complete Markdown report up to 4,000 characters, otherwise save the complete report to a uniquely named temporary file and return its path, byte/line counts, and heading outline. Update the connector skill signature and example.

Validation: JavaScript syntax and diff checks passed. Ad hoc checks verified full inline output, legacy extra-argument behavior, exact oversized-file contents and outline, and one API request per call. No test files added.
