### PR TITLE
docs(wix-app): give the useOptimisticActions row a real signature

### DIFF
--- a/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
+++ b/skills/wix-app/references/dashboard-page/COLLECTION_TOOLKIT.md
@@ -61,7 +61,7 @@ A dialog that creates, updates or displays one listed record is **not** a dashbo
 | Table toolbar button | `PrimaryActionButton` — the table's own `primaryActionButton` prop |
 | Row actions | `deleteSecondaryAction`, in the row's `actionCell` |
 | Acting on a multi-row selection | `MultiBulkActionToolbar`, `bulkActionModal` |
-| Immediate feedback, then reconcile | `useOptimisticActions`, `CollectionOptimisticActions` |
+| Immediate feedback, then reconcile | `useOptimisticActions(state.collection)` ✅ — not `useOptimisticActions(state)` ❌: `useTableCollection()` returns `TableState<T, F>`, and the hook takes the `CollectionState<T, F>` that state exposes as `state.collection`. Returns `CollectionOptimisticActions` |
 | A banner above the table | `TableTopNotification` |
 
 ## The states that are not the happy path


### PR DESCRIPTION
## What

`COLLECTION_TOOLKIT.md` listed `useOptimisticActions` and `CollectionOptimisticActions` as bare names under "Immediate feedback, then reconcile". A name without a call shape is where the reader guesses, and the natural guess after `const state = useTableCollection(...)` is `useOptimisticActions(state)` — which is wrong.

## The correction

```ts
// packages/core/src/hooks/useOptimisticActions.ts (cairo)
export function useOptimisticActions<T, F extends FiltersMap>(
  collection: CollectionState<T, F>,
  params?: Partial<CollectionOptimisticActionsBaseParams<T, F>>,
)
```

`useTableCollection` returns `TableState<T, F>`, which holds the collection at `state.collection`. So:

- `useOptimisticActions(state.collection)` ✅
- `useOptimisticActions(state)` ❌

The row now carries the correct call, the anti-pattern beside it, and the one-line reason.

## Why in place, not a new file

This is a sharpening, not an addition. A reader who did not open a second reference for this would not have opened a third — the fix has to land on the line they were already reading.

## Related

The same wrong argument appeared in cairo's own drag-and-drop docs, which is plausibly where it was learned. Fixed upstream in wix-private/cairo#5870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)