### PR TITLE
ecom seed guides: name seed-store.cjs and show a require/setupStore example

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -64,9 +64,15 @@ need to diagnose and fix it.
 user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
 cleanup truly seems needed, ask the user first.
 
-Seed by calling the storefront's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
-`require()` as shown there (build-time exec_tool); call its functions with your data.
+Seed by calling the storefront's ready-made seed module, `seed-store.cjs` — `require()` it and use its
+one-call `setupStore` (build-time exec_tool). Read
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` for the full `setupStore`
+contract — the `ctx` and the product/category shapes.
+
+```js
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const result = await seed.setupStore(ctx, { products, categories }); // one call: install → products → categories → images
+```
 
 For code or actions not covered by this skill, read and follow the installed connector skill at
 `.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -49,9 +49,15 @@ need to diagnose and fix it.
 user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
 cleanup truly seems needed, ask the user first.
 
-Seed by calling the storefront's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.cjs` with
-`require()` as shown there (build-time exec_tool); call its functions with your data.
+Seed by calling the storefront's ready-made seed module, `seed-store.cjs` — `require()` it and use its
+one-call `setupStore` (build-time exec_tool). Read
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` for the full `setupStore`
+contract — the `ctx` and the product/category shapes.
+
+```js
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const result = await seed.setupStore(ctx, { products, categories }); // one call: install → products → categories → images
+```
 
 For code or actions not covered by this skill, read and follow the installed connector skill at
 `.agents/skills/wix-base44-connector/SKILL.md` to find Wix documentation and APIs.


### PR DESCRIPTION
## Why
The two ecom **seeding** guides referenced the seed module only as a glob (`seed-*.cjs`) and pointed at `SEED.md` for the specifics — so the exact module name and call lived only in `SEED.md`. In a recent 10-app sample, agents guessed the seed path (`seed-store.js`) and 404'd before reading `SEED.md`, then recovered.

## Change
`base44-ecom-light-seed.md` (STEP 2) and `base44-ecom-light-seed-with-install.md` (STEP 3): name the module inline (`seed-store.cjs`) and add a small `require()` + one-call `setupStore` example. `SEED.md` keeps the full contract; `base44-ecom-light.md` is untouched (it doesn't seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)