### PR TITLE
Align Base44 commerce guides around requested workflows

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -48,6 +48,14 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
+The shipped storefront provides catalog, cart, and checkout. Identify the additional workflows
+in the user's request and implement them alongside the storefront. If a workflow needs an
+external service or missing information, continue the work you can complete and identify the
+remaining dependency.
+
+For Wix features beyond the shipped storefront, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+
 **Successful STEP 1 verifies installation of the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
@@ -89,24 +97,19 @@ urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up
 
-**Never paste a Wix dashboard link or path.**
+### Preview
 
-**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
+Test the user's main workflow in the preview, including functionality beyond browsing and
+adding products to the cart. Report checks that could not be completed.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 
-## Later admin requests
+### Final text response
 
-When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
+**Never paste a Wix dashboard link or path.**
 
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const res = await fetch("https://www.wixapis.com/<api-path>", {
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ /* request body */ }),
-});
-return await res.json();
-```
+**Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, note that the seeded catalog is mock data they can edit, replace or delete, and state any requested workflows that remain unfinished and what is needed to complete them.
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the documentation skill available in your environment.
+## Follow-up changes
+
+For follow-up Wix requests, use the connector skill described in STEP 2.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -16,11 +16,10 @@ Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
 Install three skills — they land under `.agents/skills/`:
-- **`wix-vibe-headless`** — the storefront build + seed guide (STEPs 2–3): your main source of truth.
-- **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
-  catalogs, business setup).
-- **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
-  contracts, and Wix API documentation discovery.
+- **`wix-vibe-headless`** — storefront build instructions, hook/component contracts, and seeding modules.
+- **`wix-manage`** — REST recipes for managing and configuring the Wix site.
+- **`wix-base44-connector`** — Wix connector usage, API contracts, and documentation discovery.
+
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
 
@@ -42,8 +41,6 @@ const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pi
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
 ```
 
-Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
-
 ## STEP 2 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
@@ -56,11 +53,10 @@ remaining dependency.
 For Wix features beyond the shipped storefront, read and follow the installed connector skill at
 `.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
 
-**Successful STEP 1 verifies installation of the REST scaffolds in `src/rest/` and shipped storefront files in `src/`.** After reading `INSTRUCTIONS.md`, use its component outlines, interfaces, and theme guidance to build your presentation and wire it directly; don't rebuild the shipped client or inspect its source to confirm structure. Read only the relevant shipped file to resolve a specifically identified field/interface missing from the outlines or an observed runtime error.
-
-**`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
-(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
-rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
+Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
+The shipped files are already deployed and configured; you do not need to read their source or
+rebuild them. If you encounter an error after building the client, read or change whatever you
+need to diagnose and fix it.
 
 ## STEP 3 — Seed the storefront
 
@@ -86,13 +82,11 @@ Inline via exec_tool, `base44` is already declared — use it directly; do **not
 inline it throws *"Identifier 'base44' has already been declared."*).
 
 **Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step — consult official Wix API documentation using the documentation skill
-available in your environment if the module doesn't cover it.
+storefront seed module's image-attach step.
 
 **Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
 from the **completed** `generate_image` result and pass it straight into your single `setupStore`
-call (images included). A still-generating `/__generating__/<id>.png` placeholder is not a real url
-— Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
+call (images included). `generate_image` runs in the background while you build the client, so the
 urls are ready by the time you seed.
 
 ## STEP 4 — Wrap up

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -50,8 +50,8 @@ in the user's request and implement them alongside the storefront. If a workflow
 external service or missing information, continue the work you can complete and identify the
 remaining dependency.
 
-For Wix features beyond the shipped storefront, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+For code or actions not covered by this skill, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.
 
 Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
 The shipped files are already deployed and configured; you do not need to read their source or
