### PR TITLE
vibe-headless seed: the util protects against still-generating image urls

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -336,9 +336,6 @@ wire these exactly as shown below.
 When adding storefront routes and providers to `src/App.jsx`, preserve the existing platform
 authentication setup, including `AuthProvider`, `useAuth`, and their `@/lib/AuthContext` imports.
 Do not remove or replace that authentication logic.
-The storefront itself is public: shoppers browse, cart, and check out anonymously on the shipped
-Wix visitor session, which is separate from platform user auth. Keep storefront routes outside any
-auth gating, and add platform login/account pages only when the brief itself asks for user accounts.
 - Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
 - Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -336,6 +336,9 @@ wire these exactly as shown below.
 When adding storefront routes and providers to `src/App.jsx`, preserve the existing platform
 authentication setup, including `AuthProvider`, `useAuth`, and their `@/lib/AuthContext` imports.
 Do not remove or replace that authentication logic.
+The storefront itself is public: shoppers browse, cart, and check out anonymously on the shipped
+Wix visitor session, which is separate from platform user auth. Keep storefront routes outside any
+auth gating, and add platform login/account pages only when the brief itself asks for user accounts.
 - Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
 - Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -20,8 +20,13 @@ const ctx = { token: accessToken };
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images.
 // imageUrl must be the FINAL https://media.base44.com/... url from the COMPLETED generate_image
-// result — not a still-generating /__generating__/<id>.png placeholder (Wix can't fetch that).
-// generate_image runs in the background while you build, so the urls are ready by seed time.
+// result — not a still-generating /__generating__/<id>.png placeholder (Wix fetches the image
+// bytes at attach time and can't reach a placeholder). generate_image runs in the background
+// while you build, and each pending tool result UPDATES IN PLACE once its image completes: by
+// seed time, the same result that returned "pending" reads status "completed" with the permanent
+// url. Read each imageUrl from the result as it reads NOW, not from what it said when called.
+// One still pending at seed time → seed that product without imageUrl and attach it afterwards
+// with attachProductImages, once its result shows the final url.
 const result = await seed.setupStore(ctx, {
   currency: "EUR", // Pass only if the user asked for a currency or it's obvious for the store; else omit this line.
   products: [
@@ -38,6 +43,7 @@ const result = await seed.setupStore(ctx, {
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
 });
 // result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached,
+//   imagesSkippedPending (product names whose image was still generating — attach those afterwards),
 //   currency: { requested, actual, status, warnings } }
 ```
 
@@ -112,6 +118,8 @@ enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded he
 download — uploaded and created with both the file and stock, which is what the cart requires
 (`quantity` is ignored). It's also the only way in: a file-less digital product is created
 successfully, reads back healthy, and is then rejected at add-to-cart as `ITEM_NOT_FOUND_IN_CATALOG`.
+No real, fetchable file in hand → seed the product as **physical** with `inStock: true` and tell the
+user, offering the swap to a digital download once a real file exists. Never invent a `digitalFileUrl`.
 
 Two things this module does **not** seed, so don't try:
 
@@ -138,7 +146,8 @@ const products = await seed.bulkCreateProducts(ctx, [                 // → [{i
 ]);
 const cats = await seed.createCategories(ctx, ["Legends"]);           // sequential → [{id,name}]
 await seed.addProductsToCategories(ctx, { [cats[0].id]: [products[0].id] });
-// images: use the FINAL https://media.base44.com/... url only (never a /__generating__/ placeholder)
+// images: read each url from its generate_image result as it reads NOW — a completed result
+// carries the FINAL https://media.base44.com/... url (never pass a /__generating__/ placeholder)
 await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: imageUrls[i], altText: p.slug })));
 ```
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -19,14 +19,6 @@ const ctx = { token: accessToken };
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images.
-// imageUrl must be the FINAL https://media.base44.com/... url from the COMPLETED generate_image
-// result — not a still-generating /__generating__/<id>.png placeholder (Wix fetches the image
-// bytes at attach time and can't reach a placeholder). generate_image runs in the background
-// while you build, and each pending tool result UPDATES IN PLACE once its image completes: by
-// seed time, the same result that returned "pending" reads status "completed" with the permanent
-// url. Read each imageUrl from the result as it reads NOW, not from what it said when called.
-// One still pending at seed time → seed that product without imageUrl and attach it afterwards
-// with attachProductImages, once its result shows the final url.
 const result = await seed.setupStore(ctx, {
   currency: "EUR", // Pass only if the user asked for a currency or it's obvious for the store; else omit this line.
   products: [
@@ -144,8 +136,6 @@ const products = await seed.bulkCreateProducts(ctx, [                 // → [{i
 ]);
 const cats = await seed.createCategories(ctx, ["Legends"]);           // sequential → [{id,name}]
 await seed.addProductsToCategories(ctx, { [cats[0].id]: [products[0].id] });
-// images: read each url from its generate_image result as it reads NOW — a completed result
-// carries the FINAL https://media.base44.com/... url (never pass a /__generating__/ placeholder)
 await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: imageUrls[i], altText: p.slug })));
 ```
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -118,8 +118,6 @@ enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded he
 download — uploaded and created with both the file and stock, which is what the cart requires
 (`quantity` is ignored). It's also the only way in: a file-less digital product is created
 successfully, reads back healthy, and is then rejected at add-to-cart as `ITEM_NOT_FOUND_IN_CATALOG`.
-No real, fetchable file in hand → seed the product as **physical** with `inStock: true` and tell the
-user, offering the swap to a digital download once a real file exists. Never invent a `digitalFileUrl`.
 
 Two things this module does **not** seed, so don't try:
 

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -416,9 +416,17 @@ async function addProductsToCategories(ctx, mapping) {
 // caller never manages a revision token — attach any number of times, in any pass. Wix re-hosts the
 // image from the url server-side; the re-hosted media can take a little while to appear on read-back
 // (propagation) — that's normal, not a failure, so we don't block on it.
+const isPendingPlaceholder = (url) => typeof url === "string" && url.includes("/__generating__/");
+
 async function attachProductImages(ctx, items) {
   if (!items?.length) return;
   if (items.some((it) => !it.id)) throw new Error("Image attachment requires a product ID for every item; no image request was sent.");
+  const pending = items.filter((it) => isPendingPlaceholder(it.url));
+  if (pending.length) throw new Error(
+    `Image url(s) for [${pending.map((it) => it.altText || it.id).join(", ")}] are /__generating__/ placeholders — ` +
+    `still generating, and Wix cannot fetch them. generate_image results update in place: re-read them, and a ` +
+    `completed one carries the final https://media.base44.com/... url. Re-call attachProductImages with final ` +
+    `urls. No image request was sent; products are unaffected.`);
   const ids = items.map((it) => it.id);
   const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
   const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
@@ -475,7 +483,8 @@ async function configureCurrency(ctx, requested) {
  *                digitalFileUrl?, digitalFileName? }],
  *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
  * }}
- * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number, currency: {requested,actual,status,warnings} }
+ * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number,
+ *             imagesSkippedPending?: string[], note?: string, currency: {requested,actual,status,warnings} }
  */
 async function setupStore(ctx, { products = [], categories = {}, currency } = {}) {
   validateProducts(products);
@@ -498,11 +507,23 @@ async function setupStore(ctx, { products = [], categories = {}, currency } = {}
   }
 
   const imageItems = withNames
-    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug, name: p.name }))
     .filter((it) => it.url);
-  if (imageItems.length) await attachProductImages(ctx, imageItems);
+  // A /__generating__/ url is a generate_image result read too early: seed the product imageless
+  // and report it, so the caller re-reads the (in-place updated) result and attaches afterwards.
+  const readyItems = imageItems.filter((it) => !isPendingPlaceholder(it.url));
+  const skippedPending = imageItems.filter((it) => isPendingPlaceholder(it.url)).map((it) => it.name);
+  if (readyItems.length) await attachProductImages(ctx, readyItems);
 
-  return { products: withNames, categories: cats, imagesAttached: imageItems.length, currency: currencyResult };
+  return {
+    products: withNames, categories: cats, imagesAttached: readyItems.length,
+    ...(skippedPending.length && {
+      imagesSkippedPending: skippedPending,
+      note: "these images were still generating at seed time — re-read their generate_image results " +
+        "(they update in place to status 'completed' with the final url) and attach with attachProductImages",
+    }),
+    currency: currencyResult,
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
## Why

Prod storefront builds showed agents burning large hidden-reasoning time on one question: how to pass product images to the seed when `generate_image` returns a pending `/__generating__/` placeholder. SEED.md demanded the final url and forbade placeholders, but gave no way to act on that — one agent spent a 278s round rediscovering that results resolve in-turn; another concluded the url was unobtainable and shipped an imageless store (`imagesAttached: 0`).

## What changed

Protection moves out of prose and into the util, which teaches the recovery exactly when it's needed:

**seed-store.cjs**
- `setupStore` filters `/__generating__/` urls, seeds those products imageless, and reports `imagesSkippedPending: [names]` plus a `note`: re-read the generate_image results (they update in place to `status: 'completed'` with the final url) and attach with `attachProductImages`.
- A direct `attachProductImages` call containing a placeholder refuses before any request is sent, with the same instruction (verified: throws pre-network; products unaffected).

**SEED.md**
- The placeholder/final-url prose is removed entirely — including the old "urls are ready by seed time" line, which read as an assurance the agent couldn't verify and fueled the deliberation loops. The guide now only documents the util's `imagesSkippedPending` result field.

No platform change; nothing observed in prod actually passed a placeholder to the seed — this converts that path from undefined behavior into a defined, self-explaining outcome while removing the doc text that triggered the reasoning spirals.

## Verification

`node --check` on the module; the direct-call guard exercised live (instructive throw before any network call). Post-deploy: watch `imagesAttached`/`imagesSkippedPending` and reasoning share in the next prod cohort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)