### PR TITLE
Clarify testing visitor APIs with visitor tokens

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -272,7 +272,7 @@ export const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, 
   headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } });
 ```
 
-You can test visitor APIs, including redirect sessions, directly in `exec_tool`. Mint a visitor
+If you need to test a visitor API, including redirect sessions, you can do so in `exec_tool`. Mint a visitor
 token and pass it to the API call so the test uses the same identity as the visitor frontend.
 Token contract: [Retrieve Tokens](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md).
 For example, test a public read:

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -272,13 +272,15 @@ export const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, 
   headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } });
 ```
 
-Token contract: [Retrieve Tokens](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md). Prove the lane in one exec before
-writing pages — mint a visitor, make one public read with it:
+You can test visitor APIs, including redirect sessions, directly in `exec_tool`. Mint a visitor
+token and pass it to the API call so the test uses the same identity as the visitor frontend.
+Token contract: [Retrieve Tokens](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md).
+For example, test a public read:
 
 ```js
-const { access_token } = await wx.post("https://www.wixapis.com/oauth2/token",
+const { access_token: visitorToken } = await wx.post("https://www.wixapis.com/oauth2/token",
   { clientId: WIX_CLIENT_ID, grantType: "anonymous" });   // clientId: from the context report
-return await wx.post("<a public read from Learn Wix>", { query: {} }, access_token);
+return await wx.post("<a public read from Learn Wix>", { query: {} }, visitorToken);
 // 200 ⇒ every visitor-facing page in the app is this same call, no server between
 // a lean default response isn't the whole shape — contracts often define a fields param
 // that opts INTO heavier parts (formatted prices, media); read the contract for it


### PR DESCRIPTION
Clarify that agents can test visitor APIs, including redirect sessions, directly in exec_tool using a visitor token. Place the guidance beside the existing token-minting example and name its token visitorToken to make the identity explicit.

Validation: git diff --check passed. The existing example retains the same API calls and request bodies; the approach is supported by successful visitor-token probes in the inspected app conversations. Documentation-only change.
