### PR TITLE
docs(wix-app): make the bundle index a precondition, and batch the reads

### DIFF
--- a/skills/wix-app/references/WIX_PATTERNS_DOCS.md
+++ b/skills/wix-app/references/WIX_PATTERNS_DOCS.md
@@ -145,7 +145,7 @@ A doc whose index entry has a `bundle` field does **not** list its props — its
 
 ### Reading the file the index names
 
-The mechanics of the file an index names — types docs don't cover, one-line stubs that are answers rather than truncation, subpath entry points, cross-references, split compound docs — are in [Reading bundles and docs](dashboard-page/PATTERNS_BUNDLE_READING.md). Read it before your first `dist/dts-bundle/*.d.ts` of the session.
+The mechanics of the file an index names — batching the reads, types docs don't cover, one-line stubs that are answers rather than truncation, subpath entry points, cross-references, split compound docs — are in [Reading bundles and docs](dashboard-page/PATTERNS_BUNDLE_READING.md). Read it before your first `dist/dts-bundle/*.d.ts` of the session.
 
 ## The Collection → Entity Flow
 

--- a/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
+++ b/skills/wix-app/references/dashboard-page/PATTERNS_BUNDLE_READING.md
@@ -1,10 +1,34 @@
 # Reading `@wix/patterns` Bundles and Docs
 
-> **Scope.** You are here because a lookup in `dist/dts-bundle/index.json` or
-> `dist/docs/index.json` gave you an entry and you are about to open the file it names. Getting to that index in the first
-> place — resolving the package root, the version floor, the docs lookup, and the rule
+> **Precondition: an index entry.** Every path below is the `file` (or `bundle`) field of an entry
+> in `<pkgRoot>/dist/dts-bundle/index.json` or `<pkgRoot>/dist/docs/index.json`. If you haven't
+> read that index this session, you have no path to open — read it before anything else here.
+> Getting to it — resolving the package root, the version floor, the docs lookup, and the rule
 > against browsing `node_modules` by hand — is in
 > [WIX_PATTERNS_DOCS.md](../WIX_PATTERNS_DOCS.md). Nothing here replaces those steps.
+
+## Read the index once, then open its files in one call
+
+One index read covers the whole page. So name every symbol you plan to write — components, hooks,
+state types, prop types — look them all up in the index you now hold, and open what it named in a
+single call with one `Read` per file:
+
+```
+call 1   Read <pkgRoot>/dist/docs/index.json
+         Read <pkgRoot>/dist/dts-bundle/index.json
+
+call 2   Read <pkgRoot>/dist/docs/Table.md                            <- docs entry's `file`
+         Read <pkgRoot>/dist/docs/useTableCollection.md
+         Read <pkgRoot>/dist/dts-bundle/components/Table.d.ts         <- its `bundle`
+         Read <pkgRoot>/dist/dts-bundle/hooks/useTableCollection.d.ts
+         Read <pkgRoot>/dist/dts-bundle/types/TableState.d.ts         <- bundle entry's `file`
+```
+
+Two calls, not twenty-two — and nothing is lost by batching, because there is nothing to learn
+between the files: every path came out of the same index and `bytes` already told you each size.
+The same files opened one per call re-send the whole conversation once per file, which is where a
+lookup session's token cost actually goes. Batch the follow-ups the same way: when a doc names an
+example file, or a stub names another bundle (below), collect them and read them together.
 
 ## Where props live
 


### PR DESCRIPTION
## The defect

`references/dashboard-page/PATTERNS_BUNDLE_READING.md` already forbids the wrong way to get a bundle path:

> using exactly the `file` path the index gives — **never reconstruct the path from the name**

What it never said is that the index read is what *supplies* that path. Its opening was a scope note — *"You are here because a lookup in `dist/dts-bundle/index.json` or `dist/docs/index.json` gave you an entry"* — which describes a state the reader is assumed to be in, not a step they have to have taken. A run can skip `dist/dts-bundle/index.json` entirely and still be inside every rule this file states, because every rule is about the file you open *after* the lookup.

A run observed doing exactly that read ~20 bundle and doc files one per call. Nothing was wrong with the files it chose; the cost was structural — each single-file read re-sends the whole conversation, so a lookup session floors out around 110k cache-read tokens before any of it is reasoned about.

Wall clock is *not* the argument, and the audit is explicit about that: `DOCS-AUDIT-af949182.md` measured 154,222 bytes of `.d.ts` read in **1.73 s** total against sub-steps costing 40 s of pure resolution — "reading is free, and resolving is not." What serializing costs is cache reads, not latency.

## What this does

- **`PATTERNS_BUNDLE_READING.md`** — the scope blockquote becomes a stated precondition: every path in the file is an entry's `file` (or `bundle`) field, so if you haven't read the index this session you have no path to open, and you read it before anything else here. The pointer to `WIX_PATTERNS_DOCS.md` for package-root resolution, the version floor and the no-`node_modules`-browsing rule is unchanged.
- **A new first section, "Read the index once, then open its files in one call"** — the batching rule the file was missing, as one worked two-call example: both indexes together, then one `Read` per file for everything they named, each path annotated with the field that produced it.

  ```
  call 1   Read <pkgRoot>/dist/docs/index.json
           Read <pkgRoot>/dist/dts-bundle/index.json

  call 2   Read <pkgRoot>/dist/docs/Table.md                            <- docs entry's `file`
           Read <pkgRoot>/dist/docs/useTableCollection.md
           Read <pkgRoot>/dist/dts-bundle/components/Table.d.ts         <- its `bundle`
           Read <pkgRoot>/dist/dts-bundle/hooks/useTableCollection.d.ts
           Read <pkgRoot>/dist/dts-bundle/types/TableState.d.ts         <- bundle entry's `file`
  ```

  With the reason batching loses nothing: every path came out of the same index and `bytes` already gave each size, so there is nothing to learn between the files. It also says to batch the follow-ups — an example file a doc names, another bundle a stub names.
- **`WIX_PATTERNS_DOCS.md`** — "batching the reads" joins the list in the existing pointer at `### Reading the file the index names`, so a reader who never opens the reference still knows the rule is there.

## Verification

- Every path and field name in the example was checked against a real installed `@wix/patterns` **1.465.0** index, not written from memory: `Table` → `components/Table.d.ts`, `useTableCollection` → `hooks/useTableCollection.d.ts`, `TableState` → `types/TableState.d.ts`, and the `docs/index.json` entries for `Table` and `useTableCollection` carrying those first two as their `bundle`.
- `node scripts/check-truncation.mjs --fail --files=…` passes for both changed files: **9,505** and **9,907** chars. The second was 49 chars under the limit before this change, which is why its edit is 20 chars and not a sentence.

## Note for review

Both files are under `skills/wix-app/references/**`, so the eval-coverage checklist item applies. No new scenario here — the change adds no new API surface or decision, it makes an existing lookup step mandatory and cheaper, and the dashboard scenarios that already exercise this path (`employee-shift-dashboard.yml`, `refunds-dashboard-sdk-not-cms.yml`, `dashboard-page/admin-call-routed-and-elevated.yml`) cover the files as-is. Happy to add one asserting the two-call shape if the gate wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
