### PR TITLE
fix(evalforge): gate on the PR's head repository, not author_association

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30088,73 +30088,62 @@ exports.TokenProvider = TokenProvider;
 
 "use strict";
 
+/**
+ * Whether a PR's author may spend an eval run.
+ *
+ * The question this asks is "did the author have push access to this repository",
+ * answered by where the PR's head branch lives. Only someone with push access can
+ * create a branch in the repo itself; everyone else must fork, and a fork's head
+ * lives in their own namespace. The author cannot forge that — unlike a commit
+ * author email, which is free text copied from `user.email`.
+ *
+ * **`author_association` does not work for this**, which is worth recording because it
+ * looks like it should. That field is viewer-relative: GitHub computes the copy in an
+ * Actions webhook payload without visibility into private org membership, so a member
+ * whose membership is private is reported as `CONTRIBUTOR`. Measured on wix/skills, every
+ * recent PR author reads `MEMBER` to an authenticated viewer and `CONTRIBUTOR` to the
+ * payload, because none of them is a *public* org member. A gate on that field refuses
+ * everybody.
+ *
+ * This check is the same one the workflows already apply at the job level
+ * (`github.event.pull_request.head.repo.full_name == github.repository`), so the action
+ * agrees with its own trigger rather than inventing a second notion of trust.
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AuthorAssociationError = void 0;
-exports.requireAuthorAssociation = requireAuthorAssociation;
-exports.isWixOrgAuthor = isWixOrgAuthor;
-exports.assertWixAuthor = assertWixAuthor;
+exports.readHeadRepoFullName = readHeadRepoFullName;
+exports.isSameRepoBranch = isSameRepoBranch;
+exports.assertSameRepoBranch = assertSameRepoBranch;
 /**
- * Raised when the payload carries no usable association. Typed so a caller that skips rather
- * than fails can recognise it, and let every other config error keep failing the check.
- */
-class AuthorAssociationError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = 'AuthorAssociationError';
-    }
-}
-exports.AuthorAssociationError = AuthorAssociationError;
-/**
- * `author_association` values GitHub reports for someone who belongs to the
- * organization that owns the repo.
+ * The full name (`owner/repo`) of the repository holding the PR's head branch.
  *
- * GitHub computes this server-side from the account that opened the pull request, so
- * it is the only signal about the author that the author cannot set. A commit's author
- * email is free text copied from `user.email`, which is why none is consulted here.
- *
- * `COLLABORATOR` is deliberately **not** here. It means push access on this repo,
- * which an outside collaborator can hold without being in the organization — so
- * accepting it would gate on repo permissions rather than on org membership. Push
- * access is not the question this gate asks.
+ * `null` when GitHub reports no head repository. Per its payload schema `head.repo` is
+ * `oneOf: [repository, null]`, and it goes null when the source fork has been deleted.
+ * That is a real, reachable state rather than a malformed payload — and it is emphatically
+ * not this repository, so it reads as a refusal rather than an error.
  */
-const ORG_ASSOCIATIONS = new Set(['OWNER', 'MEMBER']);
-/**
- * The PR author's association, from a `pull_request` webhook payload.
- *
- * Throws rather than returning `undefined`, for the same reason `getPrNumber` does:
- * every gated mode is triggered by a `pull_request` event, and GitHub always puts
- * `author_association` on that payload's PR object. An absent one means the action was
- * wired to the wrong trigger or the payload is malformed — and a security gate that
- * cannot identify the author must fail loudly, not quietly pick a branch.
- */
-function requireAuthorAssociation(payload) {
-    const pr = payload.pull_request;
-    if (!pr) {
-        throw new AuthorAssociationError('No pull_request payload — action must be triggered by a pull_request event');
-    }
-    const association = pr.author_association;
-    if (typeof association !== 'string' || association.trim() === '') {
-        throw new AuthorAssociationError('PR payload missing author_association');
-    }
-    return association;
-}
-/** True when the PR author belongs to the organization that owns the repo. */
-function isWixOrgAuthor(association) {
-    return typeof association === 'string' && ORG_ASSOCIATIONS.has(association.trim().toUpperCase());
+function readHeadRepoFullName(payload) {
+    const fullName = payload.pull_request?.head?.repo?.full_name;
+    return typeof fullName === 'string' && fullName.trim() !== '' ? fullName : null;
 }
 /**
- * Throw unless the PR author is a member of the organization that owns the repo.
+ * True when the PR's head branch lives in this repository, which means its author had
+ * push access here.
  *
- * Takes the association rather than a client: the value is already on the payload
- * every gated mode receives, so deciding costs no API call, no token scope, and
- * nothing that can fail in transit.
+ * Compared case-insensitively: GitHub treats owner and repository names that way, and a
+ * gate should not turn on the casing of a string it did not choose.
  */
-function assertWixAuthor(association, owner, log) {
-    if (!isWixOrgAuthor(association)) {
-        throw new Error(`PR author gate failed: the PR author is not a member of the ${owner} organization ` +
-            `(author_association: ${association}). This gate is restricted to Wix authors.`);
+function isSameRepoBranch(headRepoFullName, owner, repo) {
+    if (headRepoFullName === null)
+        return false;
+    return headRepoFullName.trim().toLowerCase() === `${owner}/${repo}`.toLowerCase();
+}
+function assertSameRepoBranch(headRepoFullName, owner, repo, log) {
+    if (!isSameRepoBranch(headRepoFullName, owner, repo)) {
+        throw new Error(`PR author gate failed: this pull request's head branch is in ` +
+            `${headRepoFullName ?? 'a repository that no longer exists'}, not ${owner}/${repo}. ` +
+            `This gate is restricted to branches pushed to ${owner}/${repo}, which requires write access.`);
     }
-    log?.(`Author gate passed — PR author association: ${association}`);
+    log?.(`Author gate passed — head branch is in ${owner}/${repo}, so its author has write access.`);
 }
 
 
@@ -62851,7 +62840,6 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.MAX_TOTAL_SCENARIO_EXECUTIONS = exports.MAX_BASE_ARM_GRACE_SECONDS = exports.MAX_RUNS_PER_SCENARIO = exports.MAX_SCENARIOS_CEILING = exports.BASE_WORKSPACE_SUBDIR = void 0;
 exports.getSyncConfig = getSyncConfig;
-exports.getCommentTarget = getCommentTarget;
 exports.getGateConfig = getGateConfig;
 exports.getAnalyzeConfig = getAnalyzeConfig;
 exports.getCleanupConfig = getCleanupConfig;
@@ -62894,7 +62882,7 @@ function getSyncConfig() {
         repo: `${github.context.repo.owner}/${github.context.repo.repo}`,
         githubToken: core.getInput('github-token', { required: true }),
         prNumber: (0, evalforge_core_1.getPrNumber)(github.context.payload),
-        authorAssociation: (0, evalforge_core_1.requireAuthorAssociation)(github.context.payload),
+        headRepoFullName: (0, evalforge_core_1.readHeadRepoFullName)(github.context.payload),
     };
 }
 /** Newline-separated list input, falling back to `fallback` when blank. */
@@ -63014,18 +63002,6 @@ function getEvaluatedSha() {
         + '`evaluated-sha: ${{ steps.<checkout-step>.outputs.sha }}` from `git rev-parse HEAD`.');
     return sha;
 }
-/**
- * The minimum needed to comment on the PR: everything here is read straight from the action
- * inputs and the event context, so it stays available when building a full config throws.
- */
-function getCommentTarget() {
-    return {
-        githubToken: core.getInput('github-token', { required: true }),
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        prNumber: (0, evalforge_core_1.getPrNumber)(github.context.payload),
-    };
-}
 function getGateConfig() {
     const owner = github.context.repo.owner;
     const repo = github.context.repo.repo;
@@ -63063,7 +63039,7 @@ function getGateConfig() {
         comparisonGroupId: (0, node_crypto_1.randomUUID)(),
         runsPerScenario,
         baseArmGraceMs: getBaseArmGraceSeconds() * 1_000,
-        authorAssociation: (0, evalforge_core_1.requireAuthorAssociation)(github.context.payload),
+        headRepoFullName: (0, evalforge_core_1.readHeadRepoFullName)(github.context.payload),
     };
 }
 function getAnalyzeConfig() {
@@ -63149,28 +63125,10 @@ const pr_lookups_1 = __nccwpck_require__(1661);
 const gate_scope_1 = __nccwpck_require__(355);
 const sync_draft_scenarios_1 = __nccwpck_require__(9542);
 const run_and_report_1 = __nccwpck_require__(7535);
-/** Comments on the PR without a `GateConfig`, for the path where building one failed. */
-async function commentWithoutConfig(body) {
-    const target = (0, config_1.getCommentTarget)();
-    await (0, report_1.makeGateCommenter)(github.getOctokit(target.githubToken), target)(body);
-}
 async function runGate() {
-    // The author gate must never redden a check, so an unresolvable author is recovered here
-    // rather than escaping to `index.ts`, which turns any throw into `setFailed` — and does so
-    // regardless of `blocking`, which is the guarantee the soak period depends on. Every other
-    // config error still fails, because a missing input is a real misconfiguration.
-    let config;
-    try {
-        config = (0, config_1.getGateConfig)();
-    }
-    catch (error) {
-        if (!(error instanceof evalforge_core_1.AuthorAssociationError))
-            throw error;
-        const reason = `could not resolve the PR author: ${error.message}`;
-        core.warning(`Skipping wix-app eval gate — ${reason}`);
-        await commentWithoutConfig((0, evalforge_core_1.formatGateSkipped)(reason));
-        return;
-    }
+    // No recovery path here any more: the head repository is on the payload, so the gate always
+    // has an answer. There is no lookup to fail and nothing for a `blocking` run to trip over.
+    const config = (0, config_1.getGateConfig)();
     const octokit = github.getOctokit(config.githubToken);
     const comment = (0, report_1.makeGateCommenter)(octokit, config);
     // First, so a fork PR costs nothing. Skips rather than fails, and says so on the PR,
@@ -63377,9 +63335,12 @@ const AUTHOR_ALLOWED = { allowed: true };
  * triggered by, so there is no lookup here to blip, and no "could not resolve" case.
  */
 function checkPrAuthor(config) {
-    if ((0, evalforge_core_1.isWixOrgAuthor)(config.authorAssociation))
+    if ((0, evalforge_core_1.isSameRepoBranch)(config.headRepoFullName, config.owner, config.repo))
         return AUTHOR_ALLOWED;
-    return { allowed: false, reason: 'the PR author is not a wix author' };
+    return {
+        allowed: false,
+        reason: 'the PR branch is not in this repository, so its author has no write access',
+    };
 }
 /** True when unresolvable, so a lookup failure never releases another PR's lock. */
 async function isDraftTagActive(octokit, tag) {
@@ -63866,20 +63827,10 @@ async function applyPlan(client, projectId, plan) {
     return { hasFailures };
 }
 async function runSync() {
-    // Same recovery as the gate: an unresolvable author skips, it does not fail the check.
-    // This mode posts no comment, so the log line is the whole report.
-    let config;
-    try {
-        config = (0, config_1.getSyncConfig)();
-    }
-    catch (error) {
-        if (!(error instanceof evalforge_core_1.AuthorAssociationError))
-            throw error;
-        core.warning(`Skipping wix-app sync — could not resolve the PR author: ${error.message}`);
-        return;
-    }
-    if (!(0, evalforge_core_1.isWixOrgAuthor)(config.authorAssociation)) {
-        core.info('Skipping wix-app sync — PR author is not a Wix author');
+    const config = (0, config_1.getSyncConfig)();
+    const [owner, repoName] = config.repo.split('/', 2);
+    if (!(0, evalforge_core_1.isSameRepoBranch)(config.headRepoFullName, owner, repoName)) {
+        core.info('Skipping wix-app sync — the PR branch is not in this repository');
         return;
     }
     const workspace = (0, workspace_1.workspaceRoot)();

--- a/.github/actions/evalforge-skill-gate/src/utils/config.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/config.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github';
 import {
   DEFAULT_BASE_ARM_GRACE_SECONDS, DEFAULT_BROAD_IMPACT_GLOBS, DEFAULT_IGNORE_GLOBS, DEFAULT_MAX_SCENARIOS,
   DEFAULT_REFERENCE_DIR, DEFAULT_RUNS_PER_SCENARIO, ensureHttps, safeGetSecret, getPrNumber,
-  requireAuthorAssociation,
+  readHeadRepoFullName,
 } from '@wix/evalforge-core';
 
 /** Subdirectory the base-SHA checkout lands in, matching the yaml-gate workflows. */
@@ -46,8 +46,8 @@ export type SyncConfig = {
   repo: string;
   githubToken: string;
   prNumber: number;
-  /** GitHub's server-side view of the PR author's relationship to this repo. */
-  authorAssociation: string;
+  /** Where the PR's head branch lives; `null` if that repository is gone. */
+  headRepoFullName: string | null;
 };
 
 export function getSyncConfig(): SyncConfig {
@@ -60,7 +60,7 @@ export function getSyncConfig(): SyncConfig {
     repo: `${github.context.repo.owner}/${github.context.repo.repo}`,
     githubToken: core.getInput('github-token', { required: true }),
     prNumber: getPrNumber(github.context.payload),
-    authorAssociation: requireAuthorAssociation(github.context.payload),
+    headRepoFullName: readHeadRepoFullName(github.context.payload),
   };
 }
 
@@ -94,8 +94,8 @@ export type GateConfig = {
   baseSha: string;
   comparisonGroupId: string;
   runsPerScenario: number;
-  /** GitHub's server-side view of the PR author's relationship to this repo. */
-  authorAssociation: string;
+  /** Where the PR's head branch lives; `null` if that repository is gone. */
+  headRepoFullName: string | null;
   /** Milliseconds, converted once here from the `base-arm-grace-seconds` input — see `getBaseArmGraceSeconds`. */
   baseArmGraceMs: number;
 };
@@ -243,19 +243,6 @@ function getEvaluatedSha(): string {
   return sha;
 }
 
-/**
- * The minimum needed to comment on the PR: everything here is read straight from the action
- * inputs and the event context, so it stays available when building a full config throws.
- */
-export function getCommentTarget(): { githubToken: string; owner: string; repo: string; prNumber: number } {
-  return {
-    githubToken: core.getInput('github-token', { required: true }),
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    prNumber: getPrNumber(github.context.payload),
-  };
-}
-
 export function getGateConfig(): GateConfig {
   const owner = github.context.repo.owner;
   const repo = github.context.repo.repo;
@@ -294,7 +281,7 @@ export function getGateConfig(): GateConfig {
     comparisonGroupId: randomUUID(),
     runsPerScenario,
     baseArmGraceMs: getBaseArmGraceSeconds() * 1_000,
-    authorAssociation: requireAuthorAssociation(github.context.payload),
+    headRepoFullName: readHeadRepoFullName(github.context.payload),
   };
 }
 

--- a/.github/actions/evalforge-skill-gate/src/utils/gate-run.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/gate-run.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { AuthorAssociationError, EvalForgeClient, draftTagFor, formatGateSkipped } from '@wix/evalforge-core';
-import { getCommentTarget, getGateConfig, type GateConfig } from './config';
+import { EvalForgeClient, draftTagFor, formatGateSkipped } from '@wix/evalforge-core';
+import { getGateConfig } from './config';
 import { workspaceRoot } from './workspace';
 import { guardedCall, makeAnalysisUpdater, makeGateCommenter } from './report';
 import { checkPrAuthor } from './pr-lookups';
@@ -9,28 +9,10 @@ import { resolveGateScope } from './gate-scope';
 import { syncDraftScenarios } from './sync-draft-scenarios';
 import { runAndReport } from './run-and-report';
 
-/** Comments on the PR without a `GateConfig`, for the path where building one failed. */
-async function commentWithoutConfig(body: string): Promise<void> {
-  const target = getCommentTarget();
-  await makeGateCommenter(github.getOctokit(target.githubToken), target)(body);
-}
-
 export async function runGate(): Promise<void> {
-  // The author gate must never redden a check, so an unresolvable author is recovered here
-  // rather than escaping to `index.ts`, which turns any throw into `setFailed` — and does so
-  // regardless of `blocking`, which is the guarantee the soak period depends on. Every other
-  // config error still fails, because a missing input is a real misconfiguration.
-  let config: GateConfig;
-  try {
-    config = getGateConfig();
-  } catch (error) {
-    if (!(error instanceof AuthorAssociationError)) throw error;
-    const reason = `could not resolve the PR author: ${error.message}`;
-    core.warning(`Skipping wix-app eval gate — ${reason}`);
-    await commentWithoutConfig(formatGateSkipped(reason));
-    return;
-  }
-
+  // No recovery path here any more: the head repository is on the payload, so the gate always
+  // has an answer. There is no lookup to fail and nothing for a `blocking` run to trip over.
+  const config = getGateConfig();
   const octokit = github.getOctokit(config.githubToken);
   const comment = makeGateCommenter(octokit, config);
 

--- a/.github/actions/evalforge-skill-gate/src/utils/pr-lookups.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/pr-lookups.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { isWixOrgAuthor, parseDraftTag } from '@wix/evalforge-core';
+import { isSameRepoBranch, parseDraftTag } from '@wix/evalforge-core';
 import { describeError } from './report';
 import type { GateConfig } from './config';
 
@@ -20,10 +20,13 @@ const AUTHOR_ALLOWED: AuthorCheck = { allowed: true };
  * triggered by, so there is no lookup here to blip, and no "could not resolve" case.
  */
 export function checkPrAuthor(
-  config: Pick<GateConfig, 'authorAssociation'>,
+  config: Pick<GateConfig, 'owner' | 'repo' | 'headRepoFullName'>,
 ): AuthorCheck {
-  if (isWixOrgAuthor(config.authorAssociation)) return AUTHOR_ALLOWED;
-  return { allowed: false, reason: 'the PR author is not a wix author' };
+  if (isSameRepoBranch(config.headRepoFullName, config.owner, config.repo)) return AUTHOR_ALLOWED;
+  return {
+    allowed: false,
+    reason: 'the PR branch is not in this repository, so its author has no write access',
+  };
 }
 
 /** True when unresolvable, so a lookup failure never releases another PR's lock. */

--- a/.github/actions/evalforge-skill-gate/src/utils/sync-run.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/sync-run.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import { AuthorAssociationError, EvalForgeClient, isWixOrgAuthor, loadScenarios, planScenarioSync, type ScenarioSyncAction, type ScenarioSyncSkip } from '@wix/evalforge-core';
+import { EvalForgeClient, isSameRepoBranch, loadScenarios, planScenarioSync, type ScenarioSyncAction, type ScenarioSyncSkip } from '@wix/evalforge-core';
 import { getSyncConfig, type SyncConfig } from './config';
 import { workspaceRoot } from './workspace';
 
@@ -39,19 +39,10 @@ export async function applyPlan(
 }
 
 export async function runSync(): Promise<void> {
-  // Same recovery as the gate: an unresolvable author skips, it does not fail the check.
-  // This mode posts no comment, so the log line is the whole report.
-  let config: SyncConfig;
-  try {
-    config = getSyncConfig();
-  } catch (error) {
-    if (!(error instanceof AuthorAssociationError)) throw error;
-    core.warning(`Skipping wix-app sync — could not resolve the PR author: ${error.message}`);
-    return;
-  }
-
-  if (!isWixOrgAuthor(config.authorAssociation)) {
-    core.info('Skipping wix-app sync — PR author is not a Wix author');
+  const config = getSyncConfig();
+  const [owner, repoName] = config.repo.split('/', 2);
+  if (!isSameRepoBranch(config.headRepoFullName, owner, repoName)) {
+    core.info('Skipping wix-app sync — the PR branch is not in this repository');
     return;
   }
 

--- a/.github/actions/evalforge-skill-gate/tests/comparison-arms.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/comparison-arms.test.ts
@@ -33,7 +33,7 @@ const CONFIG: GateConfig = {
   comparisonGroupId: 'group-1',
   runsPerScenario: 3,
   baseArmGraceMs: 60_000,
-  authorAssociation: 'MEMBER',
+  headRepoFullName: 'wix/skills',
 };
 
 const runCreated = (id: string): EvalRunCreated => ({ id, status: 'pending' });

--- a/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
@@ -4,9 +4,6 @@ import type { GateConfig } from '../src/utils/config';
 
 vi.mock('../src/utils/config', () => ({
   getGateConfig: vi.fn(),
-  getCommentTarget: vi.fn(() => ({
-    githubToken: 'gh-token', owner: 'wix', repo: 'skills', prNumber: 42,
-  })),
   BASE_WORKSPACE_SUBDIR: '.action-src',
 }));
 
@@ -79,7 +76,7 @@ const CONFIG: GateConfig = {
   comparisonGroupId: 'pr-42-merge99',
   runsPerScenario: 1,
   baseArmGraceMs: 60_000,
-  authorAssociation: 'MEMBER',
+  headRepoFullName: 'wix/skills',
 };
 
 const strongScenario = (name: string, tags: string[]) => ({
@@ -129,66 +126,9 @@ async function harness(configOverrides: Partial<GateConfig> = {}) {
   return { runGate, core: coreModule, evalforge };
 }
 
-describe('runGate — an unresolvable author skips, it never reddens the check', () => {
-  /**
-   * `index.ts` turns any escaped throw into `setFailed`, and does so regardless of
-   * `blocking` — so a config that throws over the author would fail a required check
-   * during the soak period, which is exactly what the gate promises it cannot do.
-   */
-  async function harnessThrowing(error: Error) {
-    const { getGateConfig } = await import('../src/utils/config');
-    const coreModule = await import('@actions/core');
-    const evalforge = await import('@wix/evalforge-core');
-    const { runGate } = await import('../src/utils/gate-run');
-    vi.mocked(getGateConfig).mockImplementation(() => { throw error; });
-    return { runGate, core: coreModule, evalforge };
-  }
-
-  it('skips rather than fails when the author cannot be resolved', async () => {
-    const { AuthorAssociationError } = await import('@wix/evalforge-core');
-    const { runGate, core, evalforge } = await harnessThrowing(
-      new AuthorAssociationError('PR payload missing author_association'),
-    );
-    const setFailedSpy = vi.spyOn(core, 'setFailed');
-    const warningSpy = vi.spyOn(core, 'warning');
-
-    await runGate();
-
-    expect(evalforge.EvalForgeClient).not.toHaveBeenCalled();
-    expect(setFailedSpy).not.toHaveBeenCalled();
-    expect(warningSpy).toHaveBeenCalledWith(expect.stringContaining('could not resolve the PR author'));
-  });
-
-  // Returning normally is what keeps index.ts from calling setFailed, so this is the
-  // blocking-on case: there is no path left by which the check can go red.
-  it('returns normally, so nothing downstream can fail the check', async () => {
-    const { AuthorAssociationError } = await import('@wix/evalforge-core');
-    const { runGate } = await harnessThrowing(new AuthorAssociationError('missing'));
-
-    await expect(runGate()).resolves.toBeUndefined();
-  });
-
-  it('comments on skip, so a green check is not mistaken for a pass', async () => {
-    const { AuthorAssociationError } = await import('@wix/evalforge-core');
-    const { runGate } = await harnessThrowing(new AuthorAssociationError('missing'));
-
-    await runGate();
-
-    expect(upsertComment).toHaveBeenCalledWith(expect.stringContaining('could not resolve the PR author'));
-  });
-
-  // The recovery is scoped to the author. A missing input is a real misconfiguration and
-  // must still fail, or this catch would hide every broken workflow.
-  it('still fails for a config error that is not about the author', async () => {
-    const { runGate } = await harnessThrowing(new Error('Input required and not supplied: evalforge-url'));
-
-    await expect(runGate()).rejects.toThrow('Input required and not supplied: evalforge-url');
-  });
-});
-
 describe('runGate — cheap exits before any EvalForge write', () => {
   it('exits without touching EvalForge when the PR author is not a Wix author', async () => {
-    const { runGate, core, evalforge } = await harness({ authorAssociation: 'NONE' });
+    const { runGate, core, evalforge } = await harness({ headRepoFullName: 'outsider/skills' });
     const setFailedSpy = vi.spyOn(core, 'setFailed');
 
     await runGate();
@@ -199,12 +139,12 @@ describe('runGate — cheap exits before any EvalForge write', () => {
   });
 
   it('comments on skip, so a green check is not mistaken for a pass', async () => {
-    const { runGate, evalforge } = await harness({ authorAssociation: 'NONE' });
+    const { runGate, evalforge } = await harness({ headRepoFullName: 'outsider/skills' });
 
     await runGate();
 
     expect(upsertComment).toHaveBeenCalledWith(expect.stringMatching(/\*\*not evaluated\*\*/));
-    expect(upsertComment).toHaveBeenCalledWith(expect.stringContaining('not a wix author'));
+    expect(upsertComment).toHaveBeenCalledWith(expect.stringContaining('not in this repository'));
   });
 
   it('fails on YAML load errors before creating any capability version', async () => {

--- a/.github/actions/evalforge-skill-gate/tests/pr-lookups.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/pr-lookups.test.ts
@@ -17,24 +17,24 @@ beforeEach(() => {
 });
 
 describe('checkPrAuthor', () => {
-  it('allows an org member', async () => {
+  it('allows a branch pushed to this repository', async () => {
     const { checkPrAuthor } = await import('../src/utils/pr-lookups');
-    expect(checkPrAuthor({ authorAssociation: 'MEMBER' })).toEqual({ allowed: true });
+    expect(checkPrAuthor({ owner: 'wix', repo: 'skills', headRepoFullName: 'wix/skills' })).toEqual({ allowed: true });
   });
 
-  it('denies an outside author, with the reason the gate comments on the PR', async () => {
+  it('denies a fork, with the reason the gate comments on the PR', async () => {
     const { checkPrAuthor } = await import('../src/utils/pr-lookups');
-    expect(checkPrAuthor({ authorAssociation: 'NONE' })).toEqual({
+    expect(checkPrAuthor({ owner: 'wix', repo: 'skills', headRepoFullName: 'outsider/skills' })).toEqual({
       allowed: false,
-      reason: 'the PR author is not a wix author',
+      reason: 'the PR branch is not in this repository, so its author has no write access',
     });
   });
 
   // A missing return here would open the gate rather than close it, which is why the result is a
   // discriminated union rather than an optional value.
-  it('denies a collaborator, who has push access but no org membership', async () => {
+  it('denies a PR whose head repository has been deleted', async () => {
     const { checkPrAuthor } = await import('../src/utils/pr-lookups');
-    expect(checkPrAuthor({ authorAssociation: 'COLLABORATOR' }).allowed).toBe(false);
+    expect(checkPrAuthor({ owner: 'wix', repo: 'skills', headRepoFullName: null }).allowed).toBe(false);
   });
 });
 

--- a/.github/actions/evalforge-skill-gate/tests/run-and-report.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/run-and-report.test.ts
@@ -47,7 +47,7 @@ const CONFIG: GateConfig = {
   comparisonGroupId: 'group-1',
   runsPerScenario: 1,
   baseArmGraceMs: 60_000,
-  authorAssociation: 'MEMBER',
+  headRepoFullName: 'wix/skills',
 };
 
 const SCOPE: GateScope = {

--- a/.github/actions/evalforge-skill-gate/tests/sync-run.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/sync-run.test.ts
@@ -87,20 +87,20 @@ describe('runSync — author gate', () => {
     repo: 'wix/skills',
     githubToken: 'gh-token',
     prNumber: 42,
-    authorAssociation: 'MEMBER',
+    headRepoFullName: 'wix/skills',
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('skips the sync (no EvalForge calls, no setFailed) when the PR author is not a Wix author', async () => {
+  it('skips the sync (no EvalForge calls, no setFailed) when the PR branch is a fork', async () => {
     const { getSyncConfig } = await import('../src/utils/config');
     const core = await import('@actions/core');
     const { loadScenarios, EvalForgeClient } = await import('@wix/evalforge-core');
     const { runSync } = await import('../src/utils/sync-run');
 
-    vi.mocked(getSyncConfig).mockReturnValue({ ...baseConfig, authorAssociation: 'NONE' });
+    vi.mocked(getSyncConfig).mockReturnValue({ ...baseConfig, headRepoFullName: 'outsider/skills' });
     const setFailedSpy = vi.spyOn(core, 'setFailed');
     const infoSpy = vi.spyOn(core, 'info');
 
@@ -110,10 +110,10 @@ describe('runSync — author gate', () => {
     expect(EvalForgeClient).not.toHaveBeenCalled();
     expect(listTestScenarios).not.toHaveBeenCalled();
     expect(setFailedSpy).not.toHaveBeenCalled();
-    expect(infoSpy).toHaveBeenCalledWith('Skipping wix-app sync — PR author is not a Wix author');
+    expect(infoSpy).toHaveBeenCalledWith('Skipping wix-app sync — the PR branch is not in this repository');
   });
 
-  it('proceeds for an org member', async () => {
+  it('proceeds for a branch in this repository', async () => {
     const { getSyncConfig } = await import('../src/utils/config');
     const { loadScenarios } = await import('@wix/evalforge-core');
     const { runSync } = await import('../src/utils/sync-run');

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34202,73 +34202,62 @@ exports.TokenProvider = TokenProvider;
 
 "use strict";
 
+/**
+ * Whether a PR's author may spend an eval run.
+ *
+ * The question this asks is "did the author have push access to this repository",
+ * answered by where the PR's head branch lives. Only someone with push access can
+ * create a branch in the repo itself; everyone else must fork, and a fork's head
+ * lives in their own namespace. The author cannot forge that — unlike a commit
+ * author email, which is free text copied from `user.email`.
+ *
+ * **`author_association` does not work for this**, which is worth recording because it
+ * looks like it should. That field is viewer-relative: GitHub computes the copy in an
+ * Actions webhook payload without visibility into private org membership, so a member
+ * whose membership is private is reported as `CONTRIBUTOR`. Measured on wix/skills, every
+ * recent PR author reads `MEMBER` to an authenticated viewer and `CONTRIBUTOR` to the
+ * payload, because none of them is a *public* org member. A gate on that field refuses
+ * everybody.
+ *
+ * This check is the same one the workflows already apply at the job level
+ * (`github.event.pull_request.head.repo.full_name == github.repository`), so the action
+ * agrees with its own trigger rather than inventing a second notion of trust.
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AuthorAssociationError = void 0;
-exports.requireAuthorAssociation = requireAuthorAssociation;
-exports.isWixOrgAuthor = isWixOrgAuthor;
-exports.assertWixAuthor = assertWixAuthor;
+exports.readHeadRepoFullName = readHeadRepoFullName;
+exports.isSameRepoBranch = isSameRepoBranch;
+exports.assertSameRepoBranch = assertSameRepoBranch;
 /**
- * Raised when the payload carries no usable association. Typed so a caller that skips rather
- * than fails can recognise it, and let every other config error keep failing the check.
- */
-class AuthorAssociationError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = 'AuthorAssociationError';
-    }
-}
-exports.AuthorAssociationError = AuthorAssociationError;
-/**
- * `author_association` values GitHub reports for someone who belongs to the
- * organization that owns the repo.
+ * The full name (`owner/repo`) of the repository holding the PR's head branch.
  *
- * GitHub computes this server-side from the account that opened the pull request, so
- * it is the only signal about the author that the author cannot set. A commit's author
- * email is free text copied from `user.email`, which is why none is consulted here.
- *
- * `COLLABORATOR` is deliberately **not** here. It means push access on this repo,
- * which an outside collaborator can hold without being in the organization — so
- * accepting it would gate on repo permissions rather than on org membership. Push
- * access is not the question this gate asks.
+ * `null` when GitHub reports no head repository. Per its payload schema `head.repo` is
+ * `oneOf: [repository, null]`, and it goes null when the source fork has been deleted.
+ * That is a real, reachable state rather than a malformed payload — and it is emphatically
+ * not this repository, so it reads as a refusal rather than an error.
  */
-const ORG_ASSOCIATIONS = new Set(['OWNER', 'MEMBER']);
-/**
- * The PR author's association, from a `pull_request` webhook payload.
- *
- * Throws rather than returning `undefined`, for the same reason `getPrNumber` does:
- * every gated mode is triggered by a `pull_request` event, and GitHub always puts
- * `author_association` on that payload's PR object. An absent one means the action was
- * wired to the wrong trigger or the payload is malformed — and a security gate that
- * cannot identify the author must fail loudly, not quietly pick a branch.
- */
-function requireAuthorAssociation(payload) {
-    const pr = payload.pull_request;
-    if (!pr) {
-        throw new AuthorAssociationError('No pull_request payload — action must be triggered by a pull_request event');
-    }
-    const association = pr.author_association;
-    if (typeof association !== 'string' || association.trim() === '') {
-        throw new AuthorAssociationError('PR payload missing author_association');
-    }
-    return association;
-}
-/** True when the PR author belongs to the organization that owns the repo. */
-function isWixOrgAuthor(association) {
-    return typeof association === 'string' && ORG_ASSOCIATIONS.has(association.trim().toUpperCase());
+function readHeadRepoFullName(payload) {
+    const fullName = payload.pull_request?.head?.repo?.full_name;
+    return typeof fullName === 'string' && fullName.trim() !== '' ? fullName : null;
 }
 /**
- * Throw unless the PR author is a member of the organization that owns the repo.
+ * True when the PR's head branch lives in this repository, which means its author had
+ * push access here.
  *
- * Takes the association rather than a client: the value is already on the payload
- * every gated mode receives, so deciding costs no API call, no token scope, and
- * nothing that can fail in transit.
+ * Compared case-insensitively: GitHub treats owner and repository names that way, and a
+ * gate should not turn on the casing of a string it did not choose.
  */
-function assertWixAuthor(association, owner, log) {
-    if (!isWixOrgAuthor(association)) {
-        throw new Error(`PR author gate failed: the PR author is not a member of the ${owner} organization ` +
-            `(author_association: ${association}). This gate is restricted to Wix authors.`);
+function isSameRepoBranch(headRepoFullName, owner, repo) {
+    if (headRepoFullName === null)
+        return false;
+    return headRepoFullName.trim().toLowerCase() === `${owner}/${repo}`.toLowerCase();
+}
+function assertSameRepoBranch(headRepoFullName, owner, repo, log) {
+    if (!isSameRepoBranch(headRepoFullName, owner, repo)) {
+        throw new Error(`PR author gate failed: this pull request's head branch is in ` +
+            `${headRepoFullName ?? 'a repository that no longer exists'}, not ${owner}/${repo}. ` +
+            `This gate is restricted to branches pushed to ${owner}/${repo}, which requires write access.`);
     }
-    log?.(`Author gate passed — PR author association: ${association}`);
+    log?.(`Author gate passed — head branch is in ${owner}/${repo}, so its author has write access.`);
 }
 
 
@@ -66750,7 +66739,7 @@ function getSimpleConfig() {
         prNumber: (0, evalforge_core_1.getPrNumber)(github.context.payload),
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        authorAssociation: (0, evalforge_core_1.requireAuthorAssociation)(github.context.payload),
+        headRepoFullName: (0, evalforge_core_1.readHeadRepoFullName)(github.context.payload),
     };
 }
 function getScheduleConfig() {
@@ -66847,7 +66836,7 @@ function getReviewConfig() {
         // variable must not fail a check that promises it cannot fail during soak.
         timeoutSeconds: getClampedReviewTimeout(),
         isBlocking: core.getInput('blocking') === 'true',
-        authorAssociation: (0, evalforge_core_1.requireAuthorAssociation)(github.context.payload),
+        headRepoFullName: (0, evalforge_core_1.readHeadRepoFullName)(github.context.payload),
     };
 }
 function getClampedReviewTimeout() {
@@ -67577,7 +67566,7 @@ async function isDraftTagActive(octokit, tag) {
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
     const octokit = github.getOctokit(config.githubToken);
-    (0, evalforge_core_1.assertWixAuthor)(config.authorAssociation, config.owner, core.info);
+    (0, evalforge_core_1.assertSameRepoBranch)(config.headRepoFullName, config.owner, config.repo, core.info);
     const comment = (0, github_1.makeCommenter)(octokit, config.owner, config.repo, config.prNumber);
     const workspace = (0, workspace_1.workspaceRoot)();
     const baseWorkspace = node_path_1.posix.join(workspace, paths_1.BASE_WORKSPACE_SUBDIR);
@@ -68901,19 +68890,7 @@ async function reportUnavailable(reason, pending, isBlocking) {
     (0, github_1.fail)(`The skill review did not complete: ${reason}`, isBlocking);
 }
 async function runReview() {
-    // An unresolvable author skips rather than failing, the same as one who is simply not a
-    // Wix author. Every other config error still fails: a missing input is a misconfiguration,
-    // not a question about who opened the PR.
-    let config;
-    try {
-        config = (0, config_1.getReviewConfig)();
-    }
-    catch (error) {
-        if (!(error instanceof evalforge_core_1.AuthorAssociationError))
-            throw error;
-        core.info(`Skipping the skill review — could not resolve the PR author: ${error.message}`);
-        return;
-    }
+    const config = (0, config_1.getReviewConfig)();
     const octokit = github.getOctokit(config.githubToken);
     const comment = (0, github_1.makeReviewCommenter)(octokit, config.owner, config.repo, config.prNumber);
     const pending = (0, github_1.makeReviewPendingCommenter)(octokit, config.owner, config.repo, config.prNumber);
@@ -68930,10 +68907,10 @@ async function runReview() {
         await pending.clear();
         return;
     }
-    // Not `assertWixAuthor`: this mode skips rather than throwing for a non-Wix author.
-    // The association is already on the payload, so there is nothing here that can fail.
-    if (!(0, evalforge_core_1.isWixOrgAuthor)(config.authorAssociation)) {
-        const reason = 'the PR author is not a wix author';
+    // Not `assertSameRepoBranch`: this mode skips rather than throwing. The head repo is on
+    // the payload, so the answer is always available and there is nothing here that can fail.
+    if (!(0, evalforge_core_1.isSameRepoBranch)(config.headRepoFullName, config.owner, config.repo)) {
+        const reason = 'the PR branch is not in this repository, so its author has no write access';
         core.info(`Skipping the skill review — ${reason}`);
         await comment((0, review_comment_1.formatReviewSkipped)(reason));
         await pending.clear();

--- a/.github/actions/evalforge-yaml-gate/src/utils/config.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/config.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { ensureHttps as coreEnsureHttps, safeGetSecret as coreSafeGetSecret, getPrNumber as coreGetPrNumber, requireAuthorAssociation } from '@wix/evalforge-core';
+import { ensureHttps as coreEnsureHttps, safeGetSecret as coreSafeGetSecret, getPrNumber as coreGetPrNumber, readHeadRepoFullName } from '@wix/evalforge-core';
 
 export type SimpleConfig = {
   githubToken: string;
@@ -12,8 +12,8 @@ export type SimpleConfig = {
   prNumber: number;
   owner: string;
   repo: string;
-  /** GitHub's server-side view of the PR author's relationship to this repo. */
-  authorAssociation: string;
+  /** Where the PR's head branch lives; `null` if that repository is gone. */
+  headRepoFullName: string | null;
 };
 
 export type Config = SimpleConfig & {
@@ -51,7 +51,7 @@ export function getSimpleConfig(): SimpleConfig {
     prNumber: coreGetPrNumber(github.context.payload),
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    authorAssociation: requireAuthorAssociation(github.context.payload),
+    headRepoFullName: readHeadRepoFullName(github.context.payload),
   };
 }
 
@@ -171,8 +171,8 @@ export type ReviewConfig = {
   effort: string;
   timeoutSeconds: number;
   isBlocking: boolean;
-  /** GitHub's server-side view of the PR author's relationship to this repo. */
-  authorAssociation: string;
+  /** Where the PR's head branch lives; `null` if that repository is gone. */
+  headRepoFullName: string | null;
 };
 
 export function getReviewConfig(): ReviewConfig {
@@ -198,7 +198,7 @@ export function getReviewConfig(): ReviewConfig {
     // variable must not fail a check that promises it cannot fail during soak.
     timeoutSeconds: getClampedReviewTimeout(),
     isBlocking: core.getInput('blocking') === 'true',
-    authorAssociation: requireAuthorAssociation(github.context.payload),
+    headRepoFullName: readHeadRepoFullName(github.context.payload),
   };
 }
 

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -8,7 +8,7 @@ import { canonicalDocUrl } from './doc-url';
 import { changedDocsEntries, validateDocsEntries } from './docs-entry-check';
 import { computeCoverage } from './coverage';
 import {
-  EvalForgeClient, assertWixAuthor, diffSyncPlan, draftTagFor, evalRunUrl,
+  EvalForgeClient, assertSameRepoBranch, diffSyncPlan, draftTagFor, evalRunUrl,
   listRemoteScenariosForGate, parseDraftTag, remoteScenarioFiltersForGate,
   stripInactiveForeignDraftTags, type RemoteScenario,
 } from '@wix/evalforge-core';
@@ -94,7 +94,7 @@ async function isDraftTagActive(
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
-  assertWixAuthor(config.authorAssociation, config.owner, core.info);
+  assertSameRepoBranch(config.headRepoFullName, config.owner, config.repo, core.info);
   const comment = makeCommenter(octokit, config.owner, config.repo, config.prNumber);
   const workspace = workspaceRoot();
   const baseWorkspace = posix.join(workspace, BASE_WORKSPACE_SUBDIR);

--- a/.github/actions/evalforge-yaml-gate/src/utils/review.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/review.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { AuthorAssociationError, isWixOrgAuthor } from '@wix/evalforge-core';
+import { isSameRepoBranch } from '@wix/evalforge-core';
 import { getReviewConfig, type ReviewConfig } from './config';
 import {
   classifyChanges, fail, getChangedFiles, makeReviewCommenter, makeReviewPendingCommenter,
@@ -60,18 +60,7 @@ async function reportUnavailable(
 }
 
 export async function runReview(): Promise<void> {
-  // An unresolvable author skips rather than failing, the same as one who is simply not a
-  // Wix author. Every other config error still fails: a missing input is a misconfiguration,
-  // not a question about who opened the PR.
-  let config: ReviewConfig;
-  try {
-    config = getReviewConfig();
-  } catch (error) {
-    if (!(error instanceof AuthorAssociationError)) throw error;
-    core.info(`Skipping the skill review — could not resolve the PR author: ${error.message}`);
-    return;
-  }
-
+  const config = getReviewConfig();
   const octokit = github.getOctokit(config.githubToken);
 
   const comment = makeReviewCommenter(octokit, config.owner, config.repo, config.prNumber);
@@ -91,10 +80,10 @@ export async function runReview(): Promise<void> {
     return;
   }
 
-  // Not `assertWixAuthor`: this mode skips rather than throwing for a non-Wix author.
-  // The association is already on the payload, so there is nothing here that can fail.
-  if (!isWixOrgAuthor(config.authorAssociation)) {
-    const reason = 'the PR author is not a wix author';
+  // Not `assertSameRepoBranch`: this mode skips rather than throwing. The head repo is on
+  // the payload, so the answer is always available and there is nothing here that can fail.
+  if (!isSameRepoBranch(config.headRepoFullName, config.owner, config.repo)) {
+    const reason = 'the PR branch is not in this repository, so its author has no write access';
     core.info(`Skipping the skill review — ${reason}`);
     await comment(formatReviewSkipped(reason));
     await pending.clear();

--- a/.github/actions/evalforge-yaml-gate/tests/review.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/review.test.ts
@@ -32,12 +32,11 @@ vi.mock('../src/utils/review-agent', () => ({ runReviewAgent }));
 
 vi.mock('node:fs', () => ({ existsSync }));
 
-/** An org member's PR, which is how every real PR from this org arrives. */
+/** A branch pushed to this repository, which is how every non-fork PR arrives. */
 const basePullRequest = {
   number: 42,
-  head: { sha: 'abcdef1234' },
+  head: { sha: 'abcdef1234', repo: { full_name: 'wix/skills' } },
   base: { sha: 'base5678' },
-  author_association: 'MEMBER',
 };
 
 const payload: { action: string; pull_request: Record<string, unknown> } = {
@@ -70,7 +69,12 @@ const finding = (over: Partial<ReviewFinding> = {}): ReviewFinding => ({
 });
 
 /** GitHub's own verdict that the author is an outsider. */
-const asOutsideAuthor = () => { payload.pull_request = { ...basePullRequest, author_association: 'NONE' }; };
+const asOutsideAuthor = () => {
+  payload.pull_request = {
+    ...basePullRequest,
+    head: { sha: 'abcdef1234', repo: { full_name: 'outsider/skills' } },
+  };
+};
 
 let setFailed: ReturnType<typeof vi.spyOn>;
 

--- a/.github/actions/skill-eval/dist/index.js
+++ b/.github/actions/skill-eval/dist/index.js
@@ -34202,73 +34202,62 @@ exports.TokenProvider = TokenProvider;
 
 "use strict";
 
+/**
+ * Whether a PR's author may spend an eval run.
+ *
+ * The question this asks is "did the author have push access to this repository",
+ * answered by where the PR's head branch lives. Only someone with push access can
+ * create a branch in the repo itself; everyone else must fork, and a fork's head
+ * lives in their own namespace. The author cannot forge that — unlike a commit
+ * author email, which is free text copied from `user.email`.
+ *
+ * **`author_association` does not work for this**, which is worth recording because it
+ * looks like it should. That field is viewer-relative: GitHub computes the copy in an
+ * Actions webhook payload without visibility into private org membership, so a member
+ * whose membership is private is reported as `CONTRIBUTOR`. Measured on wix/skills, every
+ * recent PR author reads `MEMBER` to an authenticated viewer and `CONTRIBUTOR` to the
+ * payload, because none of them is a *public* org member. A gate on that field refuses
+ * everybody.
+ *
+ * This check is the same one the workflows already apply at the job level
+ * (`github.event.pull_request.head.repo.full_name == github.repository`), so the action
+ * agrees with its own trigger rather than inventing a second notion of trust.
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.AuthorAssociationError = void 0;
-exports.requireAuthorAssociation = requireAuthorAssociation;
-exports.isWixOrgAuthor = isWixOrgAuthor;
-exports.assertWixAuthor = assertWixAuthor;
+exports.readHeadRepoFullName = readHeadRepoFullName;
+exports.isSameRepoBranch = isSameRepoBranch;
+exports.assertSameRepoBranch = assertSameRepoBranch;
 /**
- * Raised when the payload carries no usable association. Typed so a caller that skips rather
- * than fails can recognise it, and let every other config error keep failing the check.
- */
-class AuthorAssociationError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = 'AuthorAssociationError';
-    }
-}
-exports.AuthorAssociationError = AuthorAssociationError;
-/**
- * `author_association` values GitHub reports for someone who belongs to the
- * organization that owns the repo.
+ * The full name (`owner/repo`) of the repository holding the PR's head branch.
  *
- * GitHub computes this server-side from the account that opened the pull request, so
- * it is the only signal about the author that the author cannot set. A commit's author
- * email is free text copied from `user.email`, which is why none is consulted here.
- *
- * `COLLABORATOR` is deliberately **not** here. It means push access on this repo,
- * which an outside collaborator can hold without being in the organization — so
- * accepting it would gate on repo permissions rather than on org membership. Push
- * access is not the question this gate asks.
+ * `null` when GitHub reports no head repository. Per its payload schema `head.repo` is
+ * `oneOf: [repository, null]`, and it goes null when the source fork has been deleted.
+ * That is a real, reachable state rather than a malformed payload — and it is emphatically
+ * not this repository, so it reads as a refusal rather than an error.
  */
-const ORG_ASSOCIATIONS = new Set(['OWNER', 'MEMBER']);
-/**
- * The PR author's association, from a `pull_request` webhook payload.
- *
- * Throws rather than returning `undefined`, for the same reason `getPrNumber` does:
- * every gated mode is triggered by a `pull_request` event, and GitHub always puts
- * `author_association` on that payload's PR object. An absent one means the action was
- * wired to the wrong trigger or the payload is malformed — and a security gate that
- * cannot identify the author must fail loudly, not quietly pick a branch.
- */
-function requireAuthorAssociation(payload) {
-    const pr = payload.pull_request;
-    if (!pr) {
-        throw new AuthorAssociationError('No pull_request payload — action must be triggered by a pull_request event');
-    }
-    const association = pr.author_association;
-    if (typeof association !== 'string' || association.trim() === '') {
-        throw new AuthorAssociationError('PR payload missing author_association');
-    }
-    return association;
-}
-/** True when the PR author belongs to the organization that owns the repo. */
-function isWixOrgAuthor(association) {
-    return typeof association === 'string' && ORG_ASSOCIATIONS.has(association.trim().toUpperCase());
+function readHeadRepoFullName(payload) {
+    const fullName = payload.pull_request?.head?.repo?.full_name;
+    return typeof fullName === 'string' && fullName.trim() !== '' ? fullName : null;
 }
 /**
- * Throw unless the PR author is a member of the organization that owns the repo.
+ * True when the PR's head branch lives in this repository, which means its author had
+ * push access here.
  *
- * Takes the association rather than a client: the value is already on the payload
- * every gated mode receives, so deciding costs no API call, no token scope, and
- * nothing that can fail in transit.
+ * Compared case-insensitively: GitHub treats owner and repository names that way, and a
+ * gate should not turn on the casing of a string it did not choose.
  */
-function assertWixAuthor(association, owner, log) {
-    if (!isWixOrgAuthor(association)) {
-        throw new Error(`PR author gate failed: the PR author is not a member of the ${owner} organization ` +
-            `(author_association: ${association}). This gate is restricted to Wix authors.`);
+function isSameRepoBranch(headRepoFullName, owner, repo) {
+    if (headRepoFullName === null)
+        return false;
+    return headRepoFullName.trim().toLowerCase() === `${owner}/${repo}`.toLowerCase();
+}
+function assertSameRepoBranch(headRepoFullName, owner, repo, log) {
+    if (!isSameRepoBranch(headRepoFullName, owner, repo)) {
+        throw new Error(`PR author gate failed: this pull request's head branch is in ` +
+            `${headRepoFullName ?? 'a repository that no longer exists'}, not ${owner}/${repo}. ` +
+            `This gate is restricted to branches pushed to ${owner}/${repo}, which requires write access.`);
     }
-    log?.(`Author gate passed — PR author association: ${association}`);
+    log?.(`Author gate passed — head branch is in ${owner}/${repo}, so its author has write access.`);
 }
 
 
@@ -66585,7 +66574,7 @@ function getEvalConfig() {
         headSha,
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        authorAssociation: (0, evalforge_core_1.requireAuthorAssociation)(github.context.payload),
+        headRepoFullName: (0, evalforge_core_1.readHeadRepoFullName)(github.context.payload),
         blocking: core.getInput('blocking') !== 'false',
     };
 }
@@ -66751,7 +66740,7 @@ async function runEval() {
     const octokit = github.getOctokit(config.githubToken);
     // Before anything that spends: an eval run costs a live agent build per scenario.
     // Same gate as the evalforge-* actions, so this one cannot be the way in.
-    (0, evalforge_core_1.assertWixAuthor)(config.authorAssociation, config.owner, core.info);
+    (0, evalforge_core_1.assertSameRepoBranch)(config.headRepoFullName, config.owner, config.repo, core.info);
     core.info(`Skill eval — PR #${config.prNumber}`);
     let allFiles;
     try {

--- a/.github/actions/skill-eval/src/utils/config.ts
+++ b/.github/actions/skill-eval/src/utils/config.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { requireAuthorAssociation } from '@wix/evalforge-core';
+import { readHeadRepoFullName } from '@wix/evalforge-core';
 
 export type Config = {
   githubToken: string;
@@ -15,8 +15,8 @@ export type Config = {
   headSha: string;
   owner: string;
   repo: string;
-  /** GitHub's server-side view of the PR author's relationship to this repo. */
-  authorAssociation: string;
+  /** Where the PR's head branch lives; `null` if that repository is gone. */
+  headRepoFullName: string | null;
   blocking: boolean;
 };
 
@@ -55,7 +55,7 @@ export function getEvalConfig(): Config {
     headSha,
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    authorAssociation: requireAuthorAssociation(github.context.payload),
+    headRepoFullName: readHeadRepoFullName(github.context.payload),
     blocking: core.getInput('blocking') !== 'false',
   };
 }

--- a/.github/actions/skill-eval/src/utils/eval.ts
+++ b/.github/actions/skill-eval/src/utils/eval.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import { assertWixAuthor } from '@wix/evalforge-core';
+import { assertSameRepoBranch } from '@wix/evalforge-core';
 import { getEvalConfig } from './config';
 import * as github from '@actions/github';
 import { getChangedFiles, upsertComment, fail } from './github';
@@ -18,7 +18,7 @@ export async function runEval(): Promise<void> {
   const octokit = github.getOctokit(config.githubToken);
   // Before anything that spends: an eval run costs a live agent build per scenario.
   // Same gate as the evalforge-* actions, so this one cannot be the way in.
-  assertWixAuthor(config.authorAssociation, config.owner, core.info);
+  assertSameRepoBranch(config.headRepoFullName, config.owner, config.repo, core.info);
 
   core.info(`Skill eval — PR #${config.prNumber}`);
 

--- a/.github/actions/skill-eval/tests/config.test.ts
+++ b/.github/actions/skill-eval/tests/config.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@actions/core', () => ({ getInput: vi.fn(), setSecret: vi.fn(), warning: vi.fn() }));
-/** Mutable so the author-association cases can vary it; reset in beforeEach. */
+/** Mutable so the head-repository cases can vary it; reset in beforeEach. */
 const basePullRequest = {
   number: 42,
   base: { sha: 'base-sha-123' },
-  head: { sha: 'head-sha-456' },
-  author_association: 'MEMBER',
+  head: { sha: 'head-sha-456', repo: { full_name: 'wix/skills' } },
 };
 const payload: { pull_request: Record<string, unknown> } = { pull_request: { ...basePullRequest } };
 
@@ -51,15 +50,14 @@ describe('getEvalConfig', () => {
     expect(config.headSha).toBe('head-sha-456');
     expect(config.owner).toBe('wix');
     expect(config.repo).toBe('skills');
-    expect(config.authorAssociation).toBe('MEMBER');
+    expect(config.headRepoFullName).toBe('wix/skills');
   });
 
-  // The gate cannot identify the author without it, so this fails loudly at config time
-  // rather than letting a malformed payload look like an ordinary refusal.
-  it('throws when the payload carries no author association', () => {
-    const { author_association: _dropped, ...rest } = basePullRequest;
-    payload.pull_request = rest;
-    expect(() => getEvalConfig()).toThrow(/missing author_association/);
+  // A deleted fork leaves head.repo null. That is not this repository, so it reads as a
+  // refusal downstream rather than an error here.
+  it('reports a null head repository rather than throwing', () => {
+    payload.pull_request = { ...basePullRequest, head: { sha: 'head-sha-456', repo: null } };
+    expect(getEvalConfig().headRepoFullName).toBeNull();
   });
 
   it('masks all secret inputs', () => {

--- a/.github/actions/skill-eval/tests/eval-author-gate.test.ts
+++ b/.github/actions/skill-eval/tests/eval-author-gate.test.ts
@@ -27,7 +27,7 @@ const CONFIG = {
   headSha: 'head-sha',
   owner: 'wix',
   repo: 'skills',
-  authorAssociation: 'MEMBER',
+  headRepoFullName: 'wix/skills',
   blocking: true,
 } satisfies Config;
 
@@ -49,14 +49,14 @@ beforeEach(() => {
  * was the one entry point that spent without asking who the author was.
  */
 describe('runEval — author gate', () => {
-  it('refuses an outside author before reading a single changed file', async () => {
-    const runEval = await runWith({ authorAssociation: 'NONE' });
+  it('refuses a fork before reading a single changed file', async () => {
+    const runEval = await runWith({ headRepoFullName: 'outsider/skills' });
 
-    await expect(runEval()).rejects.toThrow(/not a member of the wix organization/);
+    await expect(runEval()).rejects.toThrow(/head branch is in outsider\/skills, not wix\/skills/);
     expect(getChangedFiles).not.toHaveBeenCalled();
   });
 
-  it('lets an org member through to the changed-file lookup', async () => {
+  it('lets a branch in this repository through to the changed-file lookup', async () => {
     const runEval = await runWith();
 
     await runEval();

--- a/.github/actions/skill-eval/tests/github.test.ts
+++ b/.github/actions/skill-eval/tests/github.test.ts
@@ -24,7 +24,7 @@ const config: Config = {
   headSha: 'def456',
   owner: 'wix',
   repo: 'skills',
-  authorAssociation: 'MEMBER',
+  headRepoFullName: 'wix/skills',
   blocking: true,
 };
 

--- a/packages/evalforge-core/src/author-gate.ts
+++ b/packages/evalforge-core/src/author-gate.ts
@@ -1,115 +1,74 @@
 /**
- * The values GitHub defines for `author_association`, copied from its published payload
- * schema (`octokit/webhooks`, `payload-schemas/api.github.com/common/author_association.schema.json`).
+ * Whether a PR's author may spend an eval run.
  *
- * That schema also settles the question this gate rests on: `author_association` is in the
- * **required** list of `common/pull-request.schema.json`, and the recorded payloads for both
- * `opened` and `closed` carry it. So a `pull_request` event always has one, which is why
- * `requireAuthorAssociation` treats its absence as a wiring error rather than a normal state.
+ * The question this asks is "did the author have push access to this repository",
+ * answered by where the PR's head branch lives. Only someone with push access can
+ * create a branch in the repo itself; everyone else must fork, and a fork's head
+ * lives in their own namespace. The author cannot forge that — unlike a commit
+ * author email, which is free text copied from `user.email`.
  *
- * Written out rather than imported: `@actions/github` types the payload's `pull_request` as an
- * open bag of `any` with no `author_association` on it, and `@octokit/webhooks-types` — which
- * does declare this union — is in none of these projects' dependency trees. Adding it would
- * mean an entry in four separate lockfiles, each behind the 14-day cooldown, to type eight
- * string literals.
+ * **`author_association` does not work for this**, which is worth recording because it
+ * looks like it should. That field is viewer-relative: GitHub computes the copy in an
+ * Actions webhook payload without visibility into private org membership, so a member
+ * whose membership is private is reported as `CONTRIBUTOR`. Measured on wix/skills, every
+ * recent PR author reads `MEMBER` to an authenticated viewer and `CONTRIBUTOR` to the
+ * payload, because none of them is a *public* org member. A gate on that field refuses
+ * everybody.
  *
- * Its only job is to catch a typo in `ORG_ASSOCIATIONS` below. Values arriving at runtime are
- * deliberately **not** narrowed to it: GitHub can add a value, and an unrecognised one should
- * read as "not a member" rather than crash the gate.
+ * This check is the same one the workflows already apply at the job level
+ * (`github.event.pull_request.head.repo.full_name == github.repository`), so the action
+ * agrees with its own trigger rather than inventing a second notion of trust.
  */
-export type AuthorAssociation =
-  | 'COLLABORATOR'
-  | 'CONTRIBUTOR'
-  | 'FIRST_TIMER'
-  | 'FIRST_TIME_CONTRIBUTOR'
-  | 'MANNEQUIN'
-  | 'MEMBER'
-  | 'NONE'
-  | 'OWNER';
 
-/**
- * Raised when the payload carries no usable association. Typed so a caller that skips rather
- * than fails can recognise it, and let every other config error keep failing the check.
- */
-export class AuthorAssociationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'AuthorAssociationError';
-  }
-}
-
-/**
- * `author_association` values GitHub reports for someone who belongs to the
- * organization that owns the repo.
- *
- * GitHub computes this server-side from the account that opened the pull request, so
- * it is the only signal about the author that the author cannot set. A commit's author
- * email is free text copied from `user.email`, which is why none is consulted here.
- *
- * `COLLABORATOR` is deliberately **not** here. It means push access on this repo,
- * which an outside collaborator can hold without being in the organization — so
- * accepting it would gate on repo permissions rather than on org membership. Push
- * access is not the question this gate asks.
- */
-const ORG_ASSOCIATIONS: ReadonlySet<string> = new Set<AuthorAssociation>(['OWNER', 'MEMBER']);
-
-/**
- * The shape of the webhook payload this module reads. Declared structurally so the
- * package takes no dependency on `@actions/github`.
- *
- * `author_association` is `unknown` because `@actions/github` types the payload's
- * `pull_request` as an open bag of `any`. Narrowing it here would be a claim about
- * data this module does not control, so it is checked at runtime instead.
- */
-export type AuthorAssociationPayload = {
-  pull_request?: { author_association?: unknown; [key: string]: unknown } | null;
+/** The slice of the webhook payload this needs, declared structurally. */
+export type PullRequestSourcePayload = {
+  pull_request?: {
+    head?: { repo?: { full_name?: unknown } | null } | null;
+    [key: string]: unknown;
+  } | null;
 };
 
 /**
- * The PR author's association, from a `pull_request` webhook payload.
+ * The full name (`owner/repo`) of the repository holding the PR's head branch.
  *
- * Throws rather than returning `undefined`, for the same reason `getPrNumber` does:
- * every gated mode is triggered by a `pull_request` event, and GitHub always puts
- * `author_association` on that payload's PR object. An absent one means the action was
- * wired to the wrong trigger or the payload is malformed — and a security gate that
- * cannot identify the author must fail loudly, not quietly pick a branch.
+ * `null` when GitHub reports no head repository. Per its payload schema `head.repo` is
+ * `oneOf: [repository, null]`, and it goes null when the source fork has been deleted.
+ * That is a real, reachable state rather than a malformed payload — and it is emphatically
+ * not this repository, so it reads as a refusal rather than an error.
  */
-export function requireAuthorAssociation(payload: AuthorAssociationPayload): string {
-  const pr = payload.pull_request;
-  if (!pr) {
-    throw new AuthorAssociationError(
-      'No pull_request payload — action must be triggered by a pull_request event',
-    );
-  }
-  const association = pr.author_association;
-  if (typeof association !== 'string' || association.trim() === '') {
-    throw new AuthorAssociationError('PR payload missing author_association');
-  }
-  return association;
-}
-
-/** True when the PR author belongs to the organization that owns the repo. */
-export function isWixOrgAuthor(association: string | undefined | null): boolean {
-  return typeof association === 'string' && ORG_ASSOCIATIONS.has(association.trim().toUpperCase());
+export function readHeadRepoFullName(payload: PullRequestSourcePayload): string | null {
+  const fullName = payload.pull_request?.head?.repo?.full_name;
+  return typeof fullName === 'string' && fullName.trim() !== '' ? fullName : null;
 }
 
 /**
- * Throw unless the PR author is a member of the organization that owns the repo.
+ * True when the PR's head branch lives in this repository, which means its author had
+ * push access here.
  *
- * Takes the association rather than a client: the value is already on the payload
- * every gated mode receives, so deciding costs no API call, no token scope, and
- * nothing that can fail in transit.
+ * Compared case-insensitively: GitHub treats owner and repository names that way, and a
+ * gate should not turn on the casing of a string it did not choose.
  */
-export function assertWixAuthor(
-  association: string,
+export function isSameRepoBranch(
+  headRepoFullName: string | null,
   owner: string,
+  repo: string,
+): boolean {
+  if (headRepoFullName === null) return false;
+  return headRepoFullName.trim().toLowerCase() === `${owner}/${repo}`.toLowerCase();
+}
+
+export function assertSameRepoBranch(
+  headRepoFullName: string | null,
+  owner: string,
+  repo: string,
   log?: (message: string) => void,
 ): void {
-  if (!isWixOrgAuthor(association)) {
+  if (!isSameRepoBranch(headRepoFullName, owner, repo)) {
     throw new Error(
-      `PR author gate failed: the PR author is not a member of the ${owner} organization ` +
-        `(author_association: ${association}). This gate is restricted to Wix authors.`,
+      `PR author gate failed: this pull request's head branch is in ` +
+        `${headRepoFullName ?? 'a repository that no longer exists'}, not ${owner}/${repo}. ` +
+        `This gate is restricted to branches pushed to ${owner}/${repo}, which requires write access.`,
     );
   }
-  log?.(`Author gate passed — PR author association: ${association}`);
+  log?.(`Author gate passed — head branch is in ${owner}/${repo}, so its author has write access.`);
 }

--- a/packages/evalforge-core/tests/author-gate.test.ts
+++ b/packages/evalforge-core/tests/author-gate.test.ts
@@ -1,74 +1,71 @@
 import { describe, it, expect } from 'vitest';
-import { isWixOrgAuthor, requireAuthorAssociation, assertWixAuthor } from '../src/author-gate';
+import { readHeadRepoFullName, isSameRepoBranch, assertSameRepoBranch } from '../src/author-gate';
 
-describe('isWixOrgAuthor', () => {
-  it('accepts org members and owners', () => {
-    expect(isWixOrgAuthor('MEMBER')).toBe(true);
-    expect(isWixOrgAuthor('OWNER')).toBe(true);
-    expect(isWixOrgAuthor('  member  ')).toBe(true);
-  });
-
-  // Push access on the repo is not org membership: an outside collaborator can hold it
-  // without being in the organization, so it must not open the gate.
-  it('rejects a direct collaborator', () => {
-    expect(isWixOrgAuthor('COLLABORATOR')).toBe(false);
-  });
-
-  it('rejects outside authors and missing associations', () => {
-    expect(isWixOrgAuthor('CONTRIBUTOR')).toBe(false);
-    expect(isWixOrgAuthor('FIRST_TIME_CONTRIBUTOR')).toBe(false);
-    expect(isWixOrgAuthor('NONE')).toBe(false);
-    expect(isWixOrgAuthor('')).toBe(false);
-    expect(isWixOrgAuthor(undefined)).toBe(false);
-    expect(isWixOrgAuthor(null)).toBe(false);
-  });
-});
-
-describe('requireAuthorAssociation', () => {
-  it('reads the association off a pull_request payload', () => {
-    expect(requireAuthorAssociation({ pull_request: { author_association: 'MEMBER' } })).toBe('MEMBER');
+describe('readHeadRepoFullName', () => {
+  it('reads the head repository off a pull_request payload', () => {
+    expect(readHeadRepoFullName({ pull_request: { head: { repo: { full_name: 'wix/skills' } } } }))
+      .toBe('wix/skills');
   });
 
   /**
-   * A gate that cannot identify the author must fail loudly. Returning a default here
-   * would make a malformed payload look like an ordinary refusal, or worse a pass.
+   * `head.repo` is `oneOf: [repository, null]` in GitHub's payload schema — it goes null once
+   * the source fork is deleted. That is a reachable state, not a malformed payload, and it is
+   * certainly not this repository, so it reads as a refusal rather than an error.
    */
-  it('throws for a payload from any other event', () => {
-    expect(() => requireAuthorAssociation({})).toThrow(/must be triggered by a pull_request event/);
-    expect(() => requireAuthorAssociation({ pull_request: null })).toThrow(/pull_request event/);
+  it('returns null when GitHub reports no head repository', () => {
+    expect(readHeadRepoFullName({ pull_request: { head: { repo: null } } })).toBeNull();
+    expect(readHeadRepoFullName({ pull_request: { head: null } })).toBeNull();
+    expect(readHeadRepoFullName({ pull_request: {} })).toBeNull();
+    expect(readHeadRepoFullName({})).toBeNull();
   });
 
-  it('throws when the PR object carries no usable association', () => {
-    expect(() => requireAuthorAssociation({ pull_request: { number: 7 } }))
-      .toThrow(/missing author_association/);
-    expect(() => requireAuthorAssociation({ pull_request: { author_association: null } }))
-      .toThrow(/missing author_association/);
-    expect(() => requireAuthorAssociation({ pull_request: { author_association: 42 } }))
-      .toThrow(/missing author_association/);
-    expect(() => requireAuthorAssociation({ pull_request: { author_association: '  ' } }))
-      .toThrow(/missing author_association/);
+  it('ignores a non-string or empty full name rather than passing it on', () => {
+    expect(readHeadRepoFullName({ pull_request: { head: { repo: { full_name: 42 } } } })).toBeNull();
+    expect(readHeadRepoFullName({ pull_request: { head: { repo: { full_name: '  ' } } } })).toBeNull();
   });
 });
 
-describe('assertWixAuthor', () => {
-  it('passes an org member and logs the association', () => {
+describe('isSameRepoBranch', () => {
+  it('accepts a branch pushed to this repository', () => {
+    expect(isSameRepoBranch('wix/skills', 'wix', 'skills')).toBe(true);
+  });
+
+  // GitHub treats owner and repo names case-insensitively; a gate should not turn on casing.
+  it('accepts it regardless of casing or surrounding space', () => {
+    expect(isSameRepoBranch('Wix/Skills', 'wix', 'skills')).toBe(true);
+    expect(isSameRepoBranch('  wix/skills  ', 'wix', 'skills')).toBe(true);
+  });
+
+  /**
+   * The case the gate exists for: an outside contributor has no push access here, so their
+   * branch lives in their own fork. wix/skills#1163 is exactly this.
+   */
+  it('refuses a fork', () => {
+    expect(isSameRepoBranch('anupamme/skills', 'wix', 'skills')).toBe(false);
+  });
+
+  it('refuses a deleted head repository and a look-alike name', () => {
+    expect(isSameRepoBranch(null, 'wix', 'skills')).toBe(false);
+    expect(isSameRepoBranch('wix/skills-evil', 'wix', 'skills')).toBe(false);
+    expect(isSameRepoBranch('notwix/skills', 'wix', 'skills')).toBe(false);
+    expect(isSameRepoBranch('', 'wix', 'skills')).toBe(false);
+  });
+});
+
+describe('assertSameRepoBranch', () => {
+  it('passes a same-repo branch and logs why', () => {
     const lines: string[] = [];
-    expect(() => assertWixAuthor('MEMBER', 'wix', m => lines.push(m))).not.toThrow();
-    expect(lines).toEqual(['Author gate passed — PR author association: MEMBER']);
+    expect(() => assertSameRepoBranch('wix/skills', 'wix', 'skills', m => lines.push(m))).not.toThrow();
+    expect(lines[0]).toContain('has write access');
   });
 
-  it('throws for an outside author, naming the association and the org', () => {
-    expect(() => assertWixAuthor('CONTRIBUTOR', 'wix')).toThrow(
-      /not a member of the wix organization \(author_association: CONTRIBUTOR\)/,
-    );
+  it('throws for a fork, naming both repositories', () => {
+    expect(() => assertSameRepoBranch('outsider/skills', 'wix', 'skills'))
+      .toThrow(/head branch is in outsider\/skills, not wix\/skills/);
   });
 
-  /**
-   * The gate reads no commit data at all, so there is nothing an author can set to
-   * clear it — a commit author email is free text copied from `user.email`.
-   */
-  it('cannot be cleared by anything the author controls', () => {
-    expect(() => assertWixAuthor('NONE', 'wix')).toThrow();
-    expect(() => assertWixAuthor('ceo@wix.com', 'wix')).toThrow();
+  it('throws for a deleted head repository', () => {
+    expect(() => assertSameRepoBranch(null, 'wix', 'skills'))
+      .toThrow(/no longer exists/);
   });
 });

--- a/packages/evalforge-core/tests/author-gate.test.ts
+++ b/packages/evalforge-core/tests/author-gate.test.ts
@@ -38,10 +38,10 @@ describe('isSameRepoBranch', () => {
 
   /**
    * The case the gate exists for: an outside contributor has no push access here, so their
-   * branch lives in their own fork. wix/skills#1163 is exactly this.
+   * branch lives in their own fork.
    */
   it('refuses a fork', () => {
-    expect(isSameRepoBranch('anupamme/skills', 'wix', 'skills')).toBe(false);
+    expect(isSameRepoBranch('outsider/skills', 'wix', 'skills')).toBe(false);
   });
 
   it('refuses a deleted head repository and a look-alike name', () => {


### PR DESCRIPTION
## TL;DR

**#1311 shipped a gate that refuses everybody. This fixes it.** Merging this restores gating on every PR in the repo.

`author_association` is **viewer-relative**. GitHub computes the copy it puts in an Actions webhook payload without visibility into private org membership, so a member whose membership is private is reported as `CONTRIBUTOR`. Same PR, same moment:

| Viewer | Value |
| --- | --- |
| A token that can see private membership | `MEMBER` |
| The Actions payload | `CONTRIBUTOR` |

Not one recent author in this repo is a *public* member of `wix`, so the merged gate refuses all of them.

The check that works is the one these workflows already apply at the job level: **the PR's head branch lives in this repository**. Only someone with push access can create a branch here; everyone else must fork.

## How #1311 got through

I verified the field with `gh api`, which authenticates as a user who can see their own private membership, and concluded the payload would agree. It doesn't. Verifying a payload field through a privileged API view is the mistake, and it is worth naming so the next person doesn't repeat it.

## Current damage on `main`

| Mode | Behaviour for every author |
| --- | --- |
| yaml gate, `eval` | throws → red check |
| skill review | green check having reviewed nothing |
| wix-app gate | skips, comments |
| wix-app sync | skips |

The second row is the original bug this whole effort set out to fix.

## The check

```ts
isSameRepoBranch(config.headRepoFullName, config.owner, config.repo)
```

It is not a new idea. Eight workflows already carry it as a job condition:

```yaml
if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
```

That is why a fork PR from someone without push access reports **no checks at all** — the job never starts. The action now agrees with its own trigger instead of inventing a second notion of trust, and `CONTRIBUTING.md` already states the matching rule for authors.

It costs no API call, no token scope and no secret, and the author cannot forge it — unlike a commit email, which is free text copied from `user.email`.

## What this actually gates on

"Has push access here", not "is in the `wix` org". Measured:

| | Count |
| --- | --- |
| Principals with access to `wix/skills` | 1,326 |
| Of those, not `wix` org members | **1** |

That one is an outside collaborator with **admin**, who can merge anything regardless — so the gap is in the permissive direction, and it is latitude they already have. Closing it would need a GitHub App with `Members: Read-only`, since the payload genuinely cannot answer the org question.

## Details worth a reviewer's eye

`head.repo` is `oneOf: [repository, null]` in GitHub's payload schema — it goes null once a source fork is deleted. So the config field is `string | null`, not required. That differs from the association, whose absence was unreachable; here null is a real state, and it reads as a refusal rather than an error.

The comparison is case-insensitive, because GitHub treats owner and repository names that way and a gate should not turn on casing it did not choose.

The unresolvable-author recovery added in #1311 is gone with the thing it recovered from. The head repository is on the payload, so the gate always has an answer, and there is no lookup left to blip.

## Tests

| Package | Tests |
| --- | --- |
| `packages/evalforge-core` | 423 passing |
| `.github/actions/evalforge-yaml-gate` | 209 passing |
| `.github/actions/evalforge-skill-gate` | 222 passing |
| `.github/actions/skill-eval` | 99 passing |

Covering a same-repo branch, a fork, a deleted head repository, a look-alike name (`wix/skills-evil`, `notwix/skills`), and casing. All three bundles rebuilt with ncc and committed.

**Local note:** the suites need Node 20+. On Node 18 most fail during module mocking with `(0 , U.tracingChannel) is not a function`, from a transitive `lru-cache`. CI runs Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

