### PR TITLE
vibe-headless: two storefront reasoning-loop fixes (digital files, auth)

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -336,6 +336,10 @@ wire these exactly as shown below.
 When adding storefront routes and providers to `src/App.jsx`, preserve the existing platform
 authentication setup, including `AuthProvider`, `useAuth`, and their `@/lib/AuthContext` imports.
 Do not remove or replace that authentication logic.
+The shipped commerce flow needs no login: shoppers browse, cart, and check out on the Wix visitor
+session, which is separate from platform user auth. Whether the storefront is public or members-only
+is the brief's call — default to public, and gate routes behind platform auth only when the brief
+asks for it. Neither choice affects the commerce flow.
 - Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
 - Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -112,6 +112,8 @@ enrolls in — is **Pricing Plans**, not a Stores product, so it isn't seeded he
 download — uploaded and created with both the file and stock, which is what the cart requires
 (`quantity` is ignored). It's also the only way in: a file-less digital product is created
 successfully, reads back healthy, and is then rejected at add-to-cart as `ITEM_NOT_FOUND_IN_CATALOG`.
+No real, fetchable file in hand → seed the product as **physical** with `inStock: true` and tell the
+user; swap it to a digital download once a real file exists.
 
 Two things this module does **not** seed, so don't try:
 

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -257,7 +257,8 @@ async function uploadDigitalFile(ctx, url, fileName) {
   if (!mimeType) throw new Error(`digitalFileName needs one of these extensions (${Object.keys(FILE_MIME).join(", ")}): ${fileName}`);
   const { uploadUrl } = await req(ctx, "/site-media/v1/files/generate-upload-url", { body: { mimeType, fileName } });
   const src = await fetch(url);
-  if (!src.ok) throw new Error(`digitalFileUrl ${url} -> ${src.status}`);
+  if (!src.ok) throw new Error(`digitalFileUrl ${url} -> ${src.status}. A digital product needs a real, ` +
+    `fetchable file — with none at hand, seed this product as physical with inStock: true and tell the user.`);
   const res = await fetch(uploadUrl, {
     method: "PUT", headers: { "Content-Type": mimeType }, body: Buffer.from(await src.arrayBuffer()),
   });


### PR DESCRIPTION
## Why

Same prod reasoning-trace analysis as #1314 (the images fix): two more deliberation loops agents pay for on storefront builds, each re-deriving an answer the skill can state once.

**Digital products.** An agent selling "digital blueprints" with no real file cycled ~6 times between a file-less digital product (passes creation, fails add-to-cart as `ITEM_NOT_FOUND_IN_CATALOG`) and fabricating a file ("I could write a simple HTML file via write_file, but that's not a publicly hosted URL Wix can fetch"), before landing on physical-with-unlimited-stock. The trap is documented; the *decision rule* wasn't.

**Auth.** An agent asked for an "Account" nav icon spent ~5 cycles untangling: "registering auth routes requires ProtectedRoute gating… but shoppers are anonymous… does the Base44 AuthProvider redirect unauthenticated users? … the storefront uses visitor auth (Wix visitor token), not Base44 user auth." It derived the right answer expensively; a wrong derivation ships a store that demands login before showing products.

## What changed

**SEED.md** — one decision rule after the `ITEM_NOT_FOUND_IN_CATALOG` paragraph: no real, fetchable file in hand → seed the product as **physical** with `inStock: true` and tell the user; swap to a digital download once a real file exists.

**seed-store.cjs** — the util already protects this path (`uploadDigitalFile` fetches the source and throws on failure; file-less digital is impossible by construction). The change makes that existing failure instructive: the error now carries the same recovery ("seed as physical with inStock: true and tell the user") instead of only the status code.

**INSTRUCTIONS.md** — after the existing "preserve the platform authentication setup" paragraph (itself half the trigger — "preserve auth" reads as "auth matters here"), the contract that unblocks the loop without legislating the product decision:

> The shipped commerce flow needs no login: shoppers browse, cart, and check out on the Wix visitor session, which is separate from platform user auth. Whether the storefront is public or members-only is the brief's call — default to public, and gate routes behind platform auth only when the brief asks for it. Neither choice affects the commerce flow.

Members-only stores remain fully supported — the note states facts (commerce works without login; the systems are separate; gating is orthogonal), and leaves the choice to the brief.

## Verification

`node --check` on the module. Expected effect: these loops cost ~1–2K reasoning tokens per affected build (vs the image loop's 10–20K) — the stronger argument is the tail risk each removes: fabricated digital files and login-gated storefronts nobody asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)