### PR TITLE
connector: index the skill up top; point the vertical-build case at wix-vibe-headless

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -21,6 +21,23 @@ actually writes, and the order two calls have to go in — from the schemas alon
 several errors at a time. `wx.search` ranks the matching recipes too (recipe entries in `hits`), so
 they also surface from a search that began at the methods.
 
+In this skill:
+
+- **What are you building?** — route each feature to its identity: visitor token, admin token
+  in a backend function, or admin ad hoc in exec_tool
+- **The helpers** — the `wx.*` loader every exec opens with
+- **Gather context** — `wx.context`, the report of what the site actually has
+- **Learn Wix** — find the APIs, learn their contracts
+  - **Management recipes** — first stop for an admin task (`wx.mgmtRecipes`)
+  - **Search and browse** — `wx.search` across methods, recipes and articles
+  - **Read a doc page** — `wx.page` for a located doc URL
+  - **The spec index** — `wx.spec`, a located method's exact schema
+- **Write the code**
+  - **Admin ops while building** — you, in exec_tool
+  - **Backend functions** — the app, as the owner
+  - **Visitor authentication and Wix-hosted flows** — the visitor client, redirect sessions,
+    the headless OAuth app — and bootstrapping a whole vertical with `wix-vibe-headless`
+
 ## What are you building?
 
 Choose the token by who the code acts for. A headless app can serve visitors, provide admin
@@ -378,3 +395,17 @@ export async function redirectToWix(intent, returnPath = "/") {
   window.location.assign(redirectSession.fullUrl);
 }
 ```
+
+**Building a whole vertical? Bootstrap it with `wix-vibe-headless`.** When the build is a
+visitor-facing site on a Wix vertical it supports — a storefront, bookings, pricing plans,
+events, restaurants, rentals, a blog and more — the `wix-vibe-headless` skill stands the
+vertical up fast: it is built entirely on the same Wix APIs as this skill, but ships working
+code (REST transport, scaffolds, UI) plus management-API abstractions (seeding,
+configuration), so the vertical bootstraps on Base44 in a fraction of the calls.
+Read the entry point at
+[`www.wix.com/skills/wix-vibe-headless/platforms/base44.md`](https://www.wix.com/skills/wix-vibe-headless/platforms/base44.md).
+Its STEP 1 carries the install itself — the verbatim `npx skills add` call to run through
+exec_tool, the companion skills, the vertical table and the scaffold deploy — after which the
+guide lives at `.agents/skills/wix-vibe-headless/platforms/base44.md`. Reading it as
+reference alone is fine, but when you do install, go through its flow end to end — the
+shipped scaffolds and seed path are most of its value.


### PR DESCRIPTION
## What

Two additions to `wix-base44-connector/SKILL.md` (single file, 25 insertions):

1. **A section index after the intro** (*"In this skill:"*) — the five sections with a one-line meaning each (what-are-you-building → helpers → gather context → Learn Wix → write the code), so a reader lands oriented before the prose.
2. **A pointer at the end of *"Visitor authentication and Wix-hosted flows"***: when the build is a whole visitor-facing Wix vertical (storefront, bookings, pricing plans, events, restaurants, rentals, blog, …), the agent can bootstrap it with **`wix-vibe-headless`** — same Wix APIs underneath, but shipped code (REST transport, scaffolds, UI) plus management-API abstractions (seeding, configuration). Links the hosted entry point ([`platforms/base44.md`](https://www.wix.com/skills/wix-vibe-headless/platforms/base44.md)), notes its **STEP 1 carries the verbatim exec_tool `npx skills add` install** (single source of truth — not duplicated in the connector), gives the on-disk path after install, and recommends going through the flow end to end when installing rather than only mining it as reference.

## Why

Agents on the connector path build whole verticals by hand from raw API docs (observed: a bookings landing page built call-by-call, competently but expensively) with no idea the packaged vertical bootstrap exists — the connector skill never mentions it.