### PR TITLE
docs(wix-app): warn that Patterns Router paths are page-relative

### DIFF
--- a/skills/wix-app/references/DASHBOARD_PAGE.md
+++ b/skills/wix-app/references/DASHBOARD_PAGE.md
@@ -33,6 +33,8 @@ wix generate --params '{"extensionType":"DASHBOARD_PAGE","title":"<title>","rout
 
 The CLI generates the folder, `page.tsx`, the builder file, the UUID, and the `src/extensions.ts` registration. After scaffolding, implement the page UI in the generated `page.tsx`.
 
+**If this page later adds a `PatternsReactRouter`** (see [Component Selection Order → Entity create and edit](../SKILL.md#entity-create-and-edit)), do not reuse `<route>` as a path prefix inside it. `PatternsReactRouter` reads a location already scoped to this page — a page scaffolded with `route: "shifts"` still sees its own router start at `path="/"`, not `path="/shifts"`. Registering `<PatternsReactRoute path="/shifts" .../>` (or `parentPath: '/shifts'` on `useEntityPage`, or `navigateToEntityPage({ path: '/shifts/new' })`) looks like the natural name to give the route but means the collection route never matches the page's actual initial location. See [Entity Page Toolkit](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the correct, page-relative paths.
+
 **Then, before writing UI:** resolve the package root and `Read <pkgRoot>/dist/dts-bundle/index.json` once, per [Prerequisites](WIX_PATTERNS_DOCS.md#prerequisites). Each Bash call is a fresh shell — re-set the path variable in every call.
 
 ## Capabilities

--- a/skills/wix-app/references/DASHBOARD_PAGE.md
+++ b/skills/wix-app/references/DASHBOARD_PAGE.md
@@ -1,10 +1,10 @@
 # Wix Dashboard Page Builder
 
-Dashboard pages appear in the site owner's Wix dashboard, where admins manage data, configure settings, and perform admin tasks.
+Dashboard pages appear in the site owner's Wix dashboard, where admins manage data and configure settings.
 
 ## Plan the Workflow Before the Components
 
-A dashboard page is a workflow, not a screen. The site owner has to understand the situation, focus on what needs attention, investigate one record, act, and see the result confirmed — so translate the prompt into those needs before choosing any component: which view fits, which drill-in surface, which data sources have to line up.
+A dashboard page is a workflow, not a screen. The site owner has to understand the situation, focus on what needs attention, investigate one record, act, and see the result confirmed — so translate the prompt into those needs before choosing any component.
 
 Do this first because a bare filtered table answers "what are all the records" and none of "how many", "which one needs my attention", or "why did this happen" — and a table is what you get by default if the workflow was never named. Read [UX Success Model](dashboard-page/UX_SUCCESS_MODEL.md) now, and run its evaluation checklist before calling the page done. Which component serves each need: [Collection Toolkit](dashboard-page/COLLECTION_TOOLKIT.md).
 
@@ -33,7 +33,7 @@ wix generate --params '{"extensionType":"DASHBOARD_PAGE","title":"<title>","rout
 
 The CLI generates the folder, `page.tsx`, the builder file, the UUID, and the `src/extensions.ts` registration. After scaffolding, implement the page UI in the generated `page.tsx`.
 
-**If this page later adds a `PatternsReactRouter`** (see [Component Selection Order → Entity create and edit](../SKILL.md#entity-create-and-edit)), do not reuse `<route>` as a path prefix inside it. `PatternsReactRouter` reads a location already scoped to this page — a page scaffolded with `route: "shifts"` still sees its own router start at `path="/"`, not `path="/shifts"`. Registering `<PatternsReactRoute path="/shifts" .../>` (or `parentPath: '/shifts'` on `useEntityPage`, or `navigateToEntityPage({ path: '/shifts/new' })`) looks like the natural name to give the route but means the collection route never matches the page's actual initial location. See [Entity Page Toolkit](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the correct, page-relative paths.
+**Never reuse `<route>` as a path prefix inside this page's `PatternsReactRouter`** — its location is already page-scoped, so a page scaffolded `route: "shifts"` still routes from `path="/"`, and `path="/shifts"` silently never matches. Page-relative paths: [Entity Page Toolkit](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
 
 **Then, before writing UI:** resolve the package root and `Read <pkgRoot>/dist/dts-bundle/index.json` once, per [Prerequisites](WIX_PATTERNS_DOCS.md#prerequisites). Each Bash call is a fresh shell — re-set the path variable in every call.
 
@@ -43,7 +43,7 @@ A dashboard page runs as the **Wix user** — see [Identity and Elevation Requir
 
 ### Data Operations (Wix Data SDK)
 
-See [Wix Data Reference](data-collection/WIX_DATA.md) in the Data Collection reference for complete documentation.
+See [Wix Data Reference](data-collection/WIX_DATA.md).
 
 - Read: `items.query('Collection').filter/sort.limit.find()` → `{ items, totalCount, hasNext }`
 - Write: `items.insert | update | remove`. Ensure collection permissions allow the action
@@ -52,7 +52,7 @@ See [Wix Data Reference](data-collection/WIX_DATA.md) in the Data Collection ref
 
 ### Dashboard APIs
 
-See [Dashboard API Reference](dashboard-page/DASHBOARD_API.md) for complete documentation including all methods, page IDs, and examples.
+See [Dashboard API Reference](dashboard-page/DASHBOARD_API.md) for all methods, page IDs, and examples.
 
 **Key methods**, all on the `dashboard` object from `@wix/dashboard` (signatures, page IDs, and examples in the reference above):
 
@@ -64,15 +64,15 @@ See [Dashboard API Reference](dashboard-page/DASHBOARD_API.md) for complete docu
 
 **CRITICAL: Using Modals in Dashboard Pages**
 
-Dashboard Pages cannot use `<Modal />`. For a true dialog overlay you **MUST** use a dashboard modal extension — never a React modal or the WDS `Modal` component. Reserve it for dialogs that neither write nor display a listed record (delete/discard confirmations, unsaved-changes prompts, notices), plus any dialog on a page that lists nothing (settings, config). They open via `dashboard.openModal()`, integrating with dashboard lifecycle, state, and navigation — see [Dashboard Modal reference](DASHBOARD_MODAL.md).
+Dashboard Pages cannot use `<Modal />`. For a true dialog overlay you **MUST** use a dashboard modal extension — never a React modal or the WDS `Modal` component. Reserve it for dialogs that neither write nor display a listed record (delete/discard confirmations, unsaved-changes prompts, notices), plus any dialog on a page that lists nothing (settings, config). They open via `dashboard.openModal()` — see [Dashboard Modal reference](DASHBOARD_MODAL.md).
 
-> **🛑 The test — does the dialog create, update, or display one record this page lists?** If yes, it is an `EntityPage`, not a modal — whether those records come from a CMS collection or an existing Wix app's SDK. **A create / "add new" form is included**: it writes the record, so it is an `EntityPage` even though nothing is being edited yet. "It's a simple data-entry dialog, not an entity edit" is the wrong reading, and it is the single most common way the patterns-first rule gets dropped after the table is already correct.
+> **🛑 The test — does the dialog create, update, or display one record this page lists?** If yes, it is an `EntityPage`, not a modal — whether those records come from a CMS collection or an existing Wix app's SDK. **A create / "add new" form is included**: it writes the record, so it is an `EntityPage` even though nothing is being edited yet. "It's a simple data-entry dialog, not an entity edit" is the wrong reading — the most common way the patterns-first rule gets dropped after the table is already correct.
 >
 > The `EntityPage` comes from `@wix/patterns`, reached via `usePatternsNavigate().navigateToEntityPage`, with `useEntityPage` owning fetch/save/validation and `@wix/patterns/form` owning form state. Its route is registered with `PatternsReactRoute` inside `PatternsReactRouter` — so do not hand-roll page location state to fake a second view (`useState<PageLocation>` as a stand-in for a route); that is the router's job, and needing it is the signal you skipped one.
 >
-> That's not a rule against `withDashboard`: the router **requires** it above itself and a `location` prop, which the page gets from `dashboard.observeState` (a Wix CLI app passes no props to dashboard pages). Skip it and `PatternsReactRouter` throws at open, though typecheck, bundling, and `wix preview` all pass. Read `<pkgRoot>/dist/docs/withDashboard.md`, or `PatternsReactRouter.md`'s **Requirements** section if that entry is missing from `dist/docs/index.json`.
+> That's not a rule against `withDashboard`: the router **requires** it above itself and a `location` prop, which the page gets from `dashboard.observeState` (a Wix CLI app passes no props to dashboard pages). Skip it and `PatternsReactRouter` throws at open, though typecheck, bundling, and `wix preview` all pass. Read `<pkgRoot>/dist/docs/withDashboard.md` (ships from 1.465.0; on older installs, `PatternsReactRouter.md`'s **Requirements**).
 >
-> **If this page lists nothing** — a settings page, an embedded-script config page — the rule does not apply and a dashboard modal is a normal choice. But "I built the list without `@wix/patterns`" is not an exception: a page that lists records should be a `CollectionPage`.
+> **If this page lists nothing** (settings, config) the rule doesn't apply. But "I built the list without `@wix/patterns`" is not an exception: a page that lists records should be a `CollectionPage`.
 >
 > See [Entity create and edit](../SKILL.md#entity-create-and-edit) and [WIX_PATTERNS_DOCS.md](WIX_PATTERNS_DOCS.md); for the `useEntityPage` call itself, [Entity Page Toolkit](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
 
@@ -80,7 +80,7 @@ Dashboard Pages cannot use `<Modal />`. For a true dialog overlay you **MUST** u
 
 ### Embedded Script Configuration API
 
-When building a dashboard page to configure an embedded script, see [Dynamic Parameters Reference](dashboard-page/DYNAMIC_PARAMETERS.md) for the implementation guide.
+When building a dashboard page to configure an embedded script, see [Dynamic Parameters Reference](dashboard-page/DYNAMIC_PARAMETERS.md).
 
 **Key points:**
 
@@ -96,7 +96,7 @@ Each output below names the library that owns each part. Confirm every patterns 
 
 **Request:** "Create a dashboard page to manage blog posts"
 
-**Output:** A `@wix/patterns` `CollectionPage` shell wrapping a `Table` driven by a collection state hook (`useTableCollection`), with search, row actions, and empty state from the collection's own APIs. Add and edit navigate to an `EntityPage` (`navigateToEntityPage` + `useEntityPage`). WDS only for the leaf UI inside cells and entity page cards. The provider lives in a parent component, in a separate file from the hook call.
+**Output:** A `@wix/patterns` `CollectionPage` wrapping a `Table` driven by `useTableCollection`, with search, row actions, and empty state from the collection's own APIs. Add and edit navigate to an `EntityPage`. WDS only for leaf UI inside cells and entity-page cards; the provider sits in a parent component, in its own file.
 
 ### Settings Form
 
@@ -108,13 +108,13 @@ Each output below names the library that owns each part. Confirm every patterns 
 
 **Request:** "Create an admin panel for customer orders"
 
-**Output:** A `@wix/patterns` `CollectionPage` + `Table`, with filters, sorting, and row actions from the collection APIs — **not** a hand-built WDS filter bar. Status badges are WDS leaf UI inside a cell. Viewing or editing an order opens an `EntityPage` via `usePatternsNavigate().navigateToEntityPage` — not a modal (see [Entity create and edit](../SKILL.md#entity-create-and-edit)). A Dashboard Modal appears only for the delete confirmation.
+**Output:** A `@wix/patterns` `CollectionPage` + `Table`, with filters, sorting, and row actions from the collection APIs — **not** a hand-built WDS filter bar. Status badges are WDS leaf UI in a cell. Viewing or editing an order opens an `EntityPage` via `navigateToEntityPage`, not a modal; a Dashboard Modal appears only for the delete confirmation.
 
 ### Embedded Script Configuration
 
 **Request:** "Create a settings page for the coupon popup embedded script"
 
-**Output:** A `@wix/patterns` `SettingsPage` shell with WDS form fields for popup headline, coupon code, minimum cart value, and enable toggle. `embeddedScripts.getEmbeddedScript()` loads the parameters on mount and `embeddedScripts.embedScript()` saves them back — both sides string-converted, per [Dynamic Parameters](dashboard-page/DYNAMIC_PARAMETERS.md).
+**Output:** A `@wix/patterns` `SettingsPage` with WDS form fields (popup headline, coupon code, minimum cart value, enable toggle). `embeddedScripts.getEmbeddedScript()` loads the parameters on mount, `embeddedScripts.embedScript()` saves them back — both sides string-converted, per [Dynamic Parameters](dashboard-page/DYNAMIC_PARAMETERS.md).
 
 
 ## API Spec Support

--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -41,9 +41,9 @@ Then confirm the installed version actually ships the bundle index:
 ls <pkgRoot>/dist/dts-bundle/index.json
 ```
 
-**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index (ships from **1.458.0**); upgrade and re-run the check. Prefer **1.464.0**+ — the lookups below assume it: 1.462.0 added `OffsetQuery` and fixed unreadable `@wix/bex-core` imports, and 1.464.0 documented `useEntityPage`'s create route. A missing *file* isn't the same as a name not being covered (see below) — the mechanism itself isn't available yet.
+**If it's missing, stop — do not look elsewhere for types or docs.** The installed `@wix/patterns` predates the index (ships from **1.458.0**); upgrade and re-run the check. Prefer **1.465.0**+ — the lookups below assume it (`OffsetQuery`, `useEntityPage`'s create route, `withDashboard.md`, a deprecation `status` in `dist/docs/index.json`, page-relative router paths). A missing *file* isn't the same as a name not being covered (see below).
 
-**Never inspect `node_modules` by hand** — no `ls`, `find`, or `cat` of an arbitrary path, including the sanctioned directories: never browse `dist/dts-bundle/` or `dist/docs/`. Every lookup below names the exact file to `Read` — go straight to it.
+**Never inspect `node_modules` by hand** — no `ls`, `find`, or `cat` of an arbitrary path, not even `dist/dts-bundle/` or `dist/docs/`. Every lookup below names the exact file to `Read` — go straight to it.
 
 ## Library Architecture
 
@@ -75,18 +75,17 @@ Common types only; `dist/dts-bundle/index.json` has the authoritative set. Creat
 | Provider | When to Use |
 | --- | --- |
 | `WixPatternsProvider` | **Default — start here.** Auto-detects the environment (BM, Essentials, Giza). |
-| `WixPatternsBMProvider` | Optional alternative for Yoshi BM Flow over Business Manager. |
-| `WixPatternsGizaProvider` | Optional alternative for Yoshi BM Flow over Giza. |
+| `WixPatternsBMProvider` / `WixPatternsGizaProvider` | Optional alternatives for Yoshi BM Flow (Business Manager / Giza). |
 | `WixPatternsEssentialsProvider` | Yoshi Fullstack. |
 | `WixPatternsBaseProvider` | App does **not** run under Giza/WixEssentials and you inject services (i18n, sentry) yourself. |
 
-**Confirm the import path in the provider's own bundle** — not all share a subpath (`WixPatternsEssentialsProvider`, `WixPatternsBaseProvider` are under `@wix/patterns/essentials`); the project's `package.json` identifies the flow.
+**Confirm the import path in the provider's own bundle** — not all share a subpath (`WixPatternsEssentialsProvider`, `WixPatternsBaseProvider` live under `@wix/patterns/essentials`).
 
 ### Keep Provider and Page Separate
 
-The provider **must** live in a parent component of the page content: hooks like `useTableCollection` need its context to already exist above them in the React tree.
+The provider **must** be a parent of the page content: hooks like `useTableCollection` need its context above them in the tree.
 
-**Wrong:** calling `useTableCollection` in the same component that renders `WixPatternsProvider` — the hook runs before the provider exists, so it throws at runtime even though the JSX nesting looks right.
+**Wrong:** calling `useTableCollection` in the component that renders `WixPatternsProvider` — the hook runs before the provider exists, so it throws at runtime even though the JSX looks right.
 
 **Correct — provider in root, page in a separate file:**
 ```tsx
@@ -124,7 +123,7 @@ function MyCollectionPage() {
 
 Keep the provider (and router, if any) in the app's root component and each page in its own file.
 
-For **multiple pages**, use the `@wix/patterns` routing solution (`PatternsReactRouter`, `PatternsReactRoute`, `usePatternsNavigate`) rather than a separate router. Read `PatternsReactRouter.md` and `withDashboard.md` for setup — the router reads page location from the dashboard context `withDashboard` renders, so it needs that wrapper above it with a `location` prop, and throws at render time without them. (No `withDashboard` entry in `dist/docs/index.json`? The installed version predates that doc — use `PatternsReactRouter.md`'s **Requirements** section instead.)
+For **multiple pages**, use the `@wix/patterns` routing solution (`PatternsReactRouter`, `PatternsReactRoute`, `usePatternsNavigate`) rather than a separate router. Read `PatternsReactRouter.md` and `withDashboard.md` for setup — the router reads page location from the dashboard context `withDashboard` renders, so it needs that wrapper above it with a `location` prop, and throws at render time without them. (it ships from **1.465.0**; no entry in `dist/docs/index.json` means an older install — use `PatternsReactRouter.md`'s **Requirements**.)
 
 ## How to Look Things Up
 
@@ -132,25 +131,25 @@ For **multiple pages**, use the `@wix/patterns` routing solution (`PatternsReact
 
 ### Finding the right name
 
-`Read <pkgRoot>/dist/dts-bundle/index.json` — one entry per name, grouped implicitly by its `category` field. Lookup is **exact-match only**: no fuzzy matching, no typo suggestions. If the exact key isn't there, scan the index you already hold for something close before concluding the name isn't covered.
+`Read <pkgRoot>/dist/dts-bundle/index.json` — one entry per name, grouped implicitly by its `category` field. Lookup is **exact-match only** — no fuzzy matching. If the exact key isn't there, scan the index you already hold for something close before concluding the name isn't covered.
 
-Not every real `@wix/patterns` export is in this index — only names these guides actually reference. If a needed name genuinely isn't there, **stop and say so rather than falling back to `node_modules`.**
+Not every real export is in this index — only names these guides reference. If a needed name genuinely isn't there, **stop and say so rather than falling back to `node_modules`.**
 
 ### Reading doc files
 
-`Read <pkgRoot>/dist/docs/index.json` to resolve a name to its doc file — or a `symbols` alias, for cases where the Storybook title doesn't match the export (`ExportTo.md` documents `ExportButton`) — then `Read <pkgRoot>/dist/docs/<file>.md` directly, the whole file, not piped through `head`. It covers more names than the bundle index above: produced for every documented component, not just the curated ones.
+`Read <pkgRoot>/dist/docs/index.json` to resolve a name to its doc file — or a `symbols` alias, for cases where the Storybook title doesn't match the export (`ExportTo.md` documents `ExportButton`) — then `Read <pkgRoot>/dist/docs/<file>.md` directly, the whole file, not piped through `head`. It covers more names than the bundle index above — every documented component, not just the curated ones.
 
 **Always check the import statement inside the doc** — not everything comes from `@wix/patterns` (some use subpaths, e.g. `@wix/patterns/provider`).
 
-A doc whose index entry has a `bundle` field does **not** list its props: its `### Props` points at that bundle instead. One without that field still carries its own table. Either way the doc owns the prose, variations, BI events, and import line.
+A doc whose index entry has a `bundle` field does **not** list its props — its `### Props` points at that bundle. One without it carries its own table. Either way the doc owns prose, variations, BI events, and the import line.
 
 ### Reading the file the index names
 
-The mechanics of the file an index names — types docs don't cover, one-line stubs that are answers rather than truncation, subpath entry points, cross-references, split compound-component docs — are in [Reading bundles and docs](dashboard-page/PATTERNS_BUNDLE_READING.md). Read it before your first `dist/dts-bundle/*.d.ts` of the session.
+The mechanics of the file an index names — types docs don't cover, one-line stubs that are answers rather than truncation, subpath entry points, cross-references, split compound docs — are in [Reading bundles and docs](dashboard-page/PATTERNS_BUNDLE_READING.md). Read it before your first `dist/dts-bundle/*.d.ts` of the session.
 
 ## The Collection → Entity Flow
 
-A collection page and its item form are **two patterns pages**, not a page plus a modal — hand-building the "add item" form as a dashboard modal is the most common way this goes wrong. Reserve modals for dialogs that neither write nor display a listed record (a delete or discard confirmation, an unsaved-changes prompt). **A create / "add new" form is not one of them** — it writes the record, so it's an `EntityPage` regardless of size or field count. A page that lists no records is outside this rule.
+A collection page and its item form are **two patterns pages**, not a page plus a modal. Reserve modals for dialogs that neither write nor display a listed record (a delete or discard confirmation, an unsaved-changes prompt); **a create / "add new" form is not one of them** — it writes the record, so it's an `EntityPage` regardless of size. A page that lists nothing is outside this rule — full test in [SKILL.md](../SKILL.md#entity-create-and-edit).
 
 | Step | What owns it |
 | --- | --- |
@@ -161,15 +160,13 @@ A collection page and its item form are **two patterns pages**, not a page plus 
 | Body layout | `EntityPage.Header`, `.MainContent`, `.AdditionalContent`, `.Card` |
 | The individual fields inside those cards | `@wix/design-system` (`FormField`, `Input`, `Text`) |
 
-Prefer `navigateToEntityPage` over a plain route change — the entity header renders before the fetch resolves.
+Prefer `navigateToEntityPage` over a plain route change — the entity header renders before the fetch resolves. **Every `path` above is page-relative**: the router roots at `path="/"` even on a page scaffolded `route: "shifts"`, so never repeat that name in a `path`, `parentPath`, or `navigateToEntityPage` call — it fails silently. See [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
 
-**Every `path` in that table is relative to this router's own mount point — the dashboard page's own root, not its `route` value from the scaffold.** A page scaffolded with `route: "shifts"` still roots its `PatternsReactRouter` at `path="/"`; reusing `"shifts"` as a path segment (`path="/shifts"`, `parentPath: '/shifts'`, `navigateToEntityPage({ path: '/shifts/new' })`) is the single most common way this table gets implemented wrong, and it fails silently — the collection route just never matches the page's actual initial location. See [DASHBOARD_PAGE.md](DASHBOARD_PAGE.md) and [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
-
-Read `EntityPage.md`, `useEntityPage.md` and `usePatternsNavigate.md` before implementing, plus [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the `useEntityPage` call itself — generics, `onSave`, params. Note `useCreateCollection` is **not** about creating items: it returns a function that initializes collection state.
+Read `EntityPage.md`, `useEntityPage.md` and `usePatternsNavigate.md` before implementing, plus [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the `useEntityPage` call itself (generics, `onSave`, params). Note `useCreateCollection` is **not** about creating items: it returns a function that initializes collection state.
 
 ## When Patterns Has No Equivalent
 
-A concept is only "missing" from patterns after you've checked `dist/dts-bundle/index.json` and `dist/docs/index.json` **and** searched by keyword within what you've read. Then, and only then:
+A concept is only "missing" from patterns after you've checked `dist/dts-bundle/index.json` and `dist/docs/index.json` **and** searched by keyword within what you've read. Then:
 
 1. Look the component up in `@wix/design-system` via the `wix-design-system` skill.
 2. Render it *inside* the patterns page shell / collection, not as a replacement for it.

--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -163,6 +163,8 @@ A collection page and its item form are **two patterns pages**, not a page plus 
 
 Prefer `navigateToEntityPage` over a plain route change — the entity header renders before the fetch resolves.
 
+**Every `path` in that table is relative to this router's own mount point — the dashboard page's own root, not its `route` value from the scaffold.** A page scaffolded with `route: "shifts"` still roots its `PatternsReactRouter` at `path="/"`; reusing `"shifts"` as a path segment (`path="/shifts"`, `parentPath: '/shifts'`, `navigateToEntityPage({ path: '/shifts/new' })`) is the single most common way this table gets implemented wrong, and it fails silently — the collection route just never matches the page's actual initial location. See [DASHBOARD_PAGE.md](DASHBOARD_PAGE.md) and [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md).
+
 Read `EntityPage.md`, `useEntityPage.md` and `usePatternsNavigate.md` before implementing, plus [ENTITY_PAGE_TOOLKIT.md](dashboard-page/ENTITY_PAGE_TOOLKIT.md) for the `useEntityPage` call itself — generics, `onSave`, params. Note `useCreateCollection` is **not** about creating items: it returns a function that initializes collection state.
 
 ## When Patterns Has No Equivalent

--- a/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
@@ -43,6 +43,12 @@ collection route it points back to is registered at `path="/"`, not
 `path="/shifts"`, so `parentPath` must match that: `'/'`. See [Create
 route](#create-route) below for the full route registration.
 
+From **1.465.0** the library's own docs state this rule — `PatternsReactRouter.md`,
+`usePatternsNavigate.md` and `useEntityPage.md`'s **Create route**. On an older
+install they don't, and their examples *demonstrate* the mistake
+(`navigateToEntityPage({ path: '/shifts/new' })`, `navigateToCollectionPage({ path:
+'/entities' })`); prefer this rule over what those examples show.
+
 `EntityPage` and `useEntityPage` are **root** exports. `@wix/patterns/page` holds `CollectionPage` and `WidgetsFormProvider` only, so importing the entity page from there is `TS2305: has no exported member` — the collection page and the entity page do not live in the same place. `Read <pkgRoot>/dist/dts-bundle/exports/page.d.ts` to see what that subpath actually gives you.
 
 ## Name both generics

--- a/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/ENTITY_PAGE_TOOLKIT.md
@@ -26,9 +26,22 @@ const state = useEntityPage<Shift, ShiftFormFields>({
       .updateShift(shiftId, { ...form.getValues(), ...widgetsFormData })
       .then((updatedEntity) => ({ updatedEntity })),
   form,
-  parentPath: '/shifts',
+  parentPath: '/',
 });
 ```
+
+**`parentPath` is relative to the router's own mount point — the dashboard page's
+own root, not the page's `route` value.** A dashboard page scaffolded with
+`{"route": "shifts"}` is served at `/dashboard/shifts`, but `PatternsReactRouter`
+still sees its own location start fresh at `/` inside that page — so `parentPath`,
+every `PatternsReactRoute`'s `path`, and the `path` passed to
+`navigateToEntityPage()` / `navigateToCollectionPage()` must never repeat the
+page's own `route`/name. `parentPath: '/shifts'` on a page whose `route` is
+`"shifts"` is the single most common way this gets copied wrong — it looks like a
+reasonable guess (name the parent after the page) and compiles, but the
+collection route it points back to is registered at `path="/"`, not
+`path="/shifts"`, so `parentPath` must match that: `'/'`. See [Create
+route](#create-route) below for the full route registration.
 
 `EntityPage` and `useEntityPage` are **root** exports. `@wix/patterns/page` holds `CollectionPage` and `WidgetsFormProvider` only, so importing the entity page from there is `TS2305: has no exported member` — the collection page and the entity page do not live in the same place. `Read <pkgRoot>/dist/dts-bundle/exports/page.d.ts` to see what that subpath actually gives you.
 
@@ -80,6 +93,8 @@ The example above is edit-only. "Add new" is an `EntityPage` too, and it is not 
 | Form state and field binding | `useForm` / `useController` from `@wix/patterns/form` — `useController`, never `register` |
 | Body layout | `EntityPage.Header`, `.MainContent`, `.AdditionalContent`, `.Card` |
 | The fields inside those cards | `@wix/design-system` (`FormField`, `Input`, `Text`) |
+
+Every `path` in that first row — the route's own `path`, `parentPath`, and the `path` argument to `navigateToEntityPage`/`navigateToCollectionPage` — is relative to the page's own root, never to its `route`/name. See the `parentPath` note under [The call](#the-call) above; it is the same rule everywhere a path appears in this table.
 
 `@wix/patterns/form` re-exports `@wix/bex-core/form`, which wraps `react-hook-form` — so `form.getValues()`, `form.reset()` and the rest are react-hook-form's API, documented there rather than in the patterns docs.
 

--- a/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
+++ b/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
@@ -63,7 +63,7 @@ A plain `import { X } from '<module>'` at the top of a bundle, with no note atta
 
 If a name you genuinely need stays unresolved after that, stop and say so, and name the bundle and the exact import path that dead-ended. Do not guess a shape and do not go spelunking in `node_modules` — a wrong guess compiles here and breaks at runtime, which is worse than the missing type.
 
-A handful of names carry `"status": "unreachable"` with a message saying not to import them (the `...BaseProps` interfaces a component's props `extends`). Read those for the props they contribute; don't write an import for them.
+A handful of names carry `"status": "unreachable"` — plus `"unexported": true` from **1.465.0** — with a message saying not to import them (the `...BaseProps` interfaces a component's props `extends`). Read those for the props they contribute; don't write an import for them.
 
 `status` also carries `"deprecated"`, and there the `statusMessage` names the replacement — `PrimaryPageButton` says *"Use `PrimaryActions` component instead."* Check it before you commit to a name — nothing else in the lookup path will stop you, since a deprecated component still compiles and still renders. If the index calls a name deprecated, use what its message names instead.
 


### PR DESCRIPTION
## Summary
- Building a dashboard page's router by following `ENTITY_PAGE_TOOLKIT.md` / `DASHBOARD_PAGE.md` reproduced the upstream cairo docs bug: prefixing route paths, `parentPath`, and `navigateToEntityPage` calls with the page's own `route`/`routePath` (e.g. `path="/shifts"` on a page scaffolded with `route: "shifts"`). `PatternsReactRouter`'s location is already scoped to the page, so the collection route never matched and the generated page silently broke.
- Fixed the worked `parentPath` example in `ENTITY_PAGE_TOOLKIT.md`.
- Added explicit warnings right where `route`/`routePath` is introduced (`DASHBOARD_PAGE.md`) and on the Collection→Entity Flow table / `useEntityPage` call (`WIX_PATTERNS_DOCS.md`, `ENTITY_PAGE_TOOLKIT.md`) — so this keeps getting caught even against an installed `@wix/patterns` version that predates the upstream fix.
- Companion fix upstream: wix-private/cairo#5865 (fixes the same issue at the source, in the `@wix/patterns` docs cairo ships).

## Test plan
- [ ] Re-run the wix-app skill against a fresh dashboard-page + entity-page generation and confirm the router paths come out page-relative (`/`, `/new`, `/:id`) rather than prefixed with the page's route

🤖 Generated with [Claude Code](https://claude.com/claude-code)