### PR TITLE
login: make awaiting_user a hard stop

### DIFF
--- a/skills/wix-auth/references/device-flow.md
+++ b/skills/wix-auth/references/device-flow.md
@@ -34,7 +34,9 @@ Response:
 { "deviceCode": "…", "userCode": "XXXXXXXX", "verificationUri": "https://users.wix.com/login/device-login", "expiresIn": 600 }
 ```
 
-## Step 2 — Ask the user to authorize
+## Step 2 — Ask the user to authorize (hard stop)
+
+**Stop all other work.** The user cannot see tool output, so they never get the code unless you send a user-visible message in the **same turn** you receive `userCode`.
 
 Show the user this URL and code:
 
@@ -43,7 +45,11 @@ URL:  {verificationUri}?color=developer&studio=true
 Code: {userCode}
 ```
 
+Template: *Open `<URL>` and enter the code `<Code>` — I'll continue once you've logged in.*
+
 Make sure the user has copied or noted the code **before** opening the link — they'll need to enter it on the page. Present the URL as a clickable link that opens in a new tab if your interface supports it.
+
+Do **not** start polling (Step 3) as a reason to skip the message. Send the message first, then poll. Do not read files, scaffold, or continue the original task until Step 3 returns tokens. Codes expire in about `expiresIn` seconds; if that window lapses, restart from Step 1 and surface the **new** code immediately.
 
 ## Step 3 — Poll for the token
 

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -53,8 +53,8 @@ version, install or upgrade Node first — do **not** work around it:
 Download and run the shared bootstrap script. It verifies the Wix CLI and handles login,
 emitting **one JSON event per line** on stdout. **Run it and relay its events** — it exits on
 its own once the CLI is verified and a session exists (seconds, when already logged in). Only
-when a login is actually needed does it pause on `awaiting_user`; surface the URL + code and
-let it keep running until the login completes.
+when a login is actually needed does it pause on `awaiting_user`; that event is a **hard stop**
+(see below).
 
 The script is safe and inspectable: it only checks the Wix CLI via `npx` and drives
 `wix login` (a device-code flow) — no other network calls, no filesystem writes. Read it first
@@ -74,9 +74,20 @@ node bootstrap.mjs
 | Event | What to do |
 |---|---|
 | `cli_ok` | Wix CLI reachable — continue. |
-| `awaiting_user` (`verificationUri`, `userCode`) | Show the URL and code in plain prose; wait for the user to finish the login in their browser. |
+| `awaiting_user` (`verificationUri`, `userCode`) | **HARD STOP** — see below. Send the URL and code in a user-visible message in this turn; wait. |
 | `logged_in` / `success` | Login done — continue. |
 | `cli_unreachable` / `login_failed` (with `detail`) | Stop and show the user the `detail`. **Do not** improvise a parallel setup by hand. |
+
+### `awaiting_user` is a hard stop
+
+The user cannot see tool output. If you keep working after this event, they never get the code and login stalls until they ask.
+
+The moment `awaiting_user` appears:
+
+1. **Send a user-visible message in this turn.** Template: *Open `<verificationUri>` and enter the code `<userCode>` — I'll continue once you've logged in.* Present the URL as a clickable link if the interface supports it.
+2. **Do not continue the build.** No other tool calls in this turn: do not read files, install skills, scaffold, seed, plan, or poll anything except the bootstrap process.
+3. **Keep the bootstrap running.** Do not re-invoke login. Wait for `logged_in` / `success`.
+4. Codes expire in about 10 minutes (`expiresInSeconds`). If `login_failed` after expiry, re-run bootstrap **once** and surface the **new** code immediately.
 
 ## Phase 2 — Install the skill and hand off
 

--- a/skills/wix-headless/entry/bootstrap.mjs
+++ b/skills/wix-headless/entry/bootstrap.mjs
@@ -24,6 +24,11 @@ const WIX = [bin('npx'), '-y', '@wix/cli@latest']; // run the CLI via npx — no
 // Respect an existing value so a known runner (claude, cursor, …) keeps its name.
 const AGENT_ENV = { ...process.env, AI_AGENT: process.env.AI_AGENT || 'wix-headless-skill' };
 
+// Injected into the awaiting_user event so an agent that skims the JSON (and never
+// read the skill doc) still sees the hard-stop rule right next to the code it must relay.
+const AWAITING_USER_INSTRUCTION =
+  'HARD STOP. Send a user-visible message NOW with verificationUri and userCode. Do not read files, scaffold, or continue the build until logged_in/success.';
+
 // run a command, capture stdout+stderr (combined), return {status, out}
 function capture(cmd, args, opts = {}) {
   const r = spawnSync(cmd, args, { encoding: 'utf8', shell: isWin, env: AGENT_ENV, ...opts });
@@ -70,7 +75,12 @@ function login() {
       try {
         const ev = JSON.parse(t);
         if (ev && ev.event) {
-          process.stdout.write(t + '\n');
+          if (ev.event === 'awaiting_user') {
+            const { event: _event, ...rest } = ev;
+            emit('awaiting_user', { ...rest, instruction: AWAITING_USER_INSTRUCTION });
+          } else {
+            process.stdout.write(t + '\n');
+          }
           if (ev.event === 'success' || ev.event === 'logged_in') {
             loggedIn = true;
             resolve();

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -56,9 +56,20 @@ The script emits one JSON object per line:
 | Event | What to do |
 |---|---|
 | `cli_ok` | Wix CLI reachable — continue. |
-| `awaiting_user` (`verificationUri`, `userCode`) | Show the URL and code in plain prose; wait for the user to finish the login in their browser. |
+| `awaiting_user` (`verificationUri`, `userCode`) | **HARD STOP** — see below. Send the URL and code in a user-visible message in this turn; wait. |
 | `logged_in` / `success` | Login done — continue. |
 | `cli_unreachable` / `login_failed` (with `detail`) | Stop and show the user the `detail`. **Do not** improvise a parallel setup by hand. |
+
+### `awaiting_user` is a hard stop
+
+The user cannot see tool output. If you keep working after this event, they never get the code and login stalls until they ask.
+
+The moment `awaiting_user` appears:
+
+1. **Send a user-visible message in this turn.** Template: *Open `<verificationUri>` and enter the code `<userCode>` — I'll continue once you've logged in.* Present the URL as a clickable link if the interface supports it.
+2. **Do not continue the build.** No other tool calls in this turn: do not read files, install skills, scaffold, seed, plan, or poll anything except the bootstrap process.
+3. **Keep the bootstrap running.** Do not re-invoke login. Wait for `logged_in` / `success`.
+4. Codes expire in about 10 minutes (`expiresInSeconds`). If `login_failed` after expiry, re-run bootstrap **once** and surface the **new** code immediately.
 
 ## Phase 2 — Install the skill and hand off
 

--- a/skills/wix-headless/references/managed/AUTHENTICATION.md
+++ b/skills/wix-headless/references/managed/AUTHENTICATION.md
@@ -15,10 +15,14 @@ npx @wix/cli@latest whoami   # exits 0 when logged in; non-zero when logged out
 
 If it's non-zero, **log in yourself** — don't punt to the user and stop:
 
+> **Hard stop on `awaiting_user`.** The user cannot see tool output. The moment that event appears, send a user-visible message with the URL and code **in this turn**, then wait. Do **not** read files, scaffold, seed, plan, or start any other work until login completes.
+
 1. Run `npx @wix/cli@latest login` with **`run_in_background: true`** (no shell `&`, no redirect of your own — the harness captures stdout to its task-output file and returns the path).
 2. Poll that file for the first JSON event: `{"event":"awaiting_user","userCode":"…","verificationUri":"…"}`.
-3. Surface it to the user in plain prose: *"Open `<verificationUri>` and enter the code `<userCode>` — I'll continue once you've logged in."* **Send the message; do not re-invoke login.**
+3. **STOP.** Send this message to the user immediately: *"Open `<verificationUri>` and enter the code `<userCode>` — I'll continue once you've logged in."* **Send the message; do not re-invoke login; do not continue the recipe; do not call other tools in the same turn.**
 4. Wait for the harness `task-notification` with `<status>completed</status>` (not a sleep loop). On exit 0, run `whoami` once to confirm, then proceed.
+
+Codes expire in about 10 minutes. If login exits non-zero after expiry, re-run step 1 **once** and surface the **new** code immediately.
 
 ## 2 · Mint the token
 


### PR DESCRIPTION
## Why

An agent that receives `awaiting_user` and keeps building never surfaces the device code — the user can't see tool output, so login silently stalls until they ask what's going on. Observed in the wild with Grok, which kept scaffolding right past the login prompt.

## What

Makes `awaiting_user` an explicit **hard stop** everywhere the login flow is documented, and bakes the rule into the event itself:

- **`wix-headless/entry/skill.md`** and **`wix-headless-fast/entry/skill.md`** — the event-table row now says HARD STOP, with a new subsection spelling out the four rules: send a user-visible message in the same turn, no other tool calls, keep the bootstrap running, and on expiry re-run once and surface the new code.
- **`wix-headless/references/managed/AUTHENTICATION.md`** — hard-stop callout before the login steps; step 3 now forbids continuing the recipe or calling other tools in the same turn; adds the ~10-minute code-expiry rule.
- **`wix-auth/references/device-flow.md`** — Step 2 retitled as a hard stop, with the message template and an explicit "don't skip straight to polling" rule.
- **`wix-headless/entry/bootstrap.mjs`** — re-emits `awaiting_user` with an `instruction` field carrying the hard-stop rule, so an agent that skims the JSON output (and never read the skill doc) still sees it next to the code it must relay.

`node --check` passes on the modified script.

---
🤖 This PR was written and opened by Joseph, an automated AI agent (Claude Code), on behalf of Gonen Jerbi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)