@@ -66,8 +66,10 @@ cleanup truly seems needed, ask the user first.
 
 Seed by calling the storefront's ready-made seed module — read
 `.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
-`require()` as shown there (build-time exec_tool); call its functions with your data. Gaps or an unexpected
-shape → the documentation skill available in your environment.
+`require()` as shown there (build-time exec_tool); call its functions with your data.
+
+For code or actions not covered by this skill, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its
 access token and send it as a bearer token:
@@ -105,6 +107,6 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 ## Additional Wix functionality
 
-For any Wix functionality or changes not covered by the shipped code or seeding, during the
-initial build or later, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+During the initial build or later, use the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs for writing code
+or performing actions not covered by this skill.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -93,10 +93,9 @@ urls are ready by the time you seed.
 
 ### Preview
 
-Test the user's main workflow in the preview, including functionality beyond browsing and
-adding products to the cart. Report checks that could not be completed.
-
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+the platform replaces these automatically at turn end, with a stock fallback if generation
+fails. You can finish without waiting for those images or replacing their placeholder URLs.
 
 ### Final text response
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -93,7 +93,7 @@ urls are ready by the time you seed.
 
 ### Preview
 
-Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation
 fails. You can finish without waiting for those images or replacing their placeholder URLs.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -103,6 +103,8 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 **Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, note that the seeded catalog is mock data they can edit, replace or delete, and state any requested workflows that remain unfinished and what is needed to complete them.
 
-## Follow-up changes
+## Additional Wix functionality
 
-For follow-up Wix requests, use the connector skill described in STEP 2.
+For any Wix functionality or changes not covered by the shipped code or seeding, during the
+initial build or later, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -88,6 +88,8 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 **Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, note that the seeded catalog is mock data they can edit, replace or delete, and state any requested workflows that remain unfinished and what is needed to complete them.
 
-## Follow-up changes
+## Additional Wix functionality
 
-For follow-up Wix requests, use the connector skill described in STEP 1.
+For any Wix functionality or changes not covered by the shipped code or seeding, during the
+initial build or later, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -78,10 +78,9 @@ urls are ready by the time you seed.
 
 ### Preview
 
-Test the user's main workflow in the preview, including functionality beyond browsing and
-adding products to the cart. Report checks that could not be completed.
-
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+the platform replaces these automatically at turn end, with a stock fallback if generation
+fails. You can finish without waiting for those images or replacing their placeholder URLs.
 
 ### Final text response
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -30,6 +30,14 @@ Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
+The shipped storefront provides catalog, cart, and checkout. Identify the additional workflows
+in the user's request and implement them alongside the storefront. If a workflow needs an
+external service or missing information, continue the work you can complete and identify the
+remaining dependency.
+
+For Wix features beyond the shipped storefront, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+
 Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
 The shipped files are already deployed and configured; you do not need to read their source or
 rebuild them. If you encounter an error after building the client, read or change whatever you
@@ -70,18 +78,17 @@ urls are ready by the time you seed.
 
 ### Preview
 
+Test the user's main workflow in the preview, including functionality beyond browsing and
+adding products to the cart. Report checks that could not be completed.
+
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 
 ### Final text response
 
 **Never paste a Wix dashboard link or path.**
 
-**Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say; add only that the catalog you seeded is mock data they can edit, replace or delete.
+**Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, note that the seeded catalog is mock data they can edit, replace or delete, and state any requested workflows that remain unfinished and what is needed to complete them.
 
-## Follow-up changes and additional Wix features
+## Follow-up changes
 
-For follow-up Wix requests or features not covered by the shipped storefront, read and follow the
-already-installed `wix-base44-connector` skill at `.agents/skills/wix-base44-connector/SKILL.md`.
-It covers building on the connected Wix site: gathering site context, discovering APIs and their
-contracts, choosing visitor or admin authentication, and writing frontend and backend code, as
-well as management and configuration. Use it to research and implement these changes.
+For follow-up Wix requests, use the connector skill described in STEP 1.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -78,7 +78,7 @@ urls are ready by the time you seed.
 
 ### Preview
 
-Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation
 fails. You can finish without waiting for those images or replacing their placeholder URLs.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -35,8 +35,8 @@ in the user's request and implement them alongside the storefront. If a workflow
 external service or missing information, continue the work you can complete and identify the
 remaining dependency.
 
-For Wix features beyond the shipped storefront, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+For code or actions not covered by this skill, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.
 
 Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
 The shipped files are already deployed and configured; you do not need to read their source or
@@ -51,8 +51,10 @@ cleanup truly seems needed, ask the user first.
 
 Seed by calling the storefront's ready-made seed module — read
 `.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
-`require()` as shown there (build-time exec_tool); call its functions with your data. Gaps or an unexpected
-shape → the documentation skill available in your environment.
+`require()` as shown there (build-time exec_tool); call its functions with your data.
+
+For code or actions not covered by this skill, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its
 access token and send it as a bearer token:
@@ -90,6 +92,6 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 ## Additional Wix functionality
 
