### PR TITLE
fix(wix-app): teach the withDashboard bootstrap, and let a required name be looked up

### DIFF
--- a/skills/wix-app/references/DASHBOARD_PAGE.md
+++ b/skills/wix-app/references/DASHBOARD_PAGE.md
@@ -35,6 +35,67 @@ The CLI generates the folder, `page.tsx`, the builder file, the UUID, and the `s
 
 **Then, before writing UI:** resolve the package root and `Read <pkgRoot>/dist/dts-bundle/index.json` once, per [Prerequisites](WIX_PATTERNS_DOCS.md#prerequisites). Each Bash call is a fresh shell, so if you keep the path in a variable, set it again in every call.
 
+### The `withDashboard` bootstrap — required for any routed page
+
+If the page routes — anything using `PatternsReactRouter`, which is every `CollectionPage` + `EntityPage` pair — the routing component **must** be wrapped in `withDashboard`, and in a Wix CLI app you must supply its `location` yourself.
+
+`PatternsReactRouter` reads the current location through bex-core's dashboard context, which only `withDashboard` renders, from its `location` prop. Under the Yoshi BM flow the host passes that prop; **in a CLI app nothing passes props to a dashboard page component**, so the page reads it from the dashboard SDK. Omit either half and the router throws at render time:
+
+> It appears that `PatternsReactRouter` is being used incorrectly. Please refer to the documentation to ensure proper implementation.
+
+Nothing catches this before runtime — `tsc` and `wix build` both pass, because neither renders the page.
+
+The scaffolded `page.tsx` does the subscribing; the routing component is a separate file it renders:
+
+```tsx
+// page.tsx — the scaffolded entry point
+import { useEffect, useState, type FC } from 'react';
+import { dashboard, type PageLocation } from '@wix/dashboard';
+import { WixDesignSystemProvider } from '@wix/design-system';
+import '@wix/design-system/styles.global.css';
+import { App } from './App';
+
+const DashboardPage: FC = () => {
+  const [location, setLocation] = useState<PageLocation>();
+
+  useEffect(() => {
+    const subscription = dashboard.observeState((_pageParams, environmentState) => {
+      setLocation(environmentState.pageLocation);
+    });
+    return () => subscription.disconnect();
+  }, []);
+
+  return (
+    <WixDesignSystemProvider>
+      {location ? <App location={location} /> : null}
+    </WixDesignSystemProvider>
+  );
+};
+
+export default DashboardPage;
+```
+
+```tsx
+// App.tsx — the routed component
+import { withDashboard } from '@wix/patterns';
+import { WixPatternsProvider } from '@wix/patterns/provider';
+import { PatternsReactRouter, PatternsReactRoute } from '@wix/patterns/router';
+
+export const App = withDashboard(() => (
+  <WixPatternsProvider>
+    <PatternsReactRouter>
+      <PatternsReactRoute type="collection" path="/" element={<MyCollectionPage />} />
+      <PatternsReactRoute type="createEntity" path="/new" element={<MyEntityPage />} />
+      <PatternsReactRoute type="editEntity" path="/:id" element={<MyEntityPage />} />
+    </PatternsReactRouter>
+  </WixPatternsProvider>
+));
+```
+
+`withDashboard` is a `@wix/patterns` export re-exported from `@wix/bex-core`. It is documented in `dist/docs/WixPatternsProvider.md` and `dist/docs/PatternsReactRouter.md`; look it up by those doc names, not by its own.
+
+**Keep the wrapper even before you add a router.** Adding one later otherwise breaks the page in a way neither type checking nor bundling reports.
+
 ## Capabilities
 
 A dashboard page runs as the **Wix user** — see [Identity and Elevation Requirement](../SKILL.md#identity-and-elevation-requirement) before deciding where an SDK call runs.
@@ -66,7 +127,9 @@ Dashboard Pages cannot use `<Modal />`. For a true dialog overlay you **MUST** u
 
 > **🛑 The test — does the dialog create, update, or display one record this page lists?** If yes, it is an `EntityPage`, not a modal — whether those records come from a CMS collection or an existing Wix app's SDK. **A create / "add new" form is included**: it writes the record, so it is an `EntityPage` even though nothing is being edited yet. "It's a simple data-entry dialog, not an entity edit" is the wrong reading, and it is the single most common way the patterns-first rule gets dropped after the table is already correct.
 >
-> The `EntityPage` comes from `@wix/patterns`, reached via `usePatternsNavigate().navigateToEntityPage`, with `useEntityPage` owning fetch/save/validation and `@wix/patterns/form` owning form state. Its route is registered with `PatternsReactRoute` inside `PatternsReactRouter` — so do not hand-roll page location state to fake a second view (`useState<PageLocation>`, a `location` cast on `withDashboard`); that is the router's job, and needing the cast is the signal you skipped it.
+> The `EntityPage` comes from `@wix/patterns`, reached via `usePatternsNavigate().navigateToEntityPage`, with `useEntityPage` owning fetch/save/validation and `@wix/patterns/form` owning form state. Its route is registered with `PatternsReactRoute` inside `PatternsReactRouter` — so do not branch on the page location yourself to fake a second view. Switching on `location.pathname`, or casting it, to decide which of two screens to render is the router's job, and reaching for that is the signal you skipped it.
+>
+> This is **not** a ban on `useState<PageLocation>`. Reading the location once in `page.tsx` and handing it to `withDashboard` is the [required bootstrap](#the-withdashboard-bootstrap--required-for-any-routed-page) — the router cannot work without it. The anti-pattern is using that state *instead of* routes, not feeding it to the router.
 >
 > **If this page lists nothing** — a settings page, an embedded-script config page — the rule does not apply and a dashboard modal is a normal choice. But "I built the list without `@wix/patterns`" is not an exception: a page that lists records should be a `CollectionPage`.
 >

--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -137,6 +137,10 @@ For **multiple pages**, use the `@wix/patterns` routing solution (`PatternsReact
 
 Not every real `@wix/patterns` export is in this index — only the names these guides actually reference. If a name you need genuinely isn't there, **stop and say so rather than falling back to `node_modules`.**
 
