### PR TITLE
seed: the Base44 guide carries the image timing; generic files stay neutral

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -11,7 +11,8 @@ or configuration changes are needed.
 **Banner disabled for this entry flow:** do not add `<WixManageBanner/>`; skip the shared
 storefront instructions' optional banner integration.
 
-Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
+Follow STEPs 1–4 below exactly. Fire product image generations first, then build the client
+(STEP 2), and seed (STEP 3) **after** the client is built — generation finishes while you build.
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
@@ -89,13 +90,13 @@ Inline via exec_tool, `base44` is already declared — use it directly; do **not
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 
-**Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step.
-
-**Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
-from the **completed** `generate_image` result and pass it straight into your single `setupStore`
-call (images included). `generate_image` runs in the background while you build the client, so the
-urls are ready by the time you seed.
+**Product images.** Fire every `generate_image` **before you build the client**, and seed **after**
+it — generation finishes while you build, so by the time you write the seed call your images are
+ready: each finished result now reads `status: "completed"` with its final
+`https://media.base44.com/...` url. Read every `imageUrl` from the results **as they read at that
+moment** — not from what they said when you called the tool — and pass them in the single
+`setupStore` call. A result without a final url by then (still running, or failed) → seed that
+product **without** `imageUrl` and attach it afterwards with `attachProductImages`.
 
 ## STEP 4 — Wrap up
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -24,7 +24,8 @@ No installation, deployment, or AGENTS.md update is needed.
 The deployed implementation and configuration files do not need to be read; use the build and seed
 guides below for their contracts and usage. Continue with STEP 1.
 
-Follow STEPs 1–3 below exactly (run STEP 2 in parallel with STEP 1).
+Follow STEPs 1–3 below exactly. Fire product image generations first, then build the client
+(STEP 1), and seed (STEP 2) **after** the client is built — generation finishes while you build.
 
 ## STEP 1 — Build the client
 
@@ -74,13 +75,13 @@ Inline via exec_tool, `base44` is already declared — use it directly; do **not
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 
-**Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step.
-
-**Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
-from the **completed** `generate_image` result and pass it straight into your single `setupStore`
-call (images included). `generate_image` runs in the background while you build the client, so the
-urls are ready by the time you seed.
+**Product images.** Fire every `generate_image` **before you build the client**, and seed **after**
+it — generation finishes while you build, so by the time you write the seed call your images are
+ready: each finished result now reads `status: "completed"` with its final
+`https://media.base44.com/...` url. Read every `imageUrl` from the results **as they read at that
+moment** — not from what they said when you called the tool — and pass them in the single
+`setupStore` call. A result without a final url by then (still running, or failed) → seed that
+product **without** `imageUrl` and attach it afterwards with `attachProductImages`.
 
 ## STEP 3 — Wrap up
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -11,7 +11,8 @@ only), safe in the frontend; use it directly for the Wix client setup.
 **Banner enabled for this entry flow:** mount `<WixManageBanner/>` once in the Layout, above
 the header in the fixed top region, per the vertical instructions. It is preview-only.
 
-Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **except `forms`**, see STEP 3).
+Follow STEPs 1–5 below exactly (run STEP 4 in parallel with STEP 3 — **except `forms`**, see
+STEP 3, and **except a seed that attaches entity images**, which runs after the build; see STEP 4).
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -98,8 +99,15 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 Seed by calling your vertical's ready-made seed module — read
 `.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and follow it (the loader
-snippet, admin connector token, entity images with the final `media.base44.com` url, and every field
-shape are there). Gaps or an unexpected shape → the documentation skill available in your environment.
+snippet, admin connector token, and every field shape are there). Gaps or an unexpected shape → the
+documentation skill available in your environment.
+
+**Entity images:** fire every image generation **before you build the client**, and run an
+image-carrying seed **after** the build — generation finishes while you build, and each finished
+result then reads `status: "completed"` with its final `https://media.base44.com/...` url. Read
+every image url from the results **as they read at that moment**, not from what they said when you
+called the tool. No final url by then (still running, or failed) → seed without that image and
+attach it afterwards per the vertical's `SEED.md`.
 Seeding is **admin-only** — not part of the client, which is built solely per the `wix-vibe-headless` skill.
 
 - **Additive only:** never delete or overwrite the user's content, even apparent sample data; ask first if a cleanup truly seems needed.

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -19,6 +19,10 @@ const ctx = { token: accessToken };
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images.
+// imageUrl: your generate_image results update in place once generation completes — re-read each
+// result AS IT READS NOW, right when you write this call: a completed one carries the final
+// https://media.base44.com/... url to pass here. One still pending → seed that product without
+// imageUrl and attach it afterwards with attachProductImages.
 const result = await seed.setupStore(ctx, {
   currency: "EUR", // Pass only if the user asked for a currency or it's obvious for the store; else omit this line.
   products: [
@@ -36,6 +40,7 @@ const result = await seed.setupStore(ctx, {
 });
 // result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached,
 //   imagesSkippedPending (product names whose image was still generating — attach those afterwards),
+//   productsWithoutImages (product names seeded with no imageUrl — attach afterwards if images exist),
 //   currency: { requested, actual, status, warnings } }
 ```
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -19,10 +19,7 @@ const ctx = { token: accessToken };
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images.
-// imageUrl: your generate_image results update in place once generation completes — re-read each
-// result AS IT READS NOW, right when you write this call: a completed one carries the final
-// https://media.base44.com/... url to pass here. One still pending → seed that product without
-// imageUrl and attach it afterwards with attachProductImages.
+// imageUrl: a public, fetchable https:// url — Wix copies the image bytes at attach time.
 const result = await seed.setupStore(ctx, {
   currency: "EUR", // Pass only if the user asked for a currency or it's obvious for the store; else omit this line.
   products: [
@@ -39,8 +36,8 @@ const result = await seed.setupStore(ctx, {
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
 });
 // result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached,
-//   imagesSkippedPending (product names whose image was still generating — attach those afterwards),
-//   productsWithoutImages (product names seeded with no imageUrl — attach afterwards if images exist),
+//   imagesSkippedPending (product names whose imageUrl was not yet fetchable — attach those afterwards),
+//   productsWithoutImages (product names seeded with no imageUrl — attach afterwards once urls exist),
 //   currency: { requested, actual, status, warnings } }
 ```
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -36,7 +36,7 @@ const result = await seed.setupStore(ctx, {
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
 });
 // result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached,
-//   imagesSkippedPending (product names whose imageUrl was not yet fetchable — attach those afterwards),
+//   imagesSkipped (product names whose imageUrl was not an absolute https:// url — attach those afterwards),
 //   productsWithoutImages (product names seeded with no imageUrl — attach afterwards once urls exist),
 //   currency: { requested, actual, status, warnings } }
 ```

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -516,12 +516,19 @@ async function setupStore(ctx, { products = [], categories = {}, currency } = {}
   const skippedPending = imageItems.filter((it) => isPendingPlaceholder(it.url)).map((it) => it.name);
   if (readyItems.length) await attachProductImages(ctx, readyItems);
 
+  const withoutImages = withNames.filter((p, i) => !products[i]?.imageUrl).map((p) => p.name);
   return {
     products: withNames, categories: cats, imagesAttached: readyItems.length,
     ...(skippedPending.length && {
       imagesSkippedPending: skippedPending,
       note: "these images were still generating at seed time — re-read their generate_image results " +
         "(they update in place to status 'completed' with the final url) and attach with attachProductImages",
+    }),
+    ...(withoutImages.length && !skippedPending.length && {
+      productsWithoutImages: withoutImages,
+      note: "these products were seeded without an image — if you generated images for them, your " +
+        "generate_image results have updated in place and now carry final urls: attach them with " +
+        "attachProductImages",
     }),
     currency: currencyResult,
   };

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -417,14 +417,15 @@ async function addProductsToCategories(ctx, mapping) {
 // caller never manages a revision token — attach any number of times, in any pass. Wix re-hosts the
 // image from the url server-side; the re-hosted media can take a little while to appear on read-back
 // (propagation) — that's normal, not a failure, so we don't block on it.
-const isPendingPlaceholder = (url) => typeof url === "string" && url.includes("/__generating__/");
+// Wix imports the image bytes server-side, so an attach needs an absolute, publicly fetchable url.
+const isFetchableImageUrl = (url) => typeof url === "string" && /^https:\/\//.test(url);
 
 async function attachProductImages(ctx, items) {
   if (!items?.length) return;
   if (items.some((it) => !it.id)) throw new Error("Image attachment requires a product ID for every item; no image request was sent.");
-  const pending = items.filter((it) => isPendingPlaceholder(it.url));
-  if (pending.length) throw new Error(
-    `Image url(s) for [${pending.map((it) => it.altText || it.id).join(", ")}] are not public, fetchable ` +
+  const unfetchable = items.filter((it) => !isFetchableImageUrl(it.url));
+  if (unfetchable.length) throw new Error(
+    `Image url(s) for [${unfetchable.map((it) => it.altText || it.id).join(", ")}] are not absolute ` +
     `https:// urls, and Wix copies the image bytes at attach time. Re-call attachProductImages once each ` +
     `image has its final url. No image request was sent; products are unaffected.`);
   const ids = items.map((it) => it.id);
@@ -484,7 +485,7 @@ async function configureCurrency(ctx, requested) {
  *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
  * }}
  * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number,
- *             imagesSkippedPending?: string[], note?: string, currency: {requested,actual,status,warnings} }
+ *             imagesSkipped?: string[], note?: string, currency: {requested,actual,status,warnings} }
  */
 async function setupStore(ctx, { products = [], categories = {}, currency } = {}) {
   validateProducts(products);
@@ -509,21 +510,21 @@ async function setupStore(ctx, { products = [], categories = {}, currency } = {}
   const imageItems = withNames
     .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug, name: p.name }))
     .filter((it) => it.url);
