### PR TITLE
docs(wix-app): stop recommending a deprecated component, and place the action ones

### DIFF
--- a/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
@@ -57,8 +57,9 @@ A dialog that creates, updates or displays one listed record is **not** a dashbo
 
 | Need | Component |
 | --- | --- |
-| Row actions | `PrimaryActions`, `SecondaryActions`, `More Actions`, `deleteSecondaryAction` |
-| Page-level button | `PrimaryPageButton`, `PrimaryActionButton` |
+| Page header actions | `PrimaryActions`, `SecondaryActions`, `More Actions` — passed to the page header's `primaryAction`, `secondaryActions` and `moreActions` slots |
+| Table toolbar button | `PrimaryActionButton` — the table's own `primaryActionButton` prop |
+| Row actions | `deleteSecondaryAction`, in the row's `actionCell` |
 | Acting on a multi-row selection | `MultiBulkActionToolbar`, `bulkActionModal` |
 | Immediate feedback, then reconcile | `useOptimisticActions`, `CollectionOptimisticActions` |
 | A banner above the table | `TableTopNotification` |

--- a/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
+++ b/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
@@ -65,6 +65,8 @@ If a name you genuinely need stays unresolved after that, stop and say so, and n
 
 A handful of names carry `"status": "unreachable"` with a message saying not to import them (the `...BaseProps` interfaces a component's props `extends`). Read those for the props they contribute; don't write an import for them.
 
+`status` also carries `"deprecated"`, and there the `statusMessage` names the replacement — `PrimaryPageButton` says *"Use `PrimaryActions` component instead."* Check it before you commit to a name — nothing else in the lookup path will stop you, since a deprecated component still compiles and still renders. If the index calls a name deprecated, use what its message names instead.
+
 ## Subpath entry points
 
 `@wix/patterns` is 31 entry points, not one namespace, and `/form` re-exports `@wix/bex-core/form`. To see what's importable from a specific one: `Read <pkgRoot>/dist/dts-bundle/exports/<subpath>.d.ts` directly (`.` is `exports/index.d.ts`; a nested one like `./testkit/backend` is `exports/testkit/backend.d.ts`). This only lists the curated names covered above — a file with nothing in it (a one-line comment) means no curated name lives on that subpath yet, not that the subpath doesn't exist.


### PR DESCRIPTION
P4 (skills half) from `DOCS-AUDIT-af949182.md`. The cairo half — making the deprecation visible in the component's own doc page — is wix-private/cairo#5863.

## The finding

`COLLECTION_TOOLKIT.md`'s "Act and confirm" table listed `PrimaryPageButton` as one of two choices for a page-level button. It is deprecated: its index entry reads `status: "deprecated"`, `"Use \`PrimaryActions\` component instead."` A benchmark run avoided it only because it read `dist/dts-bundle/index.json` and noticed the status field — the component's doc page says nothing, and the skill sanctions that lookup path too.

## Why the row needed more than a deletion

Dropping the name leaves the row wrong the other way, because the two names in it were not the same kind of thing and neither is the replacement:

| Name | What it actually is |
|---|---|
| `PrimaryActions` | the page header's `primaryAction` slot — and what the deprecation points at |
| `PrimaryActionButton` | the table's own `primaryActionButton` prop |

`PrimaryActions` was listed under **Row actions**, and so were `SecondaryActions` and `More Actions`. All three are page-header components (`primaryAction`, `secondaryActions`, `moreActions` — each confirmed from its own doc's examples), so that row named the wrong surface for every one of them, and the row-level `actionCell` it should have named appeared nowhere.

Split by the slot each one fills, with the slot named:

```
| Page header actions | `PrimaryActions`, `SecondaryActions`, `More Actions` — passed to the page header's `primaryAction`, `secondaryActions` and `moreActions` slots |
| Table toolbar button | `PrimaryActionButton` — the table's own `primaryActionButton` prop |
| Row actions | `deleteSecondaryAction`, in the row's `actionCell` |
```

## The general guard

`PATTERNS_BUNDLE_READING.md` already explains `status: "unreachable"`. It now covers `"deprecated"` as well — the `statusMessage` names the replacement, and nothing else in the lookup path stops you, since a deprecated component still compiles and still renders. That is the signal that catches the next one of these without the table having to be right about every name.

Deliberately not included: nothing here mentions the `unexported` field cairo#5863 adds to the index. That field does not exist until cairo releases, and the audit's P1 is a live example of what it costs when this skill runs ahead of the library it documents.

Verification from the audit: `grep -rn "PrimaryPageButton" skills/wix-app/` → 0 hits in the toolkit table (one remains, in the new `PATTERNS_BUNDLE_READING` note, as the worked example of a deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)