### PR TITLE
Use require consistently for Base44 CommonJS helpers

### DIFF
--- a/scripts/test-commonjs-helpers.cjs
+++ b/scripts/test-commonjs-helpers.cjs
@@ -1,0 +1,66 @@
+// Run with node scripts/test-commonjs-helpers.cjs. No Wix API calls are made.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const root = path.resolve(__dirname, '..');
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'wix-commonjs-'));
+const helpers = [
+  ...['storefront/seed-store', 'bookings/seed-bookings', 'bookings/seed-rentals',
+    'blog/seed-blog', 'events/seed-events', 'portfolio/seed-portfolio',
+    'pricing-plans/seed-pricing-plans', 'restaurants/seed-restaurants'].map(entry => {
+    const [vertical, name] = entry.split('/');
+    return `wix-vibe-headless/references/${vertical}/seed/${name}.cjs`;
+  }),
+  'wix-base44-connector/scripts/utils.cjs',
+];
+
+try {
+  fs.writeFileSync(path.join(temp, 'package.json'), '{"type":"module"}');
+  for (const relative of helpers) {
+    const source = path.join(root, 'skills', relative);
+    const target = path.join(temp, '.agents/skills', relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+    // Match exec_tool's fresh node -e process inside an ESM application.
+    const output = execFileSync(process.execPath, ['-e', `
+      const helper = require(${JSON.stringify(target)});
+      const entries = Object.entries(helper).map(([key, value]) => [key, typeof value]);
+      process.stdout.write(JSON.stringify(entries));
+    `], { cwd: temp, encoding: 'utf8' });
+    const entries = JSON.parse(output);
+    assert.ok(entries.length > 0, `${relative}: empty exports`);
+    const expected = Object.entries(require(source)).map(([key, value]) => [key, typeof value]);
+    assert.deepEqual(entries, expected, `${relative}: exports changed in ESM app`);
+    assert.ok(entries.some(([, type]) => type === 'function'), `${relative}: no functions`);
+    if (relative.endsWith('seed-store.cjs')) {
+      assert.ok(entries.some(([name]) => name === 'setupStore'));
+    }
+    console.log(`${relative}: ${entries.length} exports`);
+  }
+
+  // Execute the actual connector loading example, including its first-touch path.
+  const guide = fs.readFileSync(path.join(root, 'skills/wix-base44-connector/SKILL.md'), 'utf8');
+  const section = guide.slice(guide.indexOf('## The helpers'));
+  const snippet = section.match(/```js\n([\s\S]*?)```/)[1];
+  for (const cached of [false, true]) {
+    const output = execFileSync(process.execPath, ['-e', `
+      (async () => {
+        global.fetch = async url => {
+          if (${cached}) throw new Error('Cached loader unexpectedly fetched');
+          if (!url.endsWith('/scripts/utils.cjs')) throw new Error('Wrong download path');
+          return { text: async () => require('node:fs').readFileSync(
+            ${JSON.stringify(path.join(root, 'skills/wix-base44-connector/scripts/utils.cjs'))}, 'utf8') };
+        };
+        ${snippet}
+        process.stdout.write(JSON.stringify(Object.keys(wx)));
+      })().catch(error => { console.error(error); process.exitCode = 1; });
+    `], { cwd: temp, encoding: 'utf8' });
+    assert.ok(JSON.parse(output).includes('search'));
+  }
+  console.log('Connector guide: first-touch download and cached require both passed');
+} finally {
+  fs.rmSync(temp, { recursive: true, force: true });
+}

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -55,11 +55,10 @@ reload each round; the module lives on disk next to this file, network only as f
 fallback):
 
 ```js
-const fs = require("fs"), P = ".agents/skills/wix-base44-connector/utils.js";
+const fs = require("fs"), P = ".agents/skills/wix-base44-connector/utils.cjs";
 if (!fs.existsSync(P)) { fs.mkdirSync(".agents/skills/wix-base44-connector", { recursive: true });
-  fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-base44-connector/scripts/utils.js")).text()); }
-const wx = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
+  fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-base44-connector/scripts/utils.cjs")).text()); }
+const wx = require(require("path").resolve(P));
 ```
 
 `wx` exports these helpers:

--- a/skills/wix-base44-connector/scripts/utils.cjs
+++ b/skills/wix-base44-connector/scripts/utils.cjs
@@ -3,11 +3,10 @@
 // back as { path, bytes, lines, outline } with the read tools pre-pointed at it.
 //
 // Load per exec (execs share no state) — from disk, network only as first-touch fallback:
-//   const fs = require("fs"), P = ".agents/skills/wix-base44-connector/utils.js";
+//   const fs = require("fs"), P = ".agents/skills/wix-base44-connector/utils.cjs";
 //   if (!fs.existsSync(P)) { fs.mkdirSync(".agents/skills/wix-base44-connector", { recursive: true });
-//     fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-base44-connector/scripts/utils.js")).text()); }
-//   const wx = (() => { const m = { exports: {} };
-//     new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
+//     fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-base44-connector/scripts/utils.cjs")).text()); }
+//   const wx = require(require("path").resolve(P));
 //
 // Read a saved file the way you already know how: wx.bash("grep -n 'term' <path> | head -40")
 // to find, read_file(<path>) with offset/limit to window (numbered lines, 45K cap — no exec

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -61,8 +61,8 @@ user-owned business, so never delete or overwrite existing content, even apparen
 cleanup truly seems needed, ask the user first.
 
 Seed by calling the storefront's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
-its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
+`require()` as shown there (build-time exec_tool); call its functions with your data. Gaps or an unexpected
 shape → the documentation skill available in your environment.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -42,8 +42,8 @@ user-owned business, so never delete or overwrite existing content, even apparen
 cleanup truly seems needed, ask the user first.
 
 Seed by calling the storefront's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
-its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
+`require()` as shown there (build-time exec_tool); call its functions with your data. Gaps or an unexpected
 shape → the documentation skill available in your environment.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -23,7 +23,7 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
   **shapes**, fieldsets, and paging.
 - `app/{components,pages,hooks,context}/…` — a **reference UI** (+ hooks/providers) built on that data
   layer; the field shapes and route patterns it uses (e.g. `/product/:slug`) are the data contract.
-- `seed/seed-*.js` — build-time **seeding functions** that create content.
+- `seed/seed-*.cjs` — build-time **seeding functions** that create content.
 - `INSTRUCTIONS.md` — the vertical's build guide + field-shape snippets; `seed/SEED.md` — how the seed
   module is run.
 
@@ -31,15 +31,15 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
 
 | vertical | `app/rest/` data layer | seed module |
 |---|---|---|
-| storefront | `wix-store-catalog.js`, `wix-store-cart.js` — products & variants; server cart + checkout redirect | `seed-store.js` |
-| bookings | `wix-bookings-services.js`, `wix-bookings-checkout.js` — services/categories/slots; booking + checkout | `seed-bookings.js` |
-| blog | `wix-blog.js` — posts (list + by-slug), categories, tags | `seed-blog.js` |
-| events | `wix-events-browse.js`, `wix-events-registration.js` — events & categories; RSVP / ticketing + checkout | `seed-events.js` |
-| portfolio | `wix-portfolio.js` — collections, projects, galleries | `seed-portfolio.js` |
-| restaurants | `wix-restaurants-menu.js`, `-ordering.js`, `-reservations.js` — menu; online ordering; table reservations | `seed-restaurants.js` |
+| storefront | `wix-store-catalog.js`, `wix-store-cart.js` — products & variants; server cart + checkout redirect | `seed-store.cjs` |
+| bookings | `wix-bookings-services.js`, `wix-bookings-checkout.js` — services/categories/slots; booking + checkout | `seed-bookings.cjs` |
+| blog | `wix-blog.js` — posts (list + by-slug), categories, tags | `seed-blog.cjs` |
+| events | `wix-events-browse.js`, `wix-events-registration.js` — events & categories; RSVP / ticketing + checkout | `seed-events.cjs` |
+| portfolio | `wix-portfolio.js` — collections, projects, galleries | `seed-portfolio.cjs` |
+| restaurants | `wix-restaurants-menu.js`, `-ordering.js`, `-reservations.js` — menu; online ordering; table reservations | `seed-restaurants.cjs` |
 | forms | `wix-forms.js`, `wix-forms-submissions.js` — any visitor-fillable form: read the schema; upload attachments, create a submission (schema accessors ship alongside in `lib/wix-form-schema-utils.js`) | *(none — REST shapes in `seed/SEED.md`)* |
-| cms | `wix-cms.js` — Wix Data collections: list / detail / filter | `seed-cms.js` |
-| pricing-plans | `wix-pricing-plans.js` — plans list + subscribe/checkout | `seed-pricing-plans.js` |
+| cms | `wix-cms.js` — Wix Data collections: list / detail / filter | *(none — see `seed/SEED.md`)* |
+| pricing-plans | `wix-pricing-plans.js` — plans list + subscribe/checkout | `seed-pricing-plans.cjs` |
 | members | `wix-members-auth.js` — custom login/signup (email+password, social, SSO), session, account | *(none — members sign up at runtime; nothing to seed)* |
 
 Anything in the docs about the **host's own setup** — copying files into `src/`, its `@/` alias, its

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -1,6 +1,6 @@
 # Blog — seeding
 
-Seed a Wix Blog (Blog V3) by **calling `seed-blog.js`** — don't hand-write the REST calls. It's
+Seed a Wix Blog (Blog V3) by **calling `seed-blog.cjs`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Blog
 seed operation. `require` it and call the functions with plain data.
 
@@ -15,11 +15,7 @@ for you (Blog binds the cover by the Wix Media file id, not a url).
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const result = await seed.setupBlog(ctx, {

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs
@@ -6,7 +6,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //   const memberId = await seed.getAuthorMemberId(ctx);                    // STEP 1 — required for every post
 //   const cats = await seed.createCategories(ctx, ["Recipes", "Brewing"]); // STEP 3 — only if the brief groups posts

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -1,6 +1,6 @@
 # Bookings — seeding
 
-Seed a Wix Bookings catalog by **calling `seed-bookings.js`** — don't hand-write the REST calls.
+Seed a Wix Bookings catalog by **calling `seed-bookings.cjs`** — don't hand-write the REST calls.
 It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix
 Bookings seed operation. Load it and call **`setupBookings` — the one-call path** — with plain data.
 
@@ -9,11 +9,7 @@ Bookings seed operation. Load it and call **`setupBookings` — the one-call pat
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ONE call: install → resolve staff → categories → services → CLASS sessions → images, all in the
@@ -103,12 +99,12 @@ same body; don't loop and don't re-create the ones that already succeeded.
 
 ## Rentals
 
-`seed-rentals.js` is the rentals half — the same transport, a different create order and payload.
+`seed-rentals.cjs` is the rentals half — the same transport, a different create order and payload.
 Wix Rentals has no APIs of its own, so a rental is a Bookings service with rentals-specific
 field values.
 
 ```js
-const seed = require("…/references/bookings/seed/seed-rentals.js");
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs");
 await seed.setupRentals(ctx, {
   resourceTypeName: "Meeting rooms",
   resources: ["Room A", "Room B"],              // parallel capacity = MORE RESOURCES

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs
@@ -8,7 +8,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   await seed.installBookingsApp(ctx);                          // if the site doesn't have Wix Bookings yet

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs
@@ -1,5 +1,5 @@
 // Rentals seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
-// A DELTA on seed-bookings.js: Wix Rentals has no APIs of its own, so a rental is a Bookings
+// A DELTA on seed-bookings.cjs: Wix Rentals has no APIs of its own, so a rental is a Bookings
 // service carrying rentals-specific field values. Everything about the transport, images and
 // error handling is the same; only the create order and the service payload differ.
 //
@@ -9,7 +9,7 @@
 // Usage (build-time exec_tool) — prefer `setupRentals`, which runs the whole flow in the one order
 // that works and threads the resource ids into each service for you:
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //   await seed.setupRentals(ctx, {
 //     resourceTypeName: "Meeting rooms",
@@ -27,7 +27,7 @@
 //   2. Resources created before the service, and their ids listed in `serviceResources[].resourceIds`.
 //   3. No category — a rental is surfaced by its `appId`, not by a Bookings category.
 //
-// Images are reused from seed-bookings.js — require both.
+// Images are reused from seed-bookings.cjs — require both.
 // Source recipe: wix-headless/references/inline-recipes/setup-rentals.md.
 
 const API = "https://www.wixapis.com";

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -1,6 +1,6 @@
 # Events — seeding
 
-Seed Wix Events (Events V3) by **calling `seed-events.js`** — don't hand-write the REST calls. It's
+Seed Wix Events (Events V3) by **calling `seed-events.cjs`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Events
 seed operation. `require` it and call the functions with plain data.
 
@@ -14,11 +14,7 @@ after create, and **publishing is one-way**. So per event: create DRAFT → (tic
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // DEFAULT — one call runs the whole flow per event (create DRAFT → tiers → publish), then resolves

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.cjs
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.cjs
@@ -8,7 +8,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   // setupEvents installs the Wix Events app first (installEventsApp) — base44 sites may not have it.

--- a/skills/wix-vibe-headless/references/members/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/members/seed/SEED.md
@@ -2,7 +2,7 @@
 
 **Nothing to seed.** Members login is the identity layer: members **self-register** through the
 Wix login page, so there is no member to create at build time and nothing lands in a `seeded`
-map. There is intentionally no `seed-*.js` here.
+map. There is intentionally no `seed-*.cjs` here.
 
 The members work is entirely **frontend wiring** (custom login, account area, gated content) —
 see this vertical's `INSTRUCTIONS.md` and the reference components.

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -1,6 +1,6 @@
 # Portfolio — seeding
 
-Seed a Wix Portfolio by **calling `seed-portfolio.js`** — don't hand-write the REST calls. It's
+Seed a Wix Portfolio by **calling `seed-portfolio.cjs`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix
 Portfolio seed operation. `require` it and call the functions with plain data.
 
@@ -17,11 +17,7 @@ first, then thread their real ids into each project.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const summary = await seed.setupPortfolio(ctx, {

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs
@@ -6,7 +6,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   const collections = await seed.createCollections(ctx, [{ title, description }]);        // STEP 1

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -1,6 +1,6 @@
 # Pricing Plans — seeding
 
-Seed Wix Pricing Plans (Plans V3) by **calling `seed-pricing-plans.js`** — don't hand-write the
+Seed Wix Pricing Plans (Plans V3) by **calling `seed-pricing-plans.cjs`** — don't hand-write the
 REST calls. It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts
 every Pricing Plans + Benefit Programs seed operation. `require` it and call the functions with
 plain data.
@@ -10,11 +10,7 @@ plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // setupPricingPlans installs the Wix Pricing Plans app first (idempotent) — base44 sites may not have it.

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs
@@ -7,7 +7,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   // Bookings is seeded FIRST — its service ids feed a plan's coverage (see SEED.md).

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -1,6 +1,6 @@
 # Restaurants — seeding
 
-Seed a Wix Restaurants site by **calling `seed-restaurants.js`** — don't hand-write the REST calls.
+Seed a Wix Restaurants site by **calling `seed-restaurants.cjs`** — don't hand-write the REST calls.
 It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every seed
 operation across the vertical's four recipes: the **menu** (always) plus three on-demand add-ons —
 **online ordering**, **table reservations**, and **experiences**. `require` it and call the functions
@@ -18,11 +18,7 @@ across exec calls. Online ordering and table reservations run only when the plan
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs");
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const result = await seed.setupRestaurants(ctx, {

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs
@@ -6,7 +6,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   // --- MENU (always; the seedable core) ---

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -1,6 +1,6 @@
 # Storefront — seeding
 
-Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
+Seed a Wix Stores catalog by **calling `seed-store.cjs`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
 seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
 Pass only the connector token and catalog data. The module handles site configuration internally;
@@ -13,11 +13,7 @@ the `pricing-plans` vertical, not here.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const fs = require("fs");
-// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
-const seed = (() => { const m = { exports: {} };
-  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js", "utf8"))(m, m.exports, require);
-  return m.exports; })();
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
 const ctx = { token: accessToken };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -5,7 +5,7 @@
 //
 // Usage (build-time exec_tool):
 //   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
-//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
 //   const ctx = { token: accessToken }; // Installation reads the site ID from the deployed Wix config.
 //   await seed.installStoresApp(ctx);
 //   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);


### PR DESCRIPTION
CommonJS helpers loaded as `.js` inside Base44 ES-module apps can return empty exports. Rename all eight Wix Vibe Headless seed helpers and the Wix Base44 Connector utility to `.cjs`, and replace the file-evaluation wrappers with ordinary `require()` examples throughout both skills. Helper logic is unchanged; frontend ES modules and existing `.cjs` installers retain their formats.

Validation: all nine helpers load with preserved export shapes in temporary ES-module apps on Node 20.19, 22.18 and 26.5. The actual connector loading example passes both mocked download and cached-file paths. No stale old helper references remain in the repository. No Wix mutations performed.

Existing installed skill copies are not migrated by this PR; updated guides require the matching updated helper files.
