### PR TITLE
docs(wix-app): builders come from @wix/custom-extensions, not @wix/astro

### DIFF
--- a/skills/wix-app/references/APP_TOOLS.md
+++ b/skills/wix-app/references/APP_TOOLS.md
@@ -43,7 +43,7 @@ wix generate --params '{"extensionType":"SERVICE_PLUGIN","pluginType":"TOOLS_PRO
 Open the generated `src/extensions/backend/app-tools/my-tools/my-tools.extension.ts` and replace the stub tool with your own. Read [app-tools/TOOLS.md](app-tools/TOOLS.md) for the full field reference and constraints.
 
 ```typescript
-import { extensions } from '@wix/astro/builders';
+import { extensions } from '@wix/custom-extensions';
 
 export default extensions.appTools({
   id: '<generated-uuid>',

--- a/skills/wix-app/references/DATA_COLLECTION.md
+++ b/skills/wix-app/references/DATA_COLLECTION.md
@@ -36,7 +36,7 @@ The CLI manages a shared aggregator file (`data-collections.extension.ts`) that 
 The CLI scaffolds `<CollectionName>.ts` as a `satisfies DataCollection` default export. The scaffolded `fields` and `dataPermissions` are placeholders — replace them with your real schema, and set permissions per the [Context-Based Permission Rules](#context-based-permission-rules) before shipping.
 
 ```typescript
-import type { DataCollection } from '@wix/astro/builders';
+import type { DataCollection } from '@wix/custom-extensions';
 
 export const collectionIdSuffix = '<CollectionName>';
 
@@ -313,7 +313,7 @@ wix generate --params '{"extensionType":"DATA_COLLECTION","collectionName":"addi
 Edit the generated `src/extensions/backend/data-collections/additional-fees.ts`:
 
 ```typescript
-import type { DataCollection } from '@wix/astro/builders';
+import type { DataCollection } from '@wix/custom-extensions';
 
 export const collectionIdSuffix = 'additional-fees';
 

--- a/skills/wix-app/references/EXTENSION_REGISTRATION.md
+++ b/skills/wix-app/references/EXTENSION_REGISTRATION.md
@@ -26,7 +26,7 @@ Edit `src/extensions.ts` directly only when:
 Each extension file is a default export from `<folder>/<folder>.extension.ts`. In `src/extensions.ts`, import it as a default import using the camelCase of the folder name, then chain `.use(...)`:
 
 ```typescript
-import { app } from '@wix/astro/builders';
+import { app } from '@wix/custom-extensions';
 import myPage from './extensions/dashboard/pages/my-page/my-page.extension.ts';
 import contactCreated from './extensions/backend/events/contact-created/contact-created.extension.ts';
 

--- a/skills/wix-app/references/app-tools/TOOLS.md
+++ b/skills/wix-app/references/app-tools/TOOLS.md
@@ -17,7 +17,7 @@ wix generate --params '{"extensionType":"APP_TOOLS","name":"my-tools"}'
 The generated file lives at `src/extensions/backend/app-tools/my-tools/my-tools.extension.ts`. Replace the stub tool with your own:
 
 ```typescript
-import { extensions } from '@wix/astro/builders';
+import { extensions } from '@wix/custom-extensions';
 
 export default extensions.appTools({
   id: '<generated-uuid>',

--- a/skills/wix-app/references/site-plugin/EXAMPLES.md
+++ b/skills/wix-app/references/site-plugin/EXAMPLES.md
@@ -146,7 +146,7 @@ export default Panel;
 ### Extension Configuration (`best-seller-badge.extension.ts`)
 
 ```typescript
-import { extensions } from '@wix/astro/builders';
+import { extensions } from '@wix/custom-extensions';
 
 export default extensions.sitePlugin({
   id: 'f8e2a1b3-c4d5-6789-abcd-ef0123456789',


### PR DESCRIPTION
Audit **P3** / finding F4 from `DOCS-AUDIT-cd110e21.md`.

Six documented import sites tell the reader to import the extension builders from `@wix/astro/builders`. That package is not installed in a CLI app, and the subpath does not exist, so every one of these snippets fails to resolve.

| File | Line | Was |
|---|---|---|
| `references/DATA_COLLECTION.md` | 39 | `import type { DataCollection } from '@wix/astro/builders'` |
| `references/DATA_COLLECTION.md` | 316 | same |
| `references/EXTENSION_REGISTRATION.md` | 29 | `import { app } from '@wix/astro/builders'` |
| `references/APP_TOOLS.md` | 46 | `import { extensions } from '@wix/astro/builders'` |
| `references/app-tools/TOOLS.md` | 20 | same |
| `references/site-plugin/EXAMPLES.md` | 149 | same |

## Why `@wix/custom-extensions`, and why the root

All three names — `app`, `extensions`, `DataCollection` — live at the package root. Its exports map has no `/builders` subpath at all:

```json
{
  ".":             "./build/integration/builders.mjs",
  "./experimental":"./build/integration/builders-experimental.mjs",
  "./trusted":     "./build/integration/builders-trusted.mjs",
  "./node":        "./build/integration/node.mjs"
}
```

## Verification

Checked against a scaffolded app running `@wix/custom-extensions` 0.2.9 — `wix generate` emits these imports itself:

```ts
// src/extensions.ts
import { app } from '@wix/custom-extensions';

// src/extensions/backend/data-collections/data-collections.extension.ts
import { extensions } from '@wix/custom-extensions'

// src/extensions/backend/data-collections/employee-shifts.ts
import type { DataCollection } from '@wix/custom-extensions'
```

`@wix/astro` appears **0 times** in that app's lockfile; `@wix/custom-extensions` is a devDependency. Before this change the string `@wix/custom-extensions` appeared 0 times in the entire skill.

## Deliberately not changed

The remaining `Astro` mentions in `skills/wix-app` are prose about the runtime, which genuinely is Astro-powered — `BACKEND_API.md`, `EMBEDDED_SCRIPT.md`, `EXTENSION_REGISTRATION.md:14`, `DOCUMENTATION.md:29`. Those are correct as written.

## One related thing this PR does *not* fix

`references/BACKEND_API.md:49,246` tells the reader to type handlers with `APIRoute` from the bare `astro` package. In the scaffolded app I verified against, `astro` is not installed either — so that import likely fails the same way. There *is* an `APIRoute` in `@wix/custom-extensions/node` with a matching signature:

```ts
type APIRoute = (context: APIContext) => Promise<Response> | Response;
```

but `/node` is the build-integration entry, not the app-authoring surface, so I did not want to guess that it is the intended import for route files. Worth a separate look by someone who knows the intended contract — it was not in the audit's scope for this finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)