-For any Wix functionality or changes not covered by the shipped code or seeding, during the
-initial build or later, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+During the initial build or later, use the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs for writing code
+or performing actions not covered by this skill.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -16,11 +16,10 @@ Follow STEPs 1–3 below exactly.
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
 Install three skills — they land under `.agents/skills/`:
-- **`wix-vibe-headless`** — the storefront build guide (STEP 2): your main source of truth.
-- **`wix-manage`** — REST recipes for managing and configuring the site (install apps, seed
-  catalogs, business setup).
-- **`wix-base44-connector`** — building on Wix from the Base44 sandbox: site context, API
-  contracts, and Wix API documentation discovery.
+- **`wix-vibe-headless`** — storefront build instructions, hook/component contracts, and seeding modules.
+- **`wix-manage`** — REST recipes for managing and configuring the Wix site.
+- **`wix-base44-connector`** — Wix connector usage, API contracts, and documentation discovery.
+
 
 Run this through exec_tool, exactly as written — installs all three skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
 
@@ -42,40 +41,40 @@ const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pi
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
 ```
 
-Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
-
 ## STEP 2 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**REST scaffolds are already in `src/rest/`** (STEP 1 deployed them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+The shipped storefront provides catalog, cart, and checkout. Identify the additional workflows
+in the user's request and implement them alongside the storefront. If a workflow needs an
+external service or missing information, continue the work you can complete and identify the
+remaining dependency.
 
-**`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
-(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
-rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
+For Wix features beyond the shipped storefront, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+
+Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
+The shipped files are already deployed and configured; you do not need to read their source or
+rebuild them. If you encounter an error after building the client, read or change whatever you
+need to diagnose and fix it.
 
 ## STEP 3 — Wrap up
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-**Never paste a Wix dashboard link or path.**
+### Preview
 
-**Hand off with one call, before you write anything** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. It comes back telling you what to say.
+Test the user's main workflow in the preview, including functionality beyond browsing and
+adding products to the cart. Report checks that could not be completed.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
 
-## Later admin requests
+### Final text response
 
-When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
+**Never paste a Wix dashboard link or path.**
 
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const res = await fetch("https://www.wixapis.com/<api-path>", {
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ /* request body */ }),
-});
-return await res.json();
-```
+**Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, state any requested workflows that remain unfinished and what is needed to complete them.
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via the documentation skill available in your environment.
+## Follow-up changes
+
+For follow-up Wix requests, use the connector skill described in STEP 2.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -50,8 +50,8 @@ in the user's request and implement them alongside the storefront. If a workflow
 external service or missing information, continue the work you can complete and identify the
 remaining dependency.
 
-For Wix features beyond the shipped storefront, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+For code or actions not covered by this skill, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.
 
 Build the client using the component outlines, interfaces, and theme guidance in `INSTRUCTIONS.md`.
 The shipped files are already deployed and configured; you do not need to read their source or
@@ -76,6 +76,6 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 ## Additional Wix functionality
 
-For any Wix functionality or changes not covered by the shipped code or seeding, during the
-initial build or later, read and follow the installed connector skill at
-`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.
+During the initial build or later, use the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs for writing code
+or performing actions not covered by this skill.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -64,10 +64,9 @@ need to diagnose and fix it.
 
 ### Preview
 
-Test the user's main workflow in the preview, including functionality beyond browsing and
-adding products to the cart. Report checks that could not be completed.
-
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+the platform replaces these automatically at turn end, with a stock fallback if generation
+fails. You can finish without waiting for those images or replacing their placeholder URLs.
 
 ### Final text response
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -74,6 +74,8 @@ fails. You can finish without waiting for those images or replacing their placeh
 
 **Before writing your final text response, make one handoff call** — `search_base44_docs(query="how do I manage my store's products, orders and inventory?", prefer_dashboard=true)`. Use its handoff guidance, state any requested workflows that remain unfinished and what is needed to complete them.
 
-## Follow-up changes
+## Additional Wix functionality
 
-For follow-up Wix requests, use the connector skill described in STEP 2.
+For any Wix functionality or changes not covered by the shipped code or seeding, during the
+initial build or later, read and follow the installed connector skill at
+`.agents/skills/wix-base44-connector/SKILL.md` to discover APIs and implement the integration.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -64,7 +64,7 @@ need to diagnose and fix it.
 
 ### Preview
 