+**The one exception — a name the docs themselves require.** If a doc file you just read tells you to use an export, that export is not optional, and neither index resolves it, you are not guessing: the indexes have a gap. Read its declaration in `<pkgRoot>/dist/types/index.d.ts` to find where it is re-exported from, use it, and **say in your summary that the name was missing from both indexes** so the gap gets fixed. Do not silently stop — a page that omits a required export can typecheck, build and still throw at render time, which is a worse outcome than the lookup you skipped.
+
+This exception is narrow on purpose. It does not license browsing `node_modules` for a name you merely suspect exists, or for props — those come from the bundle, and a name absent from the docs *and* the bundle *and* the prose you just read is a name you should not be using.
+
 ### Reading doc files
 
 `Read <pkgRoot>/dist/docs/index.json` to resolve a name to its doc file — or a `symbols` alias, for the cases where the Storybook title doesn't match the export (`ExportTo.md` documents `ExportButton`) — then `Read <pkgRoot>/dist/docs/<file>.md` directly, the whole file, not piped through `head`. It covers more names than the bundle index above: it's produced for every documented component, not just the curated ones.


### PR DESCRIPTION
## What

Teach the `withDashboard` bootstrap in `DASHBOARD_PAGE.md`, fix a warning that reads as forbidding it, and give the `node_modules` prohibition a narrow exception for a name the docs themselves require.

## Why

Found by the `dashboard-skill-audit` loop on 2026-09-06, run `b5dfb037`, finding **P3** (the same item this audit series has carried as **S4** since `DOCS-AUDIT-c646996e.md`, now with evidence).

**Cost:** 15 hand probes into `node_modules` across two windows — 7 for `withDashboard`, 8 for `PageLocation`, four of them returning nothing — inside the two phases that consumed **240 s of a 464 s run** and 84 % of its thinking tokens. The run's longest single reasoning turn, 48.6 s, sits immediately before the first `PageLocation` probe.

**Root cause, in this repo:**

1. `references/DASHBOARD_PAGE.md:69` names `withDashboard` exactly once — inside a warning against hand-rolling page location — and the skill never teaches the bootstrap positively.
2. That warning names `useState<PageLocation>` as the anti-pattern. It is also the **first line of the required bootstrap**, so as written the skill forbids the only correct implementation.
3. `references/WIX_PATTERNS_DOCS.md:46` — "Never inspect `node_modules` by hand" — and `:138` — "stop and say so rather than falling back to `node_modules`."

