### PR TITLE
Fix misleading connector HTTP error guidance

### DIFF
--- a/skills/wix-base44-connector/scripts/utils.cjs
+++ b/skills/wix-base44-connector/scripts/utils.cjs
@@ -39,9 +39,12 @@ async function req(method, url, body, token) {
     headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
   if (!r.ok) {
     const head = (await r.text()).slice(0, 300);
-    throw new Error(r.status + " " + head + (r.status < 500
-      ? " — a 4xx means wrong body or reference: read this endpoint's contract before changing the call"
-      : ""));
+    const guidance = r.status === 401 || r.status === 403
+      ? " — check the endpoint's required caller identity, token validity, and permissions"
+      : r.status >= 400 && r.status < 500
+        ? " — read the API error and endpoint contract before changing the call"
+        : "";
+    throw new Error(r.status + " " + head + guidance);
   }
   return r.json();
 }


### PR DESCRIPTION
The HTTP helper described every client error as a wrong body or reference, including authentication and permission failures. It now points 401/403 errors to caller identity, token validity, and permissions; other 4xx responses get neutral guidance to read the API error and endpoint contract. Existing API error excerpts and server-error behavior remain unchanged.

Validation: mocked responses for nine error statuses plus a successful authenticated POST; Node syntax check and git diff --check passed.