-Preview briefly. Images that are still generating may show `/__generating__/…` placeholders;
+Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation
 fails. You can finish without waiting for those images or replacing their placeholder URLs.
 

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -40,16 +40,9 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/blog/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens in
-`src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
-`--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
-`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, `font-display`). Those tokens
-are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
-here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
-a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
-base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -209,7 +202,6 @@ Fallback only — when you hit an error or need something not shown here: read t
 under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Blog`/`PostDetail`/category/tag pages to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Route by `slug` through the shipped helpers — never hand-build a post/category/tag URL. Display categories/tags by `.label` (not `.name`).
@@ -226,7 +218,6 @@ connector) — separate from this client build; run in parallel.
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] **Opened the vertical's data route(s)** (not just the home page) — `/blog` and a post detail page (plus a category/tag page) — and confirmed the shipped components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Blog`/`PostDetail`/`CategoryPage`/`TagPage` untouched; content clears the fixed chrome; `<TaxonomyProvider>` wraps the tree.
 - [ ] Feed lists live published posts (newest first) and paginates via `nextCursor`; post detail loads by `slug`; a bad slug shows the not-found state (no invented post).

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -51,16 +51,9 @@ the end). (Files missing? the install's `deploy` result lists what it wrote; re-
 `references/bookings/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens
-in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
-`--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
-`text-foreground`, `bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`,
-`font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
-pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
-`.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped JSX.** Build the Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it
-matches automatically. A dark brand is just base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -269,7 +262,6 @@ identical.
 - **One unit type per service.** A room rented by the hour *and* by the day is two services.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Services`/`ServiceDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
@@ -297,7 +289,6 @@ build; run in parallel.
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] **Opened `/services` and a service detail page** (not just the home page) and confirmed the shipped cards render themed (surface, text, brand color) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all
       routes; shipped `Services`/`ServiceDetail` untouched; content clears the fixed chrome.

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -47,16 +47,9 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/events/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens in
-`src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
-`--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
-`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, `font-display`). Those tokens
-are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
-here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
-a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
-base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -209,7 +202,6 @@ Fallback only — when you hit an error or need something not shown here: read t
 under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Events`/`EventDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Paid ticket checkout goes through the shipped reserve → `getTicketCheckoutUrl` redirect (the Wix-hosted ticket form) — never a hand-built registration/ticket/payment URL.
@@ -225,7 +217,6 @@ parallel.
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] Opened the vertical's data route(s) (not just the home page) and confirmed the shipped components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Events`/`EventDetail` untouched; content clears the fixed chrome.
 - [ ] Event grid renders live events; clicking a card opens the detail page by `slug`; visitor token persists across reload.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -72,16 +72,9 @@ fallback — a runtime error, or a field the snippets don't cover (see "Fallback
 > the top of the file — read that, not the whole body, if you need the contract.
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens
-in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
-`--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
-`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, `font-display`). Those tokens
-are **already set to the brand by the design phase**, so the shipped auth surfaces are themed with
-zero work here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way;
-**never add a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the
-Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it matches automatically. A
-dark brand is just base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -257,7 +250,6 @@ connection ids, a profile field these snippets don't have): read the relevant sh
 `src/rest/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - **Custom login only** — the member logs in on **your** UI; never redirect them to a Wix-hosted login page.
 - **One shared client** — login swaps the token set on `wix-client.js`; reuse it for everything so the
   member identity carries across the app. Never mint a second client or re-mint anonymously after login.
@@ -283,7 +275,6 @@ site's `metaSiteId` from the handoff / `ListWixSites`):
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] Opened the vertical's data route(s) (not just the home page) — `/login` and `/account` — and confirmed the shipped components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Login`/`Account`/`Callback` untouched; content clears the fixed chrome; `<MemberProvider>` wraps the tree; `<MemberMenu/>` in the header.
 - [ ] Sign-up: `register()` reaches `SUCCESS` (or `REQUIRE_EMAIL_VERIFICATION` handled via the code entry).

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -48,16 +48,9 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/portfolio/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens in
-`src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
-`--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
-`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, `font-display`). Those tokens
-are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
-here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
-a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
-base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -201,7 +194,6 @@ links its own reference page inline; the whole area is here:
 - Portfolio (collections, projects, project items): https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Portfolio`/`CollectionPage`/`ProjectDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
@@ -222,7 +214,6 @@ Seed collections and projects per `seed/SEED.md` — separate from this client b
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] Opened the vertical's data route(s) (`/portfolio`, a collection, a project) — not just the home page — and confirmed the shipped components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all
       routes; shipped `Portfolio`/`CollectionPage`/`ProjectDetail` untouched; content clears the fixed chrome.

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -51,16 +51,9 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/pricing-plans/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components carry **no palette of their own** — they render from base44's design tokens
-in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
-`--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
-`text-foreground`, `bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`,
-`font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
-pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
-`.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped JSX.** Build the Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it
-matches automatically. A dark brand is just base44's dark palette in `index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -211,7 +204,6 @@ Fallback only — when you hit an error or need something not shown here: read t
 file under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Plans`/`PlanDetail`/`MyPlans` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
@@ -233,7 +225,6 @@ in parallel.
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] Opened the vertical's data route(s) (not just the home page) and confirmed the shipped
       components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -51,17 +51,9 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/restaurants/app/` → `src/`.)
 
 
-## STEP 2 — Theme (nothing to style on the shipped components)
-The shipped components (menu, item dialog, order cart, reservations) carry **no palette of their
-own** — they render from base44's design tokens in `src/index.css` (`:root`/`.dark`: `--background`,
-`--foreground`, `--card`, `--primary`, `--muted`, `--border`, `--radius`, `--font-*`) via shadcn
-Tailwind classes (`bg-card`, `text-foreground`, `bg-primary`, `text-muted-foreground`,
-`border-border`, `rounded-lg`, `font-display`). Those tokens are **already set to the brand by the
-design phase**, so the shipped pages are themed with zero work here. To adjust the palette, edit
-`index.css` (`:root` **and** `.dark`) — the base44 way; **never add a parallel theme file (e.g. a
-`theme.css`) or restyle the shipped JSX.** Build the Home/Header you add (STEP 3) from the **same**
-base44 tokens/classes so it matches automatically. A dark brand is just base44's dark palette in
-`index.css` — no per-component work.
+## STEP 2 — Theme
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
@@ -229,7 +221,6 @@ Fallback only — when you hit an error or need something not shown here: read t
 file under `src/`, or look it up via the documentation skill available in your environment.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Menu`/`Reservations` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Order through the shipped cart: `addItem()` → `checkout()` (redirect-session) — never a hand-built `/checkout`, ordering, or reservation URL.
@@ -252,7 +243,6 @@ run in parallel.
 
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
-- [ ] Brand palette lives in `index.css` (`:root`/`.dark`); no parallel theme file; shipped components/pages not restyled or rewritten.
 - [ ] Opened `/menu` and `/reservations` (not just the home page) and confirmed the shipped components render themed (surface, text, brand) with images.
 - [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Menu`/`Reservations` untouched; content clears the fixed chrome; `<OrderCartProvider>` wraps the tree; `<OrderCartDrawer/>` mounted; `<OrderCartButton/>` in the header.
 - [ ] `getFullMenu()` renders real sections/items with prices, variants, modifiers, and labels; empty catalog shows the shipped empty state (no mock items).

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -35,8 +35,8 @@ after building the client, read or change whatever you need to diagnose and fix 
 If deployment failed or files are missing, re-run the install/deploy step.
 
 ## Theme
-Use the existing Base44 theme in `src/index.css` for new components. The shipped client already
-uses it; don't add a parallel theme or restyle shipped components.
+Use the existing Base44 theme in `src/index.css` so your pages and the shipped components
+share the same colors and typography.
 
 ## Presentation interfaces
 Build `pages/Shop.jsx`, `components/ProductGrid.jsx`, `components/ProductCard.jsx`, and
@@ -419,7 +419,6 @@ For a specifically missing field/interface or an observed runtime error, read on
 shipped file; catalog and cart helpers link their API references inline.
 
 ## Hard rules
-- Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file. Everything you build (Shop, grid, card, PDP, variant controls, Home) draws from the same tokens.
 - Header/footer live in a `Layout` around `<Outlet/>` (see **Routes and provider**) — keep shared chrome out of individual pages.
 - Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
 - Render live Wix data or your empty state — never mock products.


### PR DESCRIPTION
Commerce builds can finish a catalog while leaving the user’s defining workflow unimplemented. All three Base44 commerce entry guides now share guidance to implement requested workflows, use the connector skill for Wix integrations, report unfinished work, and handle still-generating images during preview.

Align build/source-reading guidance and preview-before-handoff order while preserving setup and seeding differences. Simplify theme guidance in storefront and seven other verticals to one sentence about sharing the existing Base44 theme; remove repeated theme rules and checklist entries.

Validation: compared shared sections, checked setup/no-seed distinctions and Markdown fences, and ran git diff --check. Documentation-only.
