### PR TITLE
storefront: verify once after the seed; drop the stale parallel-seed claim

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -13,6 +13,7 @@ storefront instructions' optional banner integration.
 
 Follow STEPs 1–4 below exactly. Fire product image generations first, then build the client
 (STEP 2), and seed (STEP 3) **after** the client is built — generation finishes while you build.
+Verify **once, after the seed**: home, shop, and a product page against the populated catalog.
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed-with-install.md
@@ -13,7 +13,6 @@ storefront instructions' optional banner integration.
 
 Follow STEPs 1–4 below exactly. Fire product image generations first, then build the client
 (STEP 2), and seed (STEP 3) **after** the client is built — generation finishes while you build.
-Verify **once, after the seed**: home, shop, and a product page against the populated catalog.
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
@@ -101,7 +100,9 @@ product **without** `imageUrl` and attach it afterwards with `attachProductImage
 
 ## STEP 4 — Wrap up
 
-### Preview
+### Verify
+
+Verify **once, after the seed** — home, shop, and a product page against the populated catalog.
 
 Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -26,6 +26,7 @@ guides below for their contracts and usage. Continue with STEP 1.
 
 Follow STEPs 1–3 below exactly. Fire product image generations first, then build the client
 (STEP 1), and seed (STEP 2) **after** the client is built — generation finishes while you build.
+Verify **once, after the seed**: home, shop, and a product page against the populated catalog.
 
 ## STEP 1 — Build the client
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -26,7 +26,6 @@ guides below for their contracts and usage. Continue with STEP 1.
 
 Follow STEPs 1–3 below exactly. Fire product image generations first, then build the client
 (STEP 1), and seed (STEP 2) **after** the client is built — generation finishes while you build.
-Verify **once, after the seed**: home, shop, and a product page against the populated catalog.
 
 ## STEP 1 — Build the client
 
@@ -86,7 +85,9 @@ product **without** `imageUrl` and attach it afterwards with `attachProductImage
 
 ## STEP 3 — Wrap up
 
-### Preview
+### Verify
+
+Verify **once, after the seed** — home, shop, and a product page against the populated catalog.
 
 Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -62,7 +62,7 @@ need to diagnose and fix it.
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
-### Preview
+### Verify
 
 Images that are still generating may show `/__generating__/…` placeholders;
 the platform replaces these automatically at turn end, with a stock fallback if generation

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -9,7 +9,7 @@ or configuration changes are needed to build the UI. Never mock products or hand
 `/checkout` URL; the shipped cart uses the eCom redirect session.
 
 ## Prerequisites
-- The site's **Wix Stores** catalog is the read/cart target. It's installed and seeded separately, in parallel with this build — so it may be empty at build time; render the empty state until products land.
+- The site's **Wix Stores** catalog is the read/cart target. It may be empty while the client is being built — render the empty state cleanly. Flows that seed do so after the client is built; verify the storefront once the catalog is populated, not against the empty state.
 
 ## Already installed in `src/`
 Successful deployment verified these files are in place; use this map without needing to read their source (`@/` → `src/`).


### PR DESCRIPTION
## Why

Observed on a staging build (deep-read of a full transcript): the agent finished the client, spent its **first and most expensive preview** (21.7s, dev-server warm-up) verifying the **unseeded** storefront, then caught itself mid-verification — *"Actually the catalog is empty until seeded. Let me seed now, then verify shop"* — seeded, and verified again. ~25–30s wasted per build, and it recurs, because two texts steer it wrong:

1. The platform seed guides (since #1316) order **build → seed** but say nothing about where **verification** goes, so agents improvise the interleaving.
2. `INSTRUCTIONS.md` still describes the pre-#1316 world: *"installed and seeded **separately, in parallel with this build** — so it may be empty at build time"* — teaching the empty catalog as an expected state worth checking.

## What changed

**The wrap-up section formerly called "Preview" is now "Verify"** in all three platform guides — the section instructs an act, not a surface (and "Preview" collided with both the tool name and the preview pane). In the two seed guides it now opens with the placement rule, so one section says when to verify and what in-flight images look like while you do:

> ### Verify
>
> Verify **once, after the seed** — home, shop, and a product page against the populated catalog.
>
> Images that are still generating may show `/__generating__/…` placeholders; the platform replaces these automatically at turn end, with a stock fallback if generation fails. You can finish without waiting for those images or replacing their placeholder URLs.

**`references/storefront/INSTRUCTIONS.md`** — serves client-only flows too (where the catalog genuinely may stay empty), so it keeps the empty-state robustness rule and loses only the stale claim:

> The site's Wix Stores catalog is the read/cart target. It may be empty while the client is being built — render the empty state cleanly. Flows that seed do so after the client is built; verify the storefront once the catalog is populated, not against the empty state.

4 files, +8/−6. Expected effect: one fewer preview round per store build (the warm-up preview lands on the finished, populated store), no more mid-verification reordering — checkable in any transcript by the first `preview_execute_code` appearing after the seed exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)