### PR TITLE
Clarify visitor tokens for Base44 Wix redirect sessions

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -284,8 +284,10 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 ```
 
 **Create redirect sessions with a visitor token minted for the headless OAuth app.**
-Set up the OAuth app even for an unpublished preview; anonymous visitors do not need to log in.
-Use an existing headless OAuth app's `clientId`, or create one with the admin connector token below.
+Use the OAuth app's `clientId` from `wx.context()`. If the report doesn't include an OAuth app
+and you need redirect sessions, create one with the admin connector token as shown below,
+then mint a visitor token from its `clientId`. This setup is required even for an unpublished
+preview; anonymous visitors do not need to log in.
 
 ```js
 // Use your app's actual destinations, including preview when supported.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -30,8 +30,12 @@ the connector's, server-side only.
 ```
 browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
 base44/functions/… ──(admin token)───► wixapis.com   work that needs the owner's identity
-exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
+exec_tool          ──(caller's token)─► wixapis.com  use the identity required by the API
 ```
+
+**Create Redirect Session requires a visitor token minted for the site's headless OAuth app.**
+Use that token even when testing in `exec_tool` or calling from a backend function;
+the admin connector token cannot replace it.
 
 **A site for visitors** — store, blog, booking, ecom, CMS, CRM, and the rest of the business solutions.
 Your app is the site's frontend — whether the site is headless (no pages of its own) or your
@@ -283,7 +287,9 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 // that opts INTO heavier parts (formatted prices, media); read the contract for it
 ```
 
-No OAuth app in the context report to take the `clientId` from? Create one (admin, one-time):
+Use an existing headless OAuth app's `clientId`, or create an OAuth app with the admin connector
+token as shown below. This setup is required for redirect sessions even in an unpublished preview.
+Mint an anonymous visitor token from that `clientId`; the visitor does not need to log in.
 
 ```js
 // Use your app's actual destinations, including preview when supported.
@@ -293,7 +299,7 @@ const returnDomains = appOrigins.map(origin => new URL(origin).hostname);
 
 // OAuth redirect configuration: exact login URLs versus domains for other returns.
 // https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains.md
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const { accessToken: adminToken } = await base44.asServiceRole.connectors.getConnection("wix");
 const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps", {
   oAuthApp: {
     name: "My App",
@@ -302,7 +308,7 @@ const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-a
     // Returns from Wix-hosted flows: hostnames only, allowing URLs under each domain.
     allowedRedirectDomains: returnDomains,
   },
-}, accessToken);
+}, adminToken);
 const clientId = oAuthApp.id; // Public visitor client ID, used by the frontend client above.
 
 // If destinations change later, update this OAuth app rather than creating another.
@@ -319,6 +325,7 @@ import { wix } from "@/lib/wixClient";
 // Flow prerequisites and supported intents:
 // https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api.md
 export async function redirectToWix(intent, returnPath = "/") {
+  // wix sends the minted visitor token, never the admin connector token.
   // Pass the intent required by the selected flow's schema.
   const response = await wix("/headless/v1/redirect-session", {
     method: "POST",

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -18,39 +18,34 @@ does not inherit an earlier turn's context, so re-read it before building on or 
 **A management or admin task starts at the recipes**: call `wx.mgmtRecipes` (Learn Wix) and follow
 the one that fits. A recipe states outright what an API does not support, which fields a bulk call
 actually writes, and the order two calls have to go in — from the schemas alone those get re-derived
-several errors at a time. A REST search ranks the matching recipes too (recipe entries in `hits`), so
+several errors at a time. `wx.search` ranks the matching recipes too (recipe entries in `hits`), so
 they also surface from a search that began at the methods.
 
 ## What are you building?
 
-The app's audience picks the token, and the token picks the architecture: the **visitor token is
-public** — anyone can mint it from the site's `clientId` — and the **admin token is a secret**,
-the connector's, server-side only. **Use visitor tokens for reads and actions on behalf of site
-visitors, never the admin connector token.** Use the admin token for ad hoc management calls in `exec_tool` or backend functions
-that implement the app's admin logic.
+Choose the token by who the code acts for. A headless app can serve visitors, provide admin
+management tools, or do both.
+
+**A site for visitors** — use a visitor token for public reads and actions on behalf of the
+visitor, never the admin connector token. Call Wix directly from the browser through one shared
+visitor client (Write the code, below). Anyone can mint an anonymous visitor token from the
+OAuth app's public `clientId`; no visitor login is required. APIs for the "current visitor"
+use that token to identify whose data and state to access. This applies both to a standalone
+headless frontend and to a frontend extending an existing Wix site.
+
+**An admin tool for the owner** — use the admin connector token in backend functions implementing
+admin logic; keep it secret and server-side. The frontend calls those functions, not Wix with
+visitor tokens. A custom headless management site extending the Wix back office follows this
+flow too. Ad hoc management calls in `exec_tool` also use the admin token. Backend functions
+also handle work requiring the owner's permissions, such as webhooks, scheduled jobs, and
+explicitly authorized elevated operations. For an app with both visitor and admin features,
+keep each feature on its corresponding flow.
 
 ```
-browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
-base44/functions/… ──(admin token)───► wixapis.com   work that needs the owner's identity
-exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
+visitor pages ──(visitor token)────────────────────────► wixapis.com
+admin pages   ──► base44/functions/… ──(admin token)────► wixapis.com
+exec_tool     ──(admin token, ad hoc management)────────► wixapis.com
 ```
-
-**A site for visitors** — store, blog, booking, ecom, CMS, CRM, and the rest of the business solutions.
-Your app is the site's frontend — whether the site is headless (no pages of its own) or your
-frontend extends an existing site. **The complete visitor experience —
-every page, every read, every action a visitor takes — is browser calls on the visitor token;
-none of it needs a backend function.** Public reads
-included (the visitor token queries public content directly), and per-visitor state is scoped to
-the CALLER — an API that acts on "the current visitor's" data resolves the visitor from the
-token, so only the visitor token reaches that visitor's own state. One shared visitor client
-carries it all (Write the code, below). `base44/functions/…` appear only where work
-needs the owner's identity — elevated-permission ops a visitor triggers, webhooks, scheduled
-jobs — and for the app's non-Wix backend.
-
-**An admin tool for the owner** — dashboard, back office. Admin pages and agent act as the
-owner, using the secret admin token: `pages → base44/functions/… ──(admin token)──► wixapis.com`.
-A custom headless management site extending the Wix back office follows this admin flow:
-its frontend calls backend functions that use the admin connector token, not visitor tokens.
 
 ## The helpers
 
@@ -71,7 +66,7 @@ const wx = require(require("path").resolve(P));
 - `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
 - `wx.context(token)` — the site's full dynamic context report; inline when small, otherwise a saved Markdown file with a heading outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
-- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. A default REST search also searches **WIX_HEADLESS** for integration articles (included in `hits`) and ranks the **management recipes**, returned as recipe entries in the same `hits` list as methods and articles — each with its steps, the endpoints it calls, and `file` when the wix-manage skill is on disk
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint (`VERB url`) + docsUrl + gist, and the worked requests the docs publish for them. By default it searches REST docs, Headless articles, and management recipes together in one `hits` list. Recipe entries include their steps, the endpoints they call, and `file` when the wix-manage skill is on disk
 - `wx.page(docsUrl)` — read a doc page; its worked examples come back as titles + line numbers
 - `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(docsUrl | code)` — a method's exact schema, plus the titles of the docs' own request examples saved at `examplesPath`; pass a hit's docsUrl (direct load), or raw code to query the index yourself
@@ -117,7 +112,7 @@ await wx.mgmtRecipes("stores");   // a category's list — or any task word: wx.
 // straight off disk — else `url`: wx.page(url), whole when small, saved + outline when big
 ```
 
-A recipe carries prerequisites, order, and gotchas that no method page has. A REST search ranks
+A recipe carries prerequisites, order, and gotchas that no method page has. `wx.search` ranks
 these same recipes in its `hits` list, so they surface either way.
 
 ### Find a method — search and browse

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -30,12 +30,8 @@ the connector's, server-side only.
 ```
 browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
 base44/functions/… ──(admin token)───► wixapis.com   work that needs the owner's identity
-exec_tool          ──(caller's token)─► wixapis.com  use the identity required by the API
+exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
 ```
-
-**Create Redirect Session requires a visitor token minted for the site's headless OAuth app.**
-Use that token even when testing in `exec_tool` or calling from a backend function;
-the admin connector token cannot replace it.
 
 **A site for visitors** — store, blog, booking, ecom, CMS, CRM, and the rest of the business solutions.
 Your app is the site's frontend — whether the site is headless (no pages of its own) or your
@@ -287,9 +283,9 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 // that opts INTO heavier parts (formatted prices, media); read the contract for it
 ```
 
-Use an existing headless OAuth app's `clientId`, or create an OAuth app with the admin connector
-token as shown below. This setup is required for redirect sessions even in an unpublished preview.
-Mint an anonymous visitor token from that `clientId`; the visitor does not need to log in.
+**Create redirect sessions with a visitor token minted for the headless OAuth app.**
+Set up the OAuth app even for an unpublished preview; anonymous visitors do not need to log in.
+Use an existing headless OAuth app's `clientId`, or create one with the admin connector token below.
 
 ```js
 // Use your app's actual destinations, including preview when supported.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -28,7 +28,9 @@ management tools, or do both.
 
 **A site for visitors** — use a visitor token for public reads and actions on behalf of the
 visitor, never the admin connector token. Call Wix directly from the browser through one shared
-visitor client (Write the code, below). Anyone can mint an anonymous visitor token from the
+visitor client (Write the code, below). Redirect sessions for Wix-hosted flows also require a
+visitor token minted for the headless OAuth app; see Visitor authentication and Wix-hosted flows below.
+Anyone can mint an anonymous visitor token from the
 OAuth app's public `clientId`; no visitor login is required. APIs for the "current visitor"
 use that token to identify whose data and state to access. This applies both to a standalone
 headless frontend and to a frontend extending an existing Wix site.

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -26,7 +26,8 @@ they also surface from a search that began at the methods.
 The app's audience picks the token, and the token picks the architecture: the **visitor token is
 public** — anyone can mint it from the site's `clientId` — and the **admin token is a secret**,
 the connector's, server-side only. **Never use the admin connector token for a headless site's
-visitor reads or actions; it is only for admin operations.**
+visitor reads or actions.** Use it for ad hoc management calls in `exec_tool` or backend functions
+that implement the app's admin logic.
 
 ```
 browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
@@ -323,7 +324,8 @@ import { wix } from "@/lib/wixClient";
 // Flow prerequisites and supported intents:
 // https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api.md
 export async function redirectToWix(intent, returnPath = "/") {
-  // wix sends the minted visitor token. Never use the admin token here; it is only for admin operations.
+  // wix sends the minted visitor token. Never use the admin token here.
+  // Admin tokens are for ad hoc management calls or backend functions implementing admin logic.
   // Pass the intent required by the selected flow's schema.
   const response = await wix("/headless/v1/redirect-session", {
     method: "POST",

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -25,8 +25,8 @@ they also surface from a search that began at the methods.
 
 The app's audience picks the token, and the token picks the architecture: the **visitor token is
 public** — anyone can mint it from the site's `clientId` — and the **admin token is a secret**,
-the connector's, server-side only. **Never use the admin connector token for a headless site's
-visitor reads or actions.** Use it for ad hoc management calls in `exec_tool` or backend functions
+the connector's, server-side only. **Use visitor tokens for reads and actions on behalf of site
+visitors, never the admin connector token.** Use the admin token for ad hoc management calls in `exec_tool` or backend functions
 that implement the app's admin logic.
 
 ```
@@ -49,6 +49,8 @@ jobs — and for the app's non-Wix backend.
 
 **An admin tool for the owner** — dashboard, back office. Admin pages and agent act as the
 owner, using the secret admin token: `pages → base44/functions/… ──(admin token)──► wixapis.com`.
+A custom headless management site extending the Wix back office follows this admin flow:
+its frontend calls backend functions that use the admin connector token, not visitor tokens.
 
 ## The helpers
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -25,7 +25,8 @@ they also surface from a search that began at the methods.
 
 The app's audience picks the token, and the token picks the architecture: the **visitor token is
 public** — anyone can mint it from the site's `clientId` — and the **admin token is a secret**,
-the connector's, server-side only.
+the connector's, server-side only. **Never use the admin connector token for a headless site's
+visitor reads or actions; it is only for admin operations.**
 
 ```
 browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
@@ -286,8 +287,7 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 **Create redirect sessions with a visitor token minted for the headless OAuth app.**
 Use the OAuth app's `clientId` from `wx.context()`. If the report doesn't include an OAuth app
 and you need redirect sessions, create one with the admin connector token as shown below,
-then mint a visitor token from its `clientId`. This setup is required even for an unpublished
-preview; anonymous visitors do not need to log in.
+then mint a visitor token from its `clientId`. Anonymous visitors do not need to log in.
 
 ```js
 // Use your app's actual destinations, including preview when supported.
@@ -323,7 +323,7 @@ import { wix } from "@/lib/wixClient";
 // Flow prerequisites and supported intents:
 // https://dev.wix.com/docs/go-headless/business-solutions/wix-hosted-pages/redirect-using-the-rest-api.md
 export async function redirectToWix(intent, returnPath = "/") {
-  // wix sends the minted visitor token, never the admin connector token.
+  // wix sends the minted visitor token. Never use the admin token here; it is only for admin operations.
   // Pass the intent required by the selected flow's schema.
   const response = await wix("/headless/v1/redirect-session", {
     method: "POST",


### PR DESCRIPTION
Agents used the admin connector token for visitor flows and redirect sessions after reading the skill.

Make the identity boundary explicit in the opening architecture guidance: visitor reads and actions use visitor tokens; the admin connector token is only for admin operations. Reinforce this beside OAuth setup and the redirect example. Preserve the setup path when wx.context() does not report an OAuth app, and distinguish the admin token used to create it from the visitor token used afterward.

Validation: git diff --check passed. Guidance follows saved app traces where admin-token redirect attempts failed and visitor-token attempts succeeded. Documentation-only change.
