### PR TITLE
docs(wix-app): document aggregation, so SummaryBar stops shipping capped totals

### DIFF
--- a/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
@@ -16,7 +16,9 @@ Everything below is a real name in the installed `@wix/patterns`. Confirm the pr
 | Totals, counts, status breakdown above the table | `SummaryBar` |
 | Which subset the numbers describe | wire each metric to the collection's filter state so the count follows the filters |
 
-`SummaryBar` sits inside the page shell, above the collection. Compute the values from the same query the table uses, or a count query alongside it — a metric that disagrees with the visible rows is worse than no metric.
+`SummaryBar` sits inside the page shell, above the collection. Compute the values with `items.aggregate` — **not** by fetching rows and reducing them in the component. `items.query().limit()` caps at 1000, so a client-side `.reduce()` silently reports the total for the first 1000 records and never says it is wrong; a headline number that lies as the collection grows is worse than no metric. The recipe, with the `SummaryBar` case as its worked example: [WIX_DATA.md § Aggregation](../data-collection/WIX_DATA.md#aggregation).
+
+Pass the collection's current filter state into the aggregate's `.filter()` and re-run it when the filters change, so the numbers describe the rows on screen. A metric that disagrees with the visible rows is the other half of this failure.
 
 ## Focus — narrowing
 

--- a/skills/wix-app/references/data-collection/WIX_DATA.md
+++ b/skills/wix-app/references/data-collection/WIX_DATA.md
@@ -192,6 +192,125 @@ interface WixDataBulkError extends Error {
 }
 ```
 
+## Aggregation
+
+**Never compute a headline number by fetching rows and reducing them client-side.**
+`items.query().limit()` caps at 1000, so a `.reduce()` over the result silently reports the
+total for the first 1000 records and gives no warning that it is wrong. A `SummaryBar` fed
+that way is a metric that lies as soon as the collection grows — which is worse than
+showing no metric. Use `items.aggregate`; the server does the arithmetic over every
+matching row.
+
+### The chainable form — what a `SummaryBar` needs
+
+```ts
+import { items } from '@wix/data';
+
+const totals = await items
+  .aggregate('employee-shifts')
+  .filter(items.filter().eq('status', 'approved'))   // same predicate as the table
+  .sum('hours', 'totalHours')
+  .count('shiftCount')
+  .run();
+
+// `.run()` returns WixDataResult<Record<string, any>> — one row per group,
+// and a single row when there is no `.group()`.
+const row = totals.items[0] as { totalHours?: number; shiftCount?: number } | undefined;
+
+const summary = [
+  { title: 'Total hours', value: String(row?.totalHours ?? 0) },
+  { title: 'Shifts', value: String(row?.shiftCount ?? 0) },
+];
+```
+
+**Wire the aggregate to the same filters as the table.** A metric that disagrees with the
+visible rows is the defect this section exists to prevent — pass the collection's current
+filter state into `.filter()` and re-run the aggregate when it changes, exactly as
+`fetchData` does.
+
+### Grouping — a breakdown per value
+
+```ts
+const perEmployee = await items
+  .aggregate('employee-shifts')
+  .group('employeeName')
+  .sum('hours', 'totalHours')
+  .descending('totalHours')
+  .limit(5)
+  .run();
+
+const top = perEmployee.items as { employeeName: string; totalHours: number }[];
+```
+
+### `WixDataAggregate` — the chainable surface
+
+```ts
+interface WixDataAggregate {
+  // --- Grouping ---
+  group(...fields: string[]): WixDataAggregate;   // omit entirely for a whole-collection total
+
+  // --- Accumulators. `projectedField` names the output key; default is derived from the field ---
+  sum(field: string, projectedField?: string): WixDataAggregate;
+  avg(field: string, projectedField?: string): WixDataAggregate;
+  min(field: string, projectedField?: string): WixDataAggregate;
+  max(field: string, projectedField?: string): WixDataAggregate;
+  count(projectedField?: string): WixDataAggregate;
+
+  // --- Narrowing. `filter` runs before grouping, `having` after ---
+  filter(filter: WixDataFilter): WixDataAggregate;
+  having(filter: WixDataFilter): WixDataAggregate;
+
+  // --- Sorting and paging over the groups ---
+  ascending(...fields: string[]): WixDataAggregate;
+  descending(...fields: string[]): WixDataAggregate;
+  limit(limit: number): WixDataAggregate;
+  skip(skip: number): WixDataAggregate;
+
+  // --- Execute ---
+  run(options?: WixDataAggregateOptions): Promise<WixDataResult<Record<string, any>>>;
+}
+```
+
+`.run()` has no type parameter, so read its rows the same way you read a chainable
+`.find()`: cast once, at the boundary.
+
+### The object form, when you want the return type declared
+
+`items.aggregate` also takes a REST-shaped pipeline and is generic in the result:
+
+```ts
+interface ShiftTotals {
+  totalHours: number;
+}
+
+const res = await items.aggregate<ShiftTotals>('employee-shifts', {
+  stages: [
+    {
+      group: {
+        groupIds: [],                                     // [] = one group, the whole collection
+        accumulators: [
+          { resultFieldName: 'totalHours', sum: { expression: { fieldPath: 'hours' } } },
+        ],
+      },
+    },
+  ],
+});
+
+res.results[0];   // ShiftTotals | undefined  — note `results`, not `items`
+```
+
+Two things to know before reaching for it:
+
+- **`Result` is an assertion, not a check.** TypeScript does not verify that the pipeline
+  produces the shape you named, so a mismatch between `accumulators` and `Result` compiles
+  clean and fails at runtime. The chainable form's cast is no less safe.
+- **There is no `count` accumulator.** The object form offers only `avg`, `min`, `max`,
+  `sum`, `first`, `last` and `push`; to count, sum a constant
+  (`sum: { expression: { numeric: 1 } }`). The chainable `.count()` has no equivalent.
+
+Prefer the chainable form. Reach for the object form only when you need a pipeline stage the
+builder does not expose (`projection`, `unwindArray`, `objectToArray`, `cursorPaging`).
+
 ## Usage Examples
 
 ```typescript
@@ -258,7 +377,7 @@ const bulkResult = await items.bulkInsert("MyCollection", [
 
 | Operation | Required Scope |
 | --- | --- |
-| `get`, `query`, `count`, `distinct` | `SCOPE.DC-DATA.READ` |
+| `get`, `query`, `aggregate`, `count`, `distinct` | `SCOPE.DC-DATA.READ` |
 | `insert`, `update`, `save`, `remove`, `bulkInsert`, `bulkUpdate`, `bulkRemove` | `SCOPE.DC-DATA.WRITE` |
 
 ### Elevating permissions (backend only)


### PR DESCRIPTION
Audit **P0** / finding F1 from `DOCS-AUDIT-cd110e21.md` — the one finding that shipped silently wrong numbers rather than a loud error.

## The defect

`COLLECTION_TOOLKIT.md` states the requirement in the strongest language the toolkit has:

> **The two requirements below are not suggestions.**
> 1. A dashboard that reports on records shows aggregate numbers, not only rows.

It then gave exactly one piece of guidance on *how*:

> Compute the values from the same query the table uses, or a count query alongside it.

That is a client-side reduce, prescribed. `items.query().limit()` caps at 1000 — the skill's own `WixDataQuery` block says so — so a benchmark run followed the instruction faithfully and shipped a `SummaryBar` that fetches up to 1000 rows and `.reduce()`s the hours. Correct until the collection passes 1000 shifts, then silently wrong forever, with no warning surface.

No warning was available to the run, because the skill offered no other method: **`aggregate` appeared 0 times across the entire skill.** It has been in the SDK the whole time, in two forms.

## The fix

A `## Aggregation` section in `WIX_DATA.md` built around the `SummaryBar` case, and `COLLECTION_TOOLKIT.md` repointed at it. In the order a reader needs it:

- **The chainable recipe** as the default — `.filter().sum().count().run()` — with the note that `.filter()` must carry the collection's current filter state, or the numbers disagree with the visible rows. That is the *other* half of the failure the toolkit warns about, and it was the only half it explained.
- **`.group()`** for a per-value breakdown.
- **The full `WixDataAggregate` surface**, because none of it was documented and `.having()` vs `.filter()` (after vs before grouping) is not guessable.
- **The object form** and its `<Result>` generic, with the two caveats that actually decide when to reach for it.

`aggregate` also joins the READ row of the permissions table.

## The two caveats, since they are corrections to the audit

The audit reported the typed object form "narrows." Probing it says something more useful:

1. **`Result` is an assertion, not a check.** A pipeline summing `hours` into `totalHours`, typed as `WixDataAggregateResponse<{ shiftCount: number }>`, compiles clean and fails at runtime — nothing ties the pipeline shape to `Result`. So the doc does not sell the generic as safety; the chainable form's single boundary cast is no less safe.
2. **There is no `count` accumulator.** The object form's `Accumulator` union is `avg | min | max | sum | first | last | push` only. To count, you sum a constant: `sum: { expression: { numeric: 1 } }`. The chainable `.count()` has no object-form equivalent — which is a concrete reason to prefer the builder, not just a style preference.

## Verification

Against `@wix/data` 1.0.482 / `@wix/wix-data-items-sdk` 1.0.530, in a real scaffolded app under `@wix/custom-extensions/tsconfigs/base`. Every snippet in the new section was compiled, including the entire `WixDataAggregate` chain in one expression and the count-by-constant workaround. `tsc --noEmit` clean.

Closes this line of the audit's checklist for the next benchmark run:

> - [ ] `aggregate` appears in `WIX_DATA.md`, and a generated `SummaryBar` uses it instead of a capped client-side reduce.

## Note for the reviewer

Touches `WIX_DATA.md`, as does #1269 (audit P2, the method-table generics), in a different region of the file. `git merge-tree` confirms the two merge cleanly in either order.

Not addressed here: the audit also notes the live playground app still carries the capped reduce this doc gap produced. That is an app fix, not a skill fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
