### PR TITLE
connector: require redirect URLs on the headless OAuth app (preview + published)

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -308,14 +308,28 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, visitorTok
 // that opts INTO heavier parts (formatted prices, media); read the contract for it
 ```
 
-**Create redirect sessions with a visitor token minted for the headless OAuth app.**
-Use the OAuth app's `clientId` from `wx.context()`. If the report doesn't include an OAuth app
-and you need redirect sessions, create one with the admin connector token as shown below,
-then mint a visitor token from its `clientId`. Anonymous visitors do not need to log in.
+**Any Wix-hosted flow that returns the visitor to your app needs the headless OAuth app's
+redirect config set.** This covers redirect sessions *and* sending a buyer to the Wix-hosted
+checkout `checkoutUrl` and back — any flow where Wix redirects to a URL on your app. Use the
+OAuth app's `clientId` from `wx.context()`; if the report has no OAuth app, create one with the
+admin connector token as shown below, then mint a visitor token from its `clientId` (anonymous
+visitors do not need to log in). **Always set `allowedRedirectUris` and `allowedRedirectDomains`
+when you create it** — an OAuth app created with a name only cannot complete any return, and the
+break is silent (create-checkout and the anonymous token still succeed) until a real buyer is
+redirected and stranded on Wix.
 
 ```js
-// Use your app's actual destinations, including preview when supported.
-const appOrigins = ["https://my-app.example.com", "https://my-preview.example.com"];
+// Register BOTH of this app's own URLs — its preview URL and its published URL — so returns work
+// before AND after publish. Both are built from the Base44 app id (NOT the Wix OAuth client_id /
+// appId used above):
+//   preview:   https://preview-sandbox--<base44-app-id>.base44.app
+//   published: https://<app-name-slug>-<last 8 of the base44-app-id>.base44.app
+//              where <app-name-slug> is the app's name (the brand name) slugified — e.g.
+//              "Flash Sale Spark" -> flash-sale-spark-a4615088.base44.app.
+// A custom domain the owner connects overrides the published one; the app name (hence the slug)
+// can also change. So prefer the app's real current published URL when you have it, and update
+// this same OAuth app whenever the name or domain changes — never create another.
+const appOrigins = [previewUrl, publishedUrl]; // this app's actual preview + published URLs
 const loginCallbacks = appOrigins.map(origin => new URL("/login-callback", origin).href);
 const returnDomains = appOrigins.map(origin => new URL(origin).hostname);
 


### PR DESCRIPTION
## What

Two changes to the OAuth-app section of `wix-base44-connector/SKILL.md`:

1. **Broaden the trigger.** The redirect-config guidance was headed *"Create redirect sessions…"*, so an agent adding a checkout by navigating the buyer to the Wix-hosted `checkoutUrl` read it as not applicable. Reworded: **any** Wix-hosted flow that returns the visitor to the app — redirect sessions **and** checkout — needs the redirect config, and it must be set **on create**.
2. **Give the real Base44 URLs** (replaced the `example.com` placeholders), registering **both** — both built from the **Base44 app id** (not the Wix `client_id`/`appId`):
   - **preview** — `https://preview-sandbox--<base44-app-id>.base44.app`
   - **published** — `https://<app-name-slug>-<last 8 of the base44-app-id>.base44.app`, where `<app-name-slug>` is the app's name (the **brand name**) slugified (per `AppCore._generate_slug_from_name_and_id`). A **custom domain** overrides it and the name can change, so prefer the app's real current URL and update the same OAuth app on any change — never create another.

## Why

Observed on a real app (`Flash Sale Spark`): the agent read the connector `SKILL.md` twice, then created the OAuth app with `{ name }` only — `allowedRedirectUris: []`, `allowedRedirectDomains: []`. The anonymous visitor-token flow and `create-checkout` **succeed**, so it tests green, but the return leg from the Wix-hosted checkout is unconfigured — a real buyer is stranded on Wix after paying. Reported as a recurring pattern ("another flash sale with missing redirect URLs in the OAuth app").

The skill's own example already included the redirect fields, but (a) it was scoped to "redirect sessions" and (b) used placeholder origins — so the agent went to the raw create-oauth-app spec (fields optional there) and made a bare app. This closes both gaps.

## Notes

- Docs only; no code paths change.
- Slug derivation confirmed against `backend/app/user_apps/common/models/app_core.py` (`_generate_slug_from_name_and_id`): `slugify(name[:35]) + "-" + app_id[-8:]`.