### PR TITLE
sync(editor-react-component): fix: yet another preview component reference update

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -131,6 +131,9 @@ extension configuration, and supporting files.
   all bodies, hide inactive accessibly.
 - Autoplay/loop: play/pause control, honor reduced motion, suppress autoplay in
   editor design mode.
-- `component.preview.tsx`: keep `withDefaults` and `withFallbackPlaceholder`,
-  wrap the preview adapter when present, one crucial `requiredDataFields`
-  entry, and `rootClassName` matching the root global class.
+- `component.preview.tsx`: preserve this outer-to-inner composition, inline or
+  through component variables:
+  `withDefaults(withFallbackPlaceholder(PreviewOrComponent, options), defaultProps)`.
+  Keep `withDefaults` outermost, wrap the preview adapter when present, use one
+  crucial `requiredDataFields` entry, and match `rootClassName` to the root
+  global class.

--- a/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
+++ b/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
@@ -216,7 +216,9 @@ Add `useIsEditMode` to the existing `@wix/react-component-utils` import. Then
 edit only the body of the existing `ComponentNamePreview` function — add the
 `isEditMode` check and gate the autoplay props. Do not touch the
 `withFallbackPlaceholder` call, the `withDefaults` export, or any other part
-of the file.
+of the file. The composition must keep `withDefaults` outside
+`withFallbackPlaceholder`, whether the calls are nested inline or assigned to
+component variables.
 
 ```tsx
 const ComponentNamePreview: FC<ComponentProps<typeof Component>> = (props) => {

--- a/skills/wix-app/references/editor-react-component/COMPONENT-PREVIEW.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-PREVIEW.md
@@ -9,14 +9,30 @@ The Wix CLI scaffold generates `component.preview.tsx` and wires its URL into
 the extension's editor resource. It includes `withDefaults`,
 `withFallbackPlaceholder`, required-data fields, and the root class name.
 
-Keep the wrapper structure and synchronize its values:
+Keep the wrapper structure and synchronize its values. The renderer detects
+preview defaults only when `withDefaults` wraps the result of
+`withFallbackPlaceholder`. The calls may be nested directly:
+
+```tsx
+export default withDefaults(
+  withFallbackPlaceholder(ComponentPreview, {
+    requiredDataFields: ['animationUrl'],
+    rootClassName: 'component-root',
+  }),
+  defaultProps,
+);
+```
 
 - Wrap the preview adapter when one exists; otherwise wrap `Component`.
 - In `requiredDataFields`, normally use only the one prop crucial to meaningful
   rendering, such as `animationUrl`. Use more only when each is essential.
 - Set `rootClassName` to the elected root's exact global class, not `styles.root`.
 
-Never remove `withFallbackPlaceholder`.
+Never remove either wrapper, export `withFallbackPlaceholder(...)` directly, or
+invert their order. Preserve the equivalent of
+`withDefaults(withFallbackPlaceholder(...), defaultProps)` even when editing
+the preview component or fallback options. Assigning either wrapped component
+to a variable is valid as long as that outer-to-inner order stays intact.
 
 ## Detect Editor Design Mode
 
@@ -40,12 +56,15 @@ timers, or network activity while a site owner is designing.
 For autoplaying components, force autoplay off in editor design mode and keep
 the live/preview prop values unchanged.
 
-Export the adapter through `withFallbackPlaceholder` and synchronize its data
-field and root class.
+Pass the adapter to `withFallbackPlaceholder`, then pass that wrapped component
+to `withDefaults`. This may be written inline as shown above or through component
+variables. Synchronize the data field and root class either way.
 
 ## Checklist
 
 - [ ] Generated wrappers target the preview adapter when one exists.
+- [ ] The default export resolves to `withDefaults` outside
+      `withFallbackPlaceholder`, whether inline or through component variables.
 - [ ] Normally one crucial data field and the exact root global class are set.
 - [ ] The extension still loads the preview URL as its editor resource.
 - [ ] `useIsEditMode()` is called inside a component.


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/114: fix: yet another preview component reference update

### What was synced
- Editor React Component entry and references managed by the private source repo
- Editor React Component a11y scanner scripts
- local paths mapped to the public wix/skills layout

Auto-generated by GitHub Actions.