### PR TITLE
Improve visitor-flow guidance and include Headless search

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -121,10 +121,10 @@ await wx.search("stores v3 update product");   // → [{ method, endpoint: "VERB
 // exploring an unfamiliar product? browse is deterministic — menuUrl alone orients (children + counts);
 // filter before listing methods. browse works for both portals this skill uses — REST
 // (api-reference) and WIX_HEADLESS (go-headless) — just pass that portal's menu URL.
-await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
+await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings.md",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 // non-REST portal — same call, that portal's menu URL:
-await wx.browse("https://dev.wix.com/docs/go-headless/authentication", { depth: 2 });
+await wx.browse("https://dev.wix.com/docs/go-headless/authentication.md", { depth: 2 });
 
 // don't know where it lives? search ranks, never says "no match" — drop wrong-product hits
 await wx.search("pause a pricing plan subscription and resume it");
@@ -273,7 +273,7 @@ export const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, 
   headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } });
 ```
 
-Token contract: `…/headless/authentication/retrieve-tokens`. Prove the lane in one exec before
+Token contract: [Retrieve Tokens](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md). Prove the lane in one exec before
 writing pages — mint a visitor, make one public read with it:
 
 ```js
@@ -294,7 +294,7 @@ const loginCallbacks = appOrigins.map(origin => new URL("/login-callback", origi
 const returnDomains = appOrigins.map(origin => new URL(origin).hostname);
 
 // OAuth redirect configuration: exact login URLs versus domains for other returns.
-// https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains
+// https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains.md
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
 const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps", {
   oAuthApp: {
@@ -309,7 +309,7 @@ const clientId = oAuthApp.id; // Public visitor client ID, used by the frontend 
 
 // If destinations change later, update this OAuth app rather than creating another.
 // Read its existing lists and merge new entries before updating, preserving old entries.
-// https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-oauth-app
+// https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-oauth-app.md
 
 ```
 
@@ -319,7 +319,7 @@ Frontend redirect example, using the visitor client above after obtaining a visi
 import { wix } from "@/lib/wixClient";
 
 // Flow prerequisites and supported intents:
-// https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api
+// https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api.md
 export async function redirectToWix(intent, returnPath = "/") {
   // Pass the intent required by the selected flow's schema.
   const response = await wix("/headless/v1/redirect-session", {

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -75,6 +75,9 @@ const wx = (() => { const m = { exports: {} };
 - `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
 - `wx.installApp(appDefId, siteId, token)` — install a Wix app on the site (Apps Installer). If discovery finds an API whose app isn't installed on the site, install it first — that's a one-call prerequisite, **not** a reason to fall back to a hand-built alternative. `appDefId` from `search` or the Apps-Created-by-Wix table; `siteId` from `context` (the site report)
 
+Search results interleave two recipes, two results from the selected corpus, and two Headless
+articles, repeating in that order while preserving each search's ranking.
+
 Every helper answers inline when the result fits (≤ 4,000 chars — exec results clip at ~5,000).
 A bigger result is saved under `.agents/skills/wix-base44-connector/tmp/` and comes back as
 `{ path, bytes, lines, outline }` — the outline is your map into the file. Work a saved file in

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -68,7 +68,7 @@ const wx = (() => { const m = { exports: {} };
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token)` — the site's full dynamic context report; inline when small, otherwise a saved Markdown file with a heading outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A REST search also ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration guides (`guides`) and ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself
@@ -131,7 +131,8 @@ await wx.search("pause a pricing plan subscription and resume it");
 // → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
 
 // { type } picks the portal (default "REST" — the HTTP APIs this skill calls). Same query,
-// other corpus — search WIX_HEADLESS for headless/external client code (visitor auth,
+// focused corpus — default REST already includes Headless guides alongside methods and recipes.
+// Search WIX_HEADLESS alone for headless/external client code (visitor auth,
 // JS SDK, quick-starts). It returns article-style hits (method gists thin out) — read the saved path.
 await wx.search("mint a visitor token and read the current cart", { type: "WIX_HEADLESS" });
 ```

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -290,8 +290,29 @@ the returned `id` IS the `clientId`:
 
 ```js
 const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
-  { oAuthApp: { name: "My App" } }, accessToken);   // oAuthApp.id is the visitor clientId
+  { oAuthApp: {
+    name: "My App",
+    allowedRedirectUris: ["https://my-app.example.com/login-callback"],
+    allowedRedirectDomains: ["my-app.example.com"],
+  } }, accessToken);   // oAuthApp.id is the visitor clientId
 ```
+
+
+Replace the example addresses with your app's actual destinations:
+
+- `allowedRedirectUris` contains exact login callback URLs, including the path. The
+  authorization request's redirect URI must match an entry exactly.
+- `allowedRedirectDomains` contains hostnames, without a scheme or path, for returns from
+  non-authentication Wix-hosted flows such as checkout. It allows return URLs under those domains.
+
+These lists allow destinations; they do not choose the return URL. Supply the login callback in
+its authorization request and the return URL in the redirect session's `callbacks.postFlowUrl`.
+Include the actual preview and published destinations when supporting both environments.
+If the destinations become known later, update the existing OAuth app, preserving its current
+entries. See [Allow Redirect URIs and Domains](https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains).
+
+[Create OAuth App](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/create-oauth-app)
+has no scopes field in its request; create it using the admin connector token as above.
 
 For visitor flows that send people to Wix-hosted pages and back to your app, read
 [Redirect to Wix-Hosted Pages Using the REST API](https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api)

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -253,7 +253,7 @@ return (await res.json()).contacts;
 - One file per business area, not per call — each file is its own deploy, and deploys cost time.
 - Call every function you deploy and fix what breaks. Deploying is not testing.
 
-### A visitor client — src/lib/wixClient.js
+### Visitor authentication and Wix-hosted flows
 
 The "site for visitors" shape (What are you building?), in code — one file pages import. Neither
 `clientId` (from the context report) nor the minted token is a secret; together they are "an

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -311,9 +311,6 @@ Include the actual preview and published destinations when supporting both envir
 If the destinations become known later, update the existing OAuth app, preserving its current
 entries. See [Allow Redirect URIs and Domains](https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains).
 
-[Create OAuth App](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/create-oauth-app)
-has no scopes field in its request; create it using the admin connector token as above.
-
 For visitor flows that send people to Wix-hosted pages and back to your app, read
 [Redirect to Wix-Hosted Pages Using the REST API](https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api)
 before implementing the flow. It covers redirect sessions, return URLs, and allowed redirect

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -132,12 +132,6 @@ await wx.browse("https://dev.wix.com/docs/go-headless/authentication", { depth: 
 // don't know where it lives? search ranks, never says "no match" — drop wrong-product hits
 await wx.search("pause a pricing plan subscription and resume it");
 // → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
-
-// { type } picks the portal (default "REST" — the HTTP APIs this skill calls). Same query,
-// focused corpus — default REST already includes Headless guides alongside methods and recipes.
-// Search WIX_HEADLESS alone for headless/external client code (visitor auth,
-// JS SDK, quick-starts). It returns article-style hits (method gists thin out) — read the saved path.
-await wx.search("mint a visitor token and read the current cart", { type: "WIX_HEADLESS" });
 ```
 
 Products and their capabilities — the common ones, partial lists:

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -285,31 +285,39 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 // that opts INTO heavier parts (formatted prices, media); read the contract for it
 ```
 
-No OAuth app in the context report to take the `clientId` from? Create one (admin, one-time) —
-the returned `id` IS the `clientId`:
+No OAuth app in the context report to take the `clientId` from? Create one (admin, one-time):
 
 ```js
-const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
-  { oAuthApp: {
+// Use your app's actual destinations, including preview when supported.
+const appOrigins = ["https://my-app.example.com", "https://my-preview.example.com"];
+const loginCallbacks = appOrigins.map(origin => new URL("/login-callback", origin).href);
+const returnDomains = appOrigins.map(origin => new URL(origin).hostname);
+
+// OAuth redirect configuration: exact login URLs versus domains for other returns.
+// https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps", {
+  oAuthApp: {
     name: "My App",
-    // Exact login callback URLs, including the path; must match the authorization request.
-    allowedRedirectUris: ["https://my-app.example.com/login-callback"],
-    // Hostnames without scheme or path; allow returns from non-authentication Wix-hosted
-    // flows such as checkout to any URL under these domains.
-    allowedRedirectDomains: ["my-app.example.com"],
-  } }, accessToken);   // oAuthApp.id is the visitor clientId
+    // Login callbacks: the authorization request's redirect URI must match exactly.
+    allowedRedirectUris: loginCallbacks,
+    // Returns from Wix-hosted flows: hostnames only, allowing URLs under each domain.
+    allowedRedirectDomains: returnDomains,
+  },
+}, accessToken);
+const clientId = oAuthApp.id; // Public visitor client ID, used by the frontend client above.
+
+// If destinations change later, update this OAuth app rather than creating another.
+// Read its existing lists and merge new entries before updating, preserving old entries.
+// https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-oauth-app
+
+// In the frontend, choose destinations for the environment the visitor is using:
+// const loginCallback = new URL("/login-callback", window.location.origin).href;
+// const returnUrl = new URL("/", window.location.origin).href;
+// Implement the login callback route and use loginCallback in the authorization request.
+// For Wix-hosted flows, pass returnUrl as callbacks.postFlowUrl in the redirect session.
+// The allowed lists above permit these destinations; each request chooses its destination.
+// Navigate to the returned redirectSession.fullUrl, then handle the return in your app.
+// Read the complete flow and its prerequisites before implementing:
+// https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api
 ```
-
-
-Replace the example addresses with your app's actual destinations.
-
-These lists allow destinations; they do not choose the return URL. Supply the login callback in
-its authorization request and the return URL in the redirect session's `callbacks.postFlowUrl`.
-Include the actual preview and published destinations when supporting both environments.
-If the destinations become known later, update the existing OAuth app, preserving its current
-entries. See [Allow Redirect URIs and Domains](https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains).
-
-For visitor flows that send people to Wix-hosted pages and back to your app, read
-[Redirect to Wix-Hosted Pages Using the REST API](https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api)
-before implementing the flow. It covers redirect sessions, return URLs, and allowed redirect
-domains, and links to the OAuth app setup prerequisites.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -68,7 +68,7 @@ const wx = (() => { const m = { exports: {} };
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token)` — the site's full dynamic context report; inline when small, otherwise a saved Markdown file with a heading outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration guides (`guides`) and ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration articles (included in `hits`) and ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -121,10 +121,10 @@ await wx.search("stores v3 update product");   // → [{ method, endpoint: "VERB
 // exploring an unfamiliar product? browse is deterministic — menuUrl alone orients (children + counts);
 // filter before listing methods. browse works for both portals this skill uses — REST
 // (api-reference) and WIX_HEADLESS (go-headless) — just pass that portal's menu URL.
-await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings.md",
+await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 // non-REST portal — same call, that portal's menu URL:
-await wx.browse("https://dev.wix.com/docs/go-headless/authentication.md", { depth: 2 });
+await wx.browse("https://dev.wix.com/docs/go-headless/authentication", { depth: 2 });
 
 // don't know where it lives? search ranks, never says "no match" — drop wrong-product hits
 await wx.search("pause a pricing plan subscription and resume it");

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -18,7 +18,7 @@ does not inherit an earlier turn's context, so re-read it before building on or 
 **A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) and follow
 the one that fits. A recipe states outright what an API does not support, which fields a bulk call
 actually writes, and the order two calls have to go in — from the schemas alone those get re-derived
-several errors at a time. A REST search ranks the matching recipes too (`recipes` in its return), so
+several errors at a time. A REST search ranks the matching recipes too (recipe entries in `hits`), so
 they also surface from a search that began at the methods.
 
 ## What are you building?
@@ -68,7 +68,7 @@ const wx = (() => { const m = { exports: {} };
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token)` — the site's full dynamic context report; inline when small, otherwise a saved Markdown file with a heading outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration articles (included in `hits`) and ranks the **management recipes**, returned as their own `recipes` list ahead of the methods — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration articles (included in `hits`) and ranks the **management recipes**, returned as recipe entries in the same `hits` list as methods and articles — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself
@@ -111,7 +111,7 @@ await wx.mgmtRecipes("stores");   // a category's list — or any task word: wx.
 ```
 
 A recipe carries prerequisites, order, and gotchas that no method page has. A REST search ranks
-these same recipes as its own `recipes` list, so they surface either way.
+these same recipes in its `hits` list, so they surface either way.
 
 ### Find a method — search and browse
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -292,18 +292,16 @@ the returned `id` IS the `clientId`:
 const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
   { oAuthApp: {
     name: "My App",
+    // Exact login callback URLs, including the path; must match the authorization request.
     allowedRedirectUris: ["https://my-app.example.com/login-callback"],
+    // Hostnames without scheme or path; allow returns from non-authentication Wix-hosted
+    // flows such as checkout to any URL under these domains.
     allowedRedirectDomains: ["my-app.example.com"],
   } }, accessToken);   // oAuthApp.id is the visitor clientId
 ```
 
 
-Replace the example addresses with your app's actual destinations:
-
-- `allowedRedirectUris` contains exact login callback URLs, including the path. The
-  authorization request's redirect URI must match an entry exactly.
-- `allowedRedirectDomains` contains hostnames, without a scheme or path, for returns from
-  non-authentication Wix-hosted flows such as checkout. It allows return URLs under those domains.
+Replace the example addresses with your app's actual destinations.
 
 These lists allow destinations; they do not choose the return URL. Supply the login callback in
 its authorization request and the return URL in the redirect session's `callbacks.postFlowUrl`.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -292,3 +292,8 @@ the returned `id` IS the `clientId`:
 const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
   { oAuthApp: { name: "My App" } }, accessToken);   // oAuthApp.id is the visitor clientId
 ```
+
+For visitor flows that send people to Wix-hosted pages and back to your app, read
+[Redirect to Wix-Hosted Pages Using the REST API](https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api)
+before implementing the flow. It covers redirect sessions, return URLs, and allowed redirect
+domains, and links to the OAuth app setup prerequisites.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -311,13 +311,28 @@ const clientId = oAuthApp.id; // Public visitor client ID, used by the frontend 
 // Read its existing lists and merge new entries before updating, preserving old entries.
 // https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-oauth-app
 
-// In the frontend, choose destinations for the environment the visitor is using:
-// const loginCallback = new URL("/login-callback", window.location.origin).href;
-// const returnUrl = new URL("/", window.location.origin).href;
-// Implement the login callback route and use loginCallback in the authorization request.
-// For Wix-hosted flows, pass returnUrl as callbacks.postFlowUrl in the redirect session.
-// The allowed lists above permit these destinations; each request chooses its destination.
-// Navigate to the returned redirectSession.fullUrl, then handle the return in your app.
-// Read the complete flow and its prerequisites before implementing:
+```
+
+Frontend redirect example, using the visitor client above after obtaining a visitor token:
+
+```js
+import { wix } from "@/lib/wixClient";
+
+// Flow prerequisites and supported intents:
 // https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api
+export async function redirectToWix(intent, returnPath = "/") {
+  // Pass the intent required by the selected flow's schema.
+  const response = await wix("/headless/v1/redirect-session", {
+    method: "POST",
+    body: JSON.stringify({
+      ...intent,
+      callbacks: {
+        postFlowUrl: new URL(returnPath, window.location.origin).href,
+      },
+    }),
+  });
+  if (!response.ok) throw new Error(`${response.status} ${await response.text()}`);
+  const { redirectSession } = await response.json();
+  window.location.assign(redirectSession.fullUrl);
+}
 ```

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -137,7 +137,7 @@ function recipeFile(title, docsUrl) {
 // filter before listing methods. An oversized listing is saved with its outline.
 async function browse(menuUrl, { include, filter, depth } = {}) {
   const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
-    menu_url: menuUrl.replace(/\.md(?=\?|$)/, ""), ...(include && { include }),
+    menu_url: menuUrl, ...(include && { include }),
     ...(filter && { name_filter: filter }), ...(depth && { depth }),
   });   // 404 "No menu node found" ⇒ re-orient a level up
   if (content.length <= BUDGET) return content;

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -230,8 +230,16 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
   // page sits in the REST corpus, so the same page can rank two or three times
   const seen = new Set();
   const recipeRows = recipeHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
-  const uniq = [...hits, ...guideHits].filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
-  const out = { ...saved, hits: [...recipeRows, ...uniq] };
+  const restRows = hits.filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
+  const headlessRows = guideHits.filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
+  const uniq = [...restRows, ...headlessRows];
+  const ordered = [];
+  // Two from each search in turn, retaining the service's order within each source.
+  const groups = [recipeRows, restRows, headlessRows];
+  for (let i = 0; i < Math.max(...groups.map(rows => rows.length)); i += 2) {
+    for (const rows of groups) ordered.push(...rows.slice(i, i + 2));
+  }
+  const out = { ...saved, hits: ordered };
   // over budget, shed enrichment rather than structure — clip would drop the whole shape, and
   // every title, URL and line number stays useful with the outlines gone
   for (const shed of [() => recipeRows.forEach(r => delete r.calls),

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -148,20 +148,23 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
 // Semantic search — ranks, never says "no match". The reduced hits come back inline AND the full
 // raw content is saved for grep/window follow-ups. { type } picks the corpus, one per request:
 // REST (default) · SKILLS · WIX_HEADLESS · SDK · VELO · CLI · WDS · BUILD_APPS · OVERVIEW ·
-// BUSINESS_SOLUTIONS. A REST search also runs SKILLS — the management recipes rank as their own
+// BUSINESS_SOLUTIONS. A REST search also runs SKILLS and WIX_HEADLESS — the management recipes rank as their own
 // hits, ahead of the methods, and land in the saved file whole. Each method hit lists the worked
 // requests the docs publish for it; every line number reads with read_file(path, offset: <line>).
-async function search(term, { type = "REST", max = 5, lines = 0, recipes = type === "REST" } = {}) {
+async function search(term, { type = "REST", max = 5, lines = 0, recipes = type === "REST", headless = type === "REST" } = {}) {
   const ask = (document_type, maximum_results) =>
     post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
       // lines_in_each_result 0 skips the server's per-section budget, which otherwise cuts every
       // code example after the first 30 lines and the rest after 5, and every recipe at 20 —
       // the saved file would carry stubs instead of the requests and flows the hits point at
       { search_term: term, document_type, maximum_results, lines_in_each_result: lines });
-  const [main, skills] = await Promise.all([ask(type, max),
-    recipes ? ask("SKILLS", 3).catch(() => null) : null]);   // a recipe corpus miss must not fail the search
+  const [main, skills, headlessDocs] = await Promise.all([ask(type, max),
+    recipes ? ask("SKILLS", 3).catch(() => null) : null,
+    headless ? ask("WIX_HEADLESS", 3).catch(() => null) : null]);   // a recipe corpus miss must not fail the search
   const recipeText = skills?.content ? skills.content.trimEnd() + "\n" : "";
-  const content = recipeText + main.content;
+  const guideText = headlessDocs?.content || "";
+  const guideOffset = recipeText.length + main.content.length + 1;
+  const content = recipeText + main.content + "\n" + guideText;
   const nl = [];   // newline offsets — a match's char offset becomes its line in the saved file
   for (let i = content.indexOf("\n"); i >= 0; i = content.indexOf("\n", i + 1)) nl.push(i);
   const lineAt = (off) => { let lo = 0, hi = nl.length; while (lo < hi) { const m = (lo + hi) >> 1; nl[m] < off ? lo = m + 1 : hi = m; } return lo + 1; };
@@ -211,23 +214,42 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
       .trim().replace(/\s+/g, " ").slice(0, 220),
     ...(examples.length && { examples }),
   }; }).filter(h => h.docsUrl);
+  let guideCursor = guideOffset;
+  const guideHits = guideText.split(/\n---\n+(?=#### )/).map(b => {
+    const start = content.indexOf(b, guideCursor); guideCursor = start + b.length;
+    return {
+      article: (b.match(/^## (?:Resource|Article): (.+)$/m) || [])[1],
+      docsUrl: (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
+      line: start < 0 ? 1 : lineAt(start),
+    };
+  }).filter(h => h.docsUrl);
   const saved = save("search-" + term.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40) + ".md", content);
-  if (!hits.length && !recipeHits.length) return clip({ ...saved, head: content.slice(0, 1200),
+  if (!hits.length && !recipeHits.length && !guideHits.length) return clip({ ...saved, head: content.slice(0, 1200),
     note: `no method blocks parsed — raw head above; wx.bash("grep -in 'term' ${saved.path}") for the rest` });
   // one URL, one row: a long article is indexed in chunks that rank separately, and a stray skills
   // page sits in the REST corpus, so the same page can rank two or three times
   const seen = new Set();
   const recipeRows = recipeHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
+  const guides = guideHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
   const uniq = hits.filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
-  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), hits: uniq };
+  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), ...(guides.length && { guides }), hits: uniq };
   // over budget, shed enrichment rather than structure — clip would drop the whole shape, and
   // every title, URL and line number stays useful with the outlines gone
   for (const shed of [() => recipeRows.forEach(r => delete r.calls),
                       () => recipeRows.forEach(r => delete r.steps),
                       () => uniq.forEach(h => { if (h.examples) h.examples = h.examples.slice(0, 3); }),
-                      () => uniq.forEach(h => delete h.examples)]) {
+                      () => uniq.forEach(h => delete h.examples),
+                      () => uniq.forEach(h => delete h.gist)]) {
     if (JSON.stringify(out).length <= BUDGET) break;
     shed();
+  }
+  // Keep a usable index for every corpus even when URL lengths exhaust the budget.
+  while (JSON.stringify(out).length > BUDGET) {
+    const rows = [uniq, recipeRows, guides].filter(r => r.length > 1)
+      .sort((a, b) => JSON.stringify(b).length - JSON.stringify(a).length)[0];
+    if (!rows) break;
+    rows.pop();
+    out.note = "Additional results are in the saved file.";
   }
   return clip(out);
 }

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -210,8 +210,11 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
     method,
     endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // "VERB url" — read the verb + url; call wx.<verb>(url, body, token)
     docsUrl,
-    gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
-      .trim().replace(/\s+/g, " ").slice(0, 220),
+    gist: (() => {
+      const description = ((b.match(/## Method Description:\s*\n([\s\S]*?)(?=\n## |$)/) || [])[1] || "")
+        .trim().replace(/\s+/g, " ");
+      return description.length > 160 ? description.slice(0, 159).trimEnd() + "…" : description;
+    })(),
     ...(examples.length && { examples }),
   }; }).filter(h => h.docsUrl);
   let guideCursor = guideOffset;

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -148,8 +148,8 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
 // Semantic search — ranks, never says "no match". The reduced hits come back inline AND the full
 // raw content is saved for grep/window follow-ups. { type } picks the corpus, one per request:
 // REST (default) · SKILLS · WIX_HEADLESS · SDK · VELO · CLI · WDS · BUILD_APPS · OVERVIEW ·
-// BUSINESS_SOLUTIONS. A REST search also runs SKILLS and WIX_HEADLESS — the management recipes rank as their own
-// hits, ahead of the methods, and land in the saved file whole. Each method hit lists the worked
+// BUSINESS_SOLUTIONS. A REST search also runs SKILLS and WIX_HEADLESS — the management recipes appear as recipe hits
+// alongside methods and articles, and land in the saved file whole. Each method hit lists the worked
 // requests the docs publish for it; every line number reads with read_file(path, offset: <line>).
 async function search(term, { type = "REST", max = 5, lines = 0, recipes = type === "REST", headless = type === "REST" } = {}) {
   const ask = (document_type, maximum_results) =>
@@ -231,7 +231,7 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
   const seen = new Set();
   const recipeRows = recipeHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
   const uniq = [...hits, ...guideHits].filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
-  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), hits: uniq };
+  const out = { ...saved, hits: [...recipeRows, ...uniq] };
   // over budget, shed enrichment rather than structure — clip would drop the whole shape, and
   // every title, URL and line number stays useful with the outlines gone
   for (const shed of [() => recipeRows.forEach(r => delete r.calls),
@@ -242,12 +242,13 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
     if (JSON.stringify(out).length <= BUDGET) break;
     shed();
   }
-  // Keep a usable index for every corpus even when URL lengths exhaust the budget.
+  // Preserve at least one result of each kind when the inline index needs trimming.
   while (JSON.stringify(out).length > BUDGET) {
-    const rows = [uniq, recipeRows].filter(r => r.length > 1)
-      .sort((a, b) => JSON.stringify(b).length - JSON.stringify(a).length)[0];
-    if (!rows) break;
-    rows.pop();
+    const kind = h => h.recipe ? "recipe" : h.method ? "method" : "article";
+    const counts = out.hits.reduce((n, h) => (n[kind(h)] = (n[kind(h)] || 0) + 1, n), {});
+    const index = out.hits.findLastIndex(h => counts[kind(h)] > 1);
+    if (index < 0) break;
+    out.hits.splice(index, 1);
     out.note = "Additional results are in the saved file.";
   }
   return clip(out);

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -137,7 +137,7 @@ function recipeFile(title, docsUrl) {
 // filter before listing methods. An oversized listing is saved with its outline.
 async function browse(menuUrl, { include, filter, depth } = {}) {
   const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
-    menu_url: menuUrl, ...(include && { include }),
+    menu_url: menuUrl.replace(/\.md(?=\?|$)/, ""), ...(include && { include }),
     ...(filter && { name_filter: filter }), ...(depth && { depth }),
   });   // 404 "No menu node found" ⇒ re-orient a level up
   if (content.length <= BUDGET) return content;

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -195,6 +195,20 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
              ...(steps.length && { steps: steps.slice(0, 6) }),
              ...(calls.length && { calls: calls.slice(0, 4) }) };
   }).filter(h => h.docsUrl && h.recipe);
+  const articleOutline = (block, start) => {
+    const outline = [];
+    let fenced = false, offset = 0;
+    for (const row of block.split("\n")) {
+      if (/^\s*(```|~~~)/.test(row)) fenced = !fenced;
+      const heading = !fenced && row.match(/^#{2,3} (.+)$/);
+      if (heading && !/^(Resource|Article|Article Link|Article Content):/.test(heading[1])) {
+        outline.push({ title: heading[1].slice(0, 64), line: lineAt(start + offset) });
+        if (outline.length === 3) break;
+      }
+      offset += row.length + 1;
+    }
+    return outline;
+  };
   let cursor = recipeText.length;
   const hits = main.content.split(/\n---\n+(?=#### )/).map(b => {
     const start = content.indexOf(b, cursor); cursor = start + b.length;
@@ -205,7 +219,8 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
     // the REST corpus mixes guides in with the methods — an article has no method header, so
     // name it from its own title rather than returning a row of nulls
     if (!method) return { article: (b.match(/^## (?:Resource|Article): (.+)$/m) || [])[1], docsUrl,
-                          line: start < 0 ? 1 : lineAt(start) };
+                          line: start < 0 ? 1 : lineAt(start),
+                          outline: articleOutline(b, start) };
     return {
     method,
     endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // "VERB url" — read the verb + url; call wx.<verb>(url, body, token)
@@ -224,6 +239,7 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
       article: (b.match(/^## (?:Resource|Article): (.+)$/m) || [])[1],
       docsUrl: (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
       line: start < 0 ? 1 : lineAt(start),
+      outline: articleOutline(b, start),
     };
   }).filter(h => h.docsUrl);
   const saved = save("search-" + term.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40) + ".md", content);
@@ -249,7 +265,8 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
                       () => recipeRows.forEach(r => delete r.steps),
                       () => uniq.forEach(h => { if (h.examples) h.examples = h.examples.slice(0, 3); }),
                       () => uniq.forEach(h => delete h.examples),
-                      () => uniq.forEach(h => delete h.gist)]) {
+                      () => uniq.forEach(h => delete h.gist),
+                      () => uniq.forEach(h => delete h.outline)]) {
     if (JSON.stringify(out).length <= BUDGET) break;
     shed();
   }

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -230,9 +230,8 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
   // page sits in the REST corpus, so the same page can rank two or three times
   const seen = new Set();
   const recipeRows = recipeHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
-  const guides = guideHits.filter(r => !seen.has(r.docsUrl) && seen.add(r.docsUrl));
-  const uniq = hits.filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
-  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), ...(guides.length && { guides }), hits: uniq };
+  const uniq = [...hits, ...guideHits].filter(h => !seen.has(h.docsUrl) && seen.add(h.docsUrl));
+  const out = { ...saved, ...(recipeRows.length && { recipes: recipeRows }), hits: uniq };
   // over budget, shed enrichment rather than structure — clip would drop the whole shape, and
   // every title, URL and line number stays useful with the outlines gone
   for (const shed of [() => recipeRows.forEach(r => delete r.calls),
@@ -245,7 +244,7 @@ async function search(term, { type = "REST", max = 5, lines = 0, recipes = type 
   }
   // Keep a usable index for every corpus even when URL lengths exhaust the budget.
   while (JSON.stringify(out).length > BUDGET) {
-    const rows = [uniq, recipeRows, guides].filter(r => r.length > 1)
+    const rows = [uniq, recipeRows].filter(r => r.length > 1)
       .sort((a, b) => JSON.stringify(b).length - JSON.stringify(a).length)[0];
     if (!rows) break;
     rows.pop();


### PR DESCRIPTION
Expand OAuth redirect setup and add a generic frontend redirect-session example with verified Markdown documentation links. Default REST searches now also fetch Headless guides in parallel with management recipes, returning a separate guides index into the complete saved results. Explicit portal selection remains available.

Validation: replayed three conversation searches; both checkout queries surfaced the REST redirect guide. All responses stayed below 4,000 characters and guide line references matched saved content. JavaScript syntax and git diff --check passed. No live site changes.