### PR TITLE
fix(skills): enforce node protocol in distributed scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-        if: ${{ needs.detect.outputs.evalforge == 'true' }}
         with:
           node-version: '24'
+
+      # Distributed scripts become source files in consuming repositories, whose
+      # CI can reject bare Node builtin imports. Run in the required test check,
+      # including on automated sync PRs.
+      - name: Validate Node builtin imports in skill scripts
+        run: npm run lint:skill-scripts
 
       - name: evalforge-core — install, test, build
         if: ${{ needs.detect.outputs.evalforge == 'true' }}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/wix/skills/issues"
   },
   "scripts": {
+    "lint:skill-scripts": "npx --yes oxlint@1.79.0 -A all -D unicorn/prefer-node-protocol --format json skills/wix-app/scripts skills/wix-design-system/scripts",
     "version": "node .github/scripts/sync-plugin-versions.mjs && git add .claude-plugin/plugin.json .codex-plugin/plugin.json .cursor-plugin/plugin.json plugin.json gemini-extension.json"
   },
   "files": [

--- a/skills/wix-app/scripts/scan-a11y-code.cjs
+++ b/skills/wix-app/scripts/scan-a11y-code.cjs
@@ -3,9 +3,9 @@
 
 // oxlint-disable no-console no-shadow preserve-caught-error
 
-const fs = require('fs');
-const path = require('path');
-const { createRequire } = require('module');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createRequire } = require('node:module');
 
 const ROOT = process.cwd();
 const LOCAL_REQUIRE = createRequire(__filename);

--- a/skills/wix-app/scripts/scan-a11y-eslint.cjs
+++ b/skills/wix-app/scripts/scan-a11y-eslint.cjs
@@ -3,8 +3,8 @@
 
 // oxlint-disable no-console preserve-caught-error
 
-const path = require('path');
-const { createRequire } = require('module');
+const path = require('node:path');
+const { createRequire } = require('node:module');
 
 const ROOT = process.cwd();
 const LOCAL_REQUIRE = createRequire(__filename);

--- a/skills/wix-design-system/scripts/wds.cjs
+++ b/skills/wix-design-system/scripts/wds.cjs
@@ -15,8 +15,8 @@
  *   node <path-to>/wds.cjs icons <query>
  */
 
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 // ---------------------------------------------------------------------------
 // Path discovery


### PR DESCRIPTION
Distributed skill scripts use bare Node builtin imports, which fail `unicorn/prefer-node-protocol` when installed into repositories that enforce that rule. Change the accessibility scanners and WDS helper to use `node:fs`, `node:path`, and `node:module`.

Add pinned Oxlint 1.79.0 validation for both script directories to the existing required `test` job. The check runs on every PR, including automated syncs, so a sync cannot silently restore these imports. It enables only the relevant rule and does not execute the skill scripts.

Validation: reproduced seven errors across three scripts before the fix; zero diagnostics across all three afterward. All three scripts pass `node --check`; workflow YAML parses and the lint step is unconditional; `git diff --check` passes. No skill instructions or reference content changed.