Followed literally, the agent stops and reports that `withDashboard` is not covered, and ships a page that throws at render time behind a clean `tsc` and a clean `wix build`. It disobeyed instead, and that is the only reason the run produced working code. A rule whose compliant outcome is worse than its violation needs an escape hatch.

## Evidence

`withDashboard` is mandatory. `@wix/patterns@1.462.0`, `dist/docs/WixPatternsProvider.md:67-70`:

> `withDashboard` does more than set up context for convenience: it publishes the page location that `PatternsReactRouter` reads … a page that routes and omits `withDashboard` throws at render time. Keep it even if you are not routing yet — adding a router later otherwise breaks the page in a way neither type checking nor bundling reports.

And it is reachable from nothing an agent is told to read:

```
docs/index.json        167 entries — not a key, not in any entry's `symbols` list
dts-bundle/index.json   96 entries — absent
dist/dts-bundle/**                 — zero files mention it
dist/types/index.d.ts:158          — the only place it exists, re-exported from @wix/bex-core
```

What run `b5dfb037` did at 17:08:25 → 17:10:13 and 17:12:45 → 17:12:59, having already read both docs at 17:07:53 and 17:08:04:

```
grep -rl "withDashboard" node_modules/@wix/patterns/dist/types/*.d.ts
grep -rn "withDashboard\b" node_modules/@wix/bex-core/dist/types/react/*.d.ts   → no matches
find node_modules/@wix/bex-core -iname "*.d.ts" | xargs grep -ln "withDashboard"
…11 more
```

At 17:13:50 it wrote the correct answer, which is what this PR now teaches directly.

## Changes

- **`DASHBOARD_PAGE.md` — new `### The withDashboard bootstrap` under `## Scaffold`.** Both files (`page.tsx` subscribing via `observeState`, `App.tsx` wrapped in `withDashboard`), typed, with the runtime error quoted so the failure is recognisable when it happens. Notes that it is documented under `WixPatternsProvider.md` / `PatternsReactRouter.md`, not under its own name — which is the workaround until cairo #5847 lands.
- **`DASHBOARD_PAGE.md:69` — the warning, sharpened.** The anti-pattern is *branching* on the location to fake a second view, not holding it in state. Now says so, and says explicitly that feeding it to `withDashboard` is required, with a link to the bootstrap.
- **`WIX_PATTERNS_DOCS.md:138` — a narrow exception.** When a doc you just read requires an export, and neither index resolves it, read its declaration, use it, and **report the gap**. Kept deliberately narrow: it does not license browsing for a name you merely suspect exists, or for props.

The "report the gap" half matters as much as the "use it" half — that report is what feeds this audit loop. Silent compliance produced neither the code nor the signal.

- Time profile: https://claude.ai/code/artifact/e3f62c82-78bd-4c43-a7aa-f4680d587dc6 — where the run's 464 s actually went
- Full audit: https://claude.ai/code/artifact/832d7454-e816-4308-92ea-fd5f93901421 — finding **P3**, the causal chain, and the cairo findings

The audit is also committed as `DOCS-AUDIT-b5dfb037.md` (separate PR), following `DOCS-AUDIT-c646996e.md`. It closes that document's verification checklist: **this run hit zero TypeScript errors**, confirming P0 (#1232), P3 and P7 (#1257) all work.

## Overlap with #1247

**#1247 already edits `references/DASHBOARD_PAGE.md`**, along with seven other dashboard-page references. This PR touches the `## Scaffold` section and the modal callout at :69. Whichever merges second should rebase — happy to fold this into #1247 instead if that is easier for the reviewer; say the word.

## Scope

Documentation only. The upstream fixes that would make the lookup work without an exception are in cairo: #5847 (make `withDashboard` resolvable by symbol) and #5848 (type-check the fenced examples, and type the bootstrap examples themselves). This PR is worth landing regardless — it removes the doc lookup from the critical path entirely.

Does not touch the still-open carried items from the previous audit: **P5** (`CODE_QUALITY.md`'s 5-flag claim) is already in flight as #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
