### PR TITLE
vibe-headless: seed snippets require by relative path, not /app/

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -70,7 +70,7 @@ one-call `setupStore` (build-time exec_tool). Read
 contract — the `ctx` and the product/category shapes.
 
 ```js
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs"));
 const result = await seed.setupStore(ctx, { products, categories }); // one call: install → products → categories → images
 ```
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -55,7 +55,7 @@ one-call `setupStore` (build-time exec_tool). Read
 contract — the `ctx` and the product/category shapes.
 
 ```js
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs"));
 const result = await seed.setupStore(ctx, { products, categories }); // one call: install → products → categories → images
 ```
 

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -15,7 +15,7 @@ for you (Blog binds the cover by the Wix Media file id, not a url).
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const result = await seed.setupBlog(ctx, {

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -9,7 +9,7 @@ Bookings seed operation. Load it and call **`setupBookings` — the one-call pat
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ONE call: install → resolve staff → categories → services → CLASS sessions → images, all in the
@@ -104,7 +104,7 @@ Wix Rentals has no APIs of its own, so a rental is a Bookings service with renta
 field values.
 
 ```js
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/bookings/seed/seed-rentals.cjs"));
 await seed.setupRentals(ctx, {
   resourceTypeName: "Meeting rooms",
   resources: ["Room A", "Room B"],              // parallel capacity = MORE RESOURCES

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -14,7 +14,7 @@ after create, and **publishing is one-way**. So per event: create DRAFT → (tic
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/events/seed/seed-events.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // DEFAULT — one call runs the whole flow per event (create DRAFT → tiers → publish), then resolves

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -17,7 +17,7 @@ first, then thread their real ids into each project.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const summary = await seed.setupPortfolio(ctx, {

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -10,7 +10,7 @@ plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // setupPricingPlans installs the Wix Pricing Plans app first (idempotent) — base44 sites may not have it.

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -18,7 +18,7 @@ across exec calls. Online ordering and table reservations run only when the plan
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.cjs"));
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const result = await seed.setupRestaurants(ctx, {

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -13,7 +13,7 @@ the `pricing-plans` vertical, not here.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs"));
 const ctx = { token: accessToken };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept


### PR DESCRIPTION
```diff
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs");
+const seed = require(require("path").resolve(".agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs"));
```

## Why

That `require("/app/…")` was the **only** absolute path in these guides — every file they tell an agent to read is repo-relative. Agents copied the prefix onto their reads anyway.

Measured on 20 Base44 builds: **12 opened with a failed read** of `/app/.agents/…/INSTRUCTIONS.md` and `/app/.agents/…/seed/SEED.md`, then retried the same paths relative and succeeded — 46 failed reads, one to three wasted rounds each. It surfaced when Base44 began inlining the build guide into its store-setup card: reading the guide off disk, the agent's own successful *relative* read taught the convention before it met any snippet; inlined, that read is gone and the first read is a guess from the code block.

Rather than explain the distinction, the snippets now use one path convention — the same repo-relative form, resolved the way `wix-base44-connector` already does it. `exec_tool` evaluates in `/app`, so `path.resolve` lands on exactly the file the absolute literal named. Evidence: 14 of 16 observed uses of this idiom succeeded, and both failures were a genuinely missing module and a Wix 404, not resolution.

No `/app/` remains in the guide the card inlines, so there is nothing left to copy.

Applied to every vertical's seed snippet (storefront, bookings ×2, restaurants, blog, portfolio, pricing-plans, events) and the two Base44 platform guides. The install/deploy `execSync` lines keep their absolute paths — validated install code, and not confusable with a file read.