### PR TITLE
Set requested currency before storefront seeding

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -27,6 +27,7 @@ const ctx = { token: accessToken };
 // result — not a still-generating /__generating__/<id>.png placeholder (Wix can't fetch that).
 // generate_image runs in the background while you build, so the urls are ready by seed time.
 const result = await seed.setupStore(ctx, {
+  currency: "EUR", // Use the user's requested currency; omit when none was specified.
   products: [
     // physical — a shipped item: carries `quantity` (the default type)
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
@@ -40,8 +41,19 @@ const result = await seed.setupStore(ctx, {
   ],
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
 });
-// result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached }
+// result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached,
+//   currency: { requested, actual, status, warnings } }
 ```
+
+The optional `currency` sets the site's payment currency before product creation. Product prices
+are numbers in that currency; changing currency does not convert existing amounts. When omitted,
+the current site currency is preserved.
+Currency update or verification failures do not stop seeding: inspect `result.currency.status`
+and `warnings`, report the unresolved setting, and use the connector skill to resolve it. An
+unknown actual currency is `null`; do not replace currency symbols to simulate a successful update.
+If you change currency after seeding, verify existing product prices against the cart: existing
+products may still report the previous currency even when new products and carts use the new one.
+
 
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -431,22 +431,57 @@ async function attachProductImages(ctx, items) {
   });
 }
 
+// Site-wide payment currency; product amounts are not converted when this changes.
+// https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties.md
+async function configureCurrency(ctx, requested) {
+  const result = { requested: requested ?? null, actual: null, status: "unchanged", warnings: [] };
+  if (requested !== undefined) {
+    try {
+      if (typeof requested !== "string" || !/^[A-Z]{3}$/.test(requested))
+        throw new Error("currency must be a three-letter uppercase ISO currency code");
+      await req(ctx, "/site-properties/v4/properties", {
+        method: "PATCH",
+        body: { properties: { paymentCurrency: requested }, fields: { paths: ["paymentCurrency"] } },
+      });
+      result.status = "updated";
+    } catch (error) {
+      result.status = "failed";
+      result.warnings.push(`Currency update failed; seeding continued: ${error.message}`);
+    }
+  }
+  try {
+    const snapshot = await req(ctx, "/site-properties/v4/properties", { method: "GET" });
+    result.actual = snapshot.properties?.paymentCurrency ?? null;
+    if (!result.actual) throw new Error("Site Properties returned no paymentCurrency");
+    if (requested !== undefined && result.actual !== requested) {
+      result.status = "failed";
+      result.warnings.push(`Requested currency ${requested}; site currency is ${result.actual}.`);
+    }
+  } catch (error) {
+    result.status = "failed";
+    result.warnings.push(`Currency verification failed; seeding continued: ${error.message}`);
+  }
+  return result;
+}
+
 /**
  * ONE-CALL seed: install → create products → categories → attach images, in the correct order,
  * keeping the created ids in memory (no hand-threading of product ids across exec calls). This is
  * the DEFAULT path — call it once instead of the individual functions.
  *
  * @param plan {{
+ *   currency?: string, // requested site payment currency; omitted preserves the current setting
  *   products: [{ name, description, price, compareAtPrice?, quantity?, inStock?, options?, imageUrl?, altText?,
  *                digitalFileUrl?, digitalFileName? }],
  *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
  * }}
- * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number }
+ * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number, currency: {requested,actual,status,warnings} }
  */
-async function setupStore(ctx, { products = [], categories = {} } = {}) {
+async function setupStore(ctx, { products = [], categories = {}, currency } = {}) {
   validateProducts(products);
   await installStoresApp(ctx); // installs if needed AND waits for the V3 catalog to be ready
 
+  const currencyResult = await configureCurrency(ctx, currency);
   const created = await bulkCreateProducts(ctx, products);
   const withNames = created.map((p, i) => ({ ...p, name: products[i]?.name }));
   const idByName = new Map(withNames.map((p) => [p.name, p.id]));
@@ -467,7 +502,7 @@ async function setupStore(ctx, { products = [], categories = {} } = {}) {
     .filter((it) => it.url);
   if (imageItems.length) await attachProductImages(ctx, imageItems);
 
-  return { products: withNames, categories: cats, imagesAttached: imageItems.length };
+  return { products: withNames, categories: cats, imagesAttached: imageItems.length, currency: currencyResult };
 }
 
 module.exports = {


### PR DESCRIPTION
Storefront builds could seed prices in the site's default currency while displaying the user's requested currency. Add optional `currency` to `setupStore`, updating and reading back Site Properties before creating products. Currency failures return status and warnings alongside the seed result without stopping seeding; omission preserves the current setting.

The seed guide shows the parameter and notes the observed mismatch when changing currency after products already exist.

Validation: live test-site PATCH/readback, new cart currency, and a product created after the change (admin and visitor reads). Six isolated setup-flow checks cover success, update failure, read failure, mismatch, omission, and invalid input; syntax and diff checks pass. Existing products still reported the old currency in live tests; no payment was completed.
