### PR TITLE
sync(editor-react-component): fix(skill): require editor component id prop

### DIFF
--- a/skills/wix-app/references/editor-react-component/ACCESSIBILITY.md
+++ b/skills/wix-app/references/editor-react-component/ACCESSIBILITY.md
@@ -25,7 +25,7 @@ import type { A11y, Direction } from '@wix/editor-react-types';
 import { convertA11yKeysToHtmlFormat } from '@wix/react-component-utils';
 
 export type TabsProps = {
-  id?: string;
+  id: string;
   className?: string;
   direction?: Direction;
   a11y?: A11y;

--- a/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
+++ b/skills/wix-app/references/editor-react-component/ANIMATED-COMPONENTS.md
@@ -58,7 +58,7 @@ able to force the safety control visible.
 import type { A11y, Direction } from '@wix/editor-react-types';
 
 export interface MyAnimationProps {
-  id?: string;
+  id: string;
   className?: string;
   direction?: Direction;
   a11y?: A11y;

--- a/skills/wix-app/references/editor-react-component/COMPONENT-CONTRACT.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-CONTRACT.md
@@ -25,7 +25,7 @@ Use this shape:
 import type { A11y, Direction } from '@wix/editor-react-types';
 
 export type PlanCardProps = {
-  id?: string;
+  id: string;
   className?: string;
   direction?: Direction;
   a11y?: A11y;
@@ -158,7 +158,7 @@ import type { ActiveItemIndex } from '@wix/react-component-utils';
 export type Step = { name: string; body: string };
 
 export type StepsProps = {
-  id?: string;
+  id: string;
   className?: string;
   direction?: Direction;
   a11y?: A11y;


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/117: fix(skill): require editor component id prop

### What was synced
- Editor React Component entry and references managed by the private source repo
- Editor React Component a11y scanner scripts
- local paths mapped to the public wix/skills layout

Auto-generated by GitHub Actions.