### PR TITLE
Add concise store currency recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -422,6 +422,9 @@ Drive the Wix Site Import agent to migrate an existing store or site from anothe
 
 ## Stores
 
+### [Change Store Currency](references/stores/change-store-currency.md)
+Changes the store's payment currency through Site Properties and explains delayed currency updates in catalog responses.
+
 ### [Add Store Pages to Site](references/stores/add-store-pages-to-site.md)
 Adds missing checkout and cart pages to a site when Stores app is installed. Used when store pages are missing after migration or setup issues.
 

--- a/skills/wix-manage/references/stores/change-store-currency.md
+++ b/skills/wix-manage/references/stores/change-store-currency.md
@@ -1,0 +1,10 @@
+---
+name: "Change Store Currency"
+description: "Changes the store's payment currency through Site Properties and explains delayed currency updates in catalog responses."
+---
+
+# Change Store Currency
+
+Use the [Site Properties currency recipe](https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties.md) to set the requested payment currency and read it back. Confirm the change with the user before updating it.
+
+Catalog product responses may temporarily show the previous currency after carts and checkout use the new one. Allow time for propagation, then recheck.

--- a/yaml/wix-manage-evals/stores/change-store-currency.yml
+++ b/yaml/wix-manage-evals/stores/change-store-currency.yml
@@ -1,0 +1,28 @@
+name: stores/change-store-currency
+description: Changes store payment currency through Site Properties and explains catalog propagation.
+triggerPrompt: >-
+  Change my store currency to EUR. I confirm this site-wide change. Keep existing
+  product price numbers unchanged, and tell me if catalog prices may take time to reflect it.
+tags: [stores]
+maxTokens: 30000
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/change-store-currency
+  - type: llm_judge
+    minScore: 7
+    prompt: >-
+      Verify the agent updates paymentCurrency to EUR through Site Properties with
+      the top-level field mask, reads back the setting, leaves product amounts unchanged,
+      and explains that catalog responses may temporarily lag behind carts and checkout.
+      Fail if it only relabels displayed prices or claims all catalog responses updated immediately.
+  - type: llm_judge
+    minScore: 7
+    prompt: >-
+      Rate the tool-call path from 0 to 10. Prefer following the linked Site Properties recipe,
+      a successful currency update, and readback. Penalize guessed currency endpoints,
+      using display-conversion settings instead of payment currency, repeated update attempts,
+      or unnecessary product rewrites. Identify the documentation gap behind any detour.

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -2,6 +2,10 @@ apiDoc:
   title: Wix Stores Management Recipes
 
   docs:
+    - file: ../../../skills/wix-manage/references/stores/change-store-currency.md
+      title: Change Store Currency
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
     - file: ../../../skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
       title: Find Products (Query and Search, Catalog V3)
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores


### PR DESCRIPTION
Add a short Stores recipe linking to the existing Site Properties currency recipe, with a note that catalog currency responses can temporarily lag behind carts and checkout. Includes the matching index, docs mapping, and evaluation scenario. API behavior was verified on a test site; local YAML parsing and diff checks passed. Automated evaluation is pending.