-  // A url Wix cannot fetch (e.g. a still-generating placeholder) would fail the attach: seed the
-  // product imageless and report it, so the caller attaches once the final url exists.
-  const readyItems = imageItems.filter((it) => !isPendingPlaceholder(it.url));
-  const skippedPending = imageItems.filter((it) => isPendingPlaceholder(it.url)).map((it) => it.name);
+  // A url Wix cannot fetch would fail the attach: seed the product imageless and report it,
+  // so the caller attaches once the final url exists.
+  const readyItems = imageItems.filter((it) => isFetchableImageUrl(it.url));
+  const skipped = imageItems.filter((it) => !isFetchableImageUrl(it.url)).map((it) => it.name);
   if (readyItems.length) await attachProductImages(ctx, readyItems);
 
   const withoutImages = withNames.filter((p, i) => !products[i]?.imageUrl).map((p) => p.name);
   return {
     products: withNames, categories: cats, imagesAttached: readyItems.length,
-    ...(skippedPending.length && {
-      imagesSkippedPending: skippedPending,
-      note: "these products' image urls were not yet fetchable at seed time — attach them with " +
+    ...(skipped.length && {
+      imagesSkipped: skipped,
+      note: "these products' image urls were not absolute https:// urls — attach them with " +
         "attachProductImages once each image has its final url",
     }),
-    ...(withoutImages.length && !skippedPending.length && {
+    ...(withoutImages.length && !skipped.length && {
       productsWithoutImages: withoutImages,
       note: "these products were seeded without an image — once their images have final urls, " +
         "attach them with attachProductImages",

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.cjs
@@ -424,10 +424,9 @@ async function attachProductImages(ctx, items) {
   if (items.some((it) => !it.id)) throw new Error("Image attachment requires a product ID for every item; no image request was sent.");
   const pending = items.filter((it) => isPendingPlaceholder(it.url));
   if (pending.length) throw new Error(
-    `Image url(s) for [${pending.map((it) => it.altText || it.id).join(", ")}] are /__generating__/ placeholders — ` +
-    `still generating, and Wix cannot fetch them. generate_image results update in place: re-read them, and a ` +
-    `completed one carries the final https://media.base44.com/... url. Re-call attachProductImages with final ` +
-    `urls. No image request was sent; products are unaffected.`);
+    `Image url(s) for [${pending.map((it) => it.altText || it.id).join(", ")}] are not public, fetchable ` +
+    `https:// urls, and Wix copies the image bytes at attach time. Re-call attachProductImages once each ` +
+    `image has its final url. No image request was sent; products are unaffected.`);
   const ids = items.map((it) => it.id);
   const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
   const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
@@ -510,8 +509,8 @@ async function setupStore(ctx, { products = [], categories = {}, currency } = {}
   const imageItems = withNames
     .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug, name: p.name }))
     .filter((it) => it.url);
-  // A /__generating__/ url is a generate_image result read too early: seed the product imageless
-  // and report it, so the caller re-reads the (in-place updated) result and attaches afterwards.
+  // A url Wix cannot fetch (e.g. a still-generating placeholder) would fail the attach: seed the
+  // product imageless and report it, so the caller attaches once the final url exists.
   const readyItems = imageItems.filter((it) => !isPendingPlaceholder(it.url));
   const skippedPending = imageItems.filter((it) => isPendingPlaceholder(it.url)).map((it) => it.name);
   if (readyItems.length) await attachProductImages(ctx, readyItems);
@@ -521,14 +520,13 @@ async function setupStore(ctx, { products = [], categories = {}, currency } = {}
     products: withNames, categories: cats, imagesAttached: readyItems.length,
     ...(skippedPending.length && {
       imagesSkippedPending: skippedPending,
-      note: "these images were still generating at seed time — re-read their generate_image results " +
-        "(they update in place to status 'completed' with the final url) and attach with attachProductImages",
+      note: "these products' image urls were not yet fetchable at seed time — attach them with " +
+        "attachProductImages once each image has its final url",
     }),
     ...(withoutImages.length && !skippedPending.length && {
       productsWithoutImages: withoutImages,
-      note: "these products were seeded without an image — if you generated images for them, your " +
-        "generate_image results have updated in place and now carry final urls: attach them with " +
-        "attachProductImages",
+      note: "these products were seeded without an image — once their images have final urls, " +
+        "attach them with attachProductImages",
     }),
     currency: currencyResult,
   };


### PR DESCRIPTION
## Why

Post-#1314 installs still shipped imageless stores (2 of the first 7). We verified against the **LLM dump blobs** — the exact prompts each round saw:

- **Planning round** (~1 min after firing generate_image): the results in the prompt read `status: pending, image_url: null`. The agent — reasonably — locks "seed without images" into its plan.
- **Seed round** (~4.5 min later): the *same* results in the *same* prompt read `status: completed` with final urls. The agent seeds imageless anyway — one wrote "I only have placeholder strings" against a prompt holding eight final urls.

So the failure is plan-lock: the decision is made while results are pending, and nothing re-opens it when the context refreshes. The previous guide line ("the urls are ready by the time you seed") asserted an outcome without the mechanism — and agents argued it down using the tool description ("replacement happens at turn end… so mid-turn they're still placeholders").

## Design

**Platform knowledge lives in the platform guides; the generic reference and the util stay neutral.**

**`platforms/base44-ecom-light-seed.md` / `…-with-install.md`** (what the setup flow actually serves) now carry the full mitigation, concise:
- **Ordering**: fire every `generate_image` first, build the client, seed **last** — the old "run the seed in parallel with the build" instruction is gone, so "completed by seed time" becomes true by construction.
- **The observable contract, not a bare assurance**: "each finished result now reads `status: \"completed\"` with its final url — read every imageUrl from the results **as they read at that moment**, not from what they said when you called the tool."
- **The failure path** (kept because a *failed* generation never completes): no final url by seed time → seed that product without `imageUrl`, attach afterwards with `attachProductImages`.

**`SEED.md`** drops all Base44 tool talk: the `imageUrl` contract is simply "a public, fetchable https:// url — Wix copies the image bytes at attach time."

**`seed-store.cjs`** keeps its mechanics (skip unfetchable urls → `imagesSkippedPending`; report `productsWithoutImages`) with platform-neutral messages: what to do (attach once final urls exist), no platform mechanics named.

## Verification

`node --check` on the module. Post-deploy: imageless-store rate and `productsWithoutImages` occurrences in the next cohort; a first-message store-build probe should now plan "images first, build, seed last